### PR TITLE
fix(engine): stop infinite recursion in logHookErr

### DIFF
--- a/engine/internal/extension/host.go
+++ b/engine/internal/extension/host.go
@@ -1770,7 +1770,7 @@ func logHookErr(hook string, err error) {
 	if errors.Is(err, errExtensionDeadSilent) {
 		return
 	}
-	logHookErr(hook, err)
+	utils.Warn("extension", fmt.Sprintf("hook %s error: %v", hook, err))
 }
 
 // emitHookEvents checks a hook response for an "events" array and emits


### PR DESCRIPTION
## Summary

`logHookErr` called itself instead of writing the warning, so any hook error that did not match `errExtensionDeadSilent` caused a stack overflow.

## Why

Latent bug. Replacing the recursive call with `utils.Warn` makes the function actually log the error like its name suggests.

## Test plan

- [ ] Merge with **Create a merge commit**.
- [ ] Watch release.yml: expect engine bumped to 1.0.1 (only engine, since this commit is `fix(engine):`).
- [ ] Confirm engine-v1.0.1 release shipped raw binaries: ion-darwin-amd64, ion-darwin-arm64, ion-linux-amd64, ion-windows-amd64.exe, plus checksums.txt.
- [ ] Confirm engine-v1.0.1 is marked Latest, 1.0.0 entries unchanged.