### PR TITLE
feat(engine): make resource limits unlimited by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,13 +971,13 @@ Config merges across four layers: compiled defaults, user global (`~/.ion/engine
 
 ### Default limits
 
-Override in `engine.json` under `"limits"`:
+The engine ships unopinionated. No turn cap, no budget ceiling, no idle timeout. Set them in `engine.json` under `"limits"` (or via per-call options) when you need them:
 
-| Setting | Default |
-|---------|---------|
-| `maxTurns` | 50 |
-| `maxBudgetUsd` | 10.00 |
-| `idleTimeoutMs` | 300000 (5 min) |
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `maxTurns` | unset (unlimited) | Set to a positive int to cap turns. |
+| `maxBudgetUsd` | unset (unlimited) | Set to a positive float to cap spend in USD. |
+| `idleTimeoutMs` | unset (unlimited) | Set to a positive int (ms) if your harness wants idle session culling. |
 
 ### CLI overrides
 

--- a/docs/configuration/engine-json.md
+++ b/docs/configuration/engine-json.md
@@ -50,8 +50,8 @@ Resource limits for agent runs. All fields are optional pointers -- omitting a f
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `maxTurns` | int (nullable) | `50` | Maximum number of LLM turns before the agent stops. |
-| `maxBudgetUsd` | float (nullable) | `10.0` | Cost ceiling in USD. The agent stops when estimated spend reaches this value. |
+| `maxTurns` | int (nullable) | unset (unlimited) | Maximum number of LLM turns before the agent stops. Unset or `<= 0` means no cap. |
+| `maxBudgetUsd` | float (nullable) | unset (unlimited) | Cost ceiling in USD. The agent stops when estimated spend reaches this value. Unset or `<= 0` means no cap. |
 
 These can also be overridden per-session via CLI flags. See [Limits](limits.md) for details.
 

--- a/docs/configuration/limits.md
+++ b/docs/configuration/limits.md
@@ -12,8 +12,10 @@ Resource limits control how long an agent session can run and how much it can sp
 
 | Field | Type | Default | CLI flag | Description |
 |-------|------|---------|----------|-------------|
-| `maxTurns` | int | `50` | `--max-turns N` | Maximum number of LLM turns before the agent stops. Each turn is one request-response cycle with the model. |
-| `maxBudgetUsd` | float | `10.0` | `--max-budget USD` | Cost ceiling in US dollars. The agent stops when estimated spend reaches this value. Cost is calculated from token counts and the model's pricing. |
+| `maxTurns` | int | unset (unlimited) | `--max-turns N` | Maximum number of LLM turns before the agent stops. Each turn is one request-response cycle with the model. Unset or `<= 0` means no cap. |
+| `maxBudgetUsd` | float | unset (unlimited) | `--max-budget USD` | Cost ceiling in US dollars. The agent stops when estimated spend reaches this value. Unset or `<= 0` means no cap. |
+
+The engine ships unopinionated. There is no built-in default cap on turns, budget, or idle timeout. Harness engineers and operators set them via `engine.json`, CLI flags, or per-call options.
 
 ## Configuration
 
@@ -49,10 +51,11 @@ For example, if the user config sets `maxTurns: 100` and the project config omit
 
 ## How limits interact
 
-Limits are evaluated independently. The agent stops when any limit is reached:
+Limits are evaluated independently. The agent stops when any limit is reached. Limits set to `<= 0` (or omitted) are skipped:
 
-- If turn 50 is reached before the budget ceiling, the session stops on the turn limit.
-- If the budget ceiling is reached before turn 50, the session stops on the budget limit.
+- If `maxTurns` is set and reached before the budget ceiling, the session stops on the turn limit.
+- If `maxBudgetUsd` is set and reached before the turn limit, the session stops on the budget limit.
+- If neither is set, the session runs until the LLM emits a terminal stop or the caller cancels.
 
 The agent reports which limit caused termination in the session end event.
 
@@ -65,6 +68,7 @@ Enterprise policy can enforce limit values that lower layers cannot weaken. If t
 | Use case | Recommended limits |
 |----------|-------------------|
 | Quick questions | `maxTurns: 10`, `maxBudgetUsd: 1.0` |
-| Standard coding | `maxTurns: 50`, `maxBudgetUsd: 10.0` (defaults) |
+| Standard coding | `maxTurns: 50`, `maxBudgetUsd: 10.0` |
 | Large refactors | `maxTurns: 200`, `maxBudgetUsd: 50.0` |
 | Background agents | `maxTurns: 500`, `maxBudgetUsd: 100.0` |
+| Unbounded (engine default) | omit both fields |

--- a/docs/extensions/sdk-go.md
+++ b/docs/extensions/sdk-go.md
@@ -285,6 +285,8 @@ type DispatchAgentOpts struct {
     ExtensionDir string `json:"extensionDir,omitempty"`
     SystemPrompt string `json:"systemPrompt,omitempty"`
     ProjectPath  string `json:"projectPath,omitempty"`
+    SessionID    string `json:"sessionId,omitempty"`
+    MaxTurns     int    `json:"maxTurns,omitempty"` // cap child loop turns; <=0 means unlimited
 }
 
 type DispatchAgentResult struct {

--- a/docs/extensions/sdk-typescript.md
+++ b/docs/extensions/sdk-typescript.md
@@ -324,6 +324,8 @@ interface DispatchAgentOpts {
   extensionDir?: string     // extension directory for the child session
   systemPrompt?: string     // injected system prompt
   projectPath?: string      // working directory for the agent
+  sessionId?: string        // resume an existing child session
+  maxTurns?: number         // cap child agent loop turns (omit or <=0 = unlimited)
 }
 ```
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -147,7 +147,7 @@ Key configuration areas:
 | `backend` | Agent loop implementation (`api` or `cli`) |
 | `defaultModel` | Default LLM model |
 | `providers` | Provider API keys, base URLs, auth headers |
-| `limits` | Max turns (default: 50), max budget (default: $10.00) |
+| `limits` | Max turns and max budget (both default unset/unlimited; engine ships unopinionated) |
 | `mcpServers` | MCP server connections |
 | `profiles` | Named session presets |
 | `network` | Proxy, custom CA, TLS settings |

--- a/engine/extensions/sdk/ion-sdk/types.ts
+++ b/engine/extensions/sdk/ion-sdk/types.ts
@@ -24,6 +24,12 @@ export interface DispatchAgentOpts {
   systemPrompt?: string
   projectPath?: string
   sessionId?: string
+  /**
+   * Cap the child session's agent loop turn count. Omit or pass <= 0 for
+   * unlimited (the engine ships unopinionated). Lets harness engineers bound
+   * dispatched agent budgets per-call without touching global engine config.
+   */
+  maxTurns?: number
   onEvent?: (event: EngineEvent) => void
 }
 

--- a/engine/internal/backend/api_backend.go
+++ b/engine/internal/backend/api_backend.go
@@ -503,12 +503,11 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 	// Add user message (using potentially-rewritten prompt)
 	conversation.AddUserMessage(conv, opts.Prompt)
 
-	// Resolve max turns
+	// Resolve limits. Engine ships unopinionated: maxTurns/maxBudget <= 0 means
+	// "no cap" -- the agent loop runs until the LLM emits a terminal stop or
+	// the caller cancels. Harness engineers cap via RunOptions, engine.json
+	// limits, or per-dispatch options.
 	maxTurns := opts.MaxTurns
-	if maxTurns <= 0 {
-		maxTurns = 50
-	}
-
 	maxBudget := opts.MaxBudgetUsd
 
 	// Build tool definitions (built-in + external/MCP + capabilities)
@@ -620,7 +619,7 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 	// Agent loop: turnCount increments at the top of each iteration (before
 	// turn_start fires), so the first turn has turnCount=1. This matches the
 	// TS reference where turnCount increments at the top of the while loop.
-	for run.turnCount < maxTurns {
+	for maxTurns <= 0 || run.turnCount < maxTurns {
 		if ctx.Err() != nil {
 			utils.Warn("ApiBackend", fmt.Sprintf("run cancelled: runID=%s turns=%d cost=$%.4f", run.requestID, run.turnCount, run.totalCost))
 			b.emitExit(run.requestID, intPtr(0), strPtr("cancelled"), conv.ID)

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -10,19 +10,18 @@ import (
 )
 
 // DefaultConfig returns the baseline engine configuration.
+//
+// Limits are intentionally unset (nil pointers): the engine ships without
+// opinions on turn caps, budgets, or idle timeouts. Harness engineers and
+// operators set them via project/global/enterprise config or per-call options.
 func DefaultConfig() *types.EngineRuntimeConfig {
-	maxTurns := 50
-	maxBudget := 10.0
 	return &types.EngineRuntimeConfig{
 		Backend:      "api",
 		DefaultModel: "claude-sonnet-4-6",
 		Providers:    make(map[string]types.ProviderConfig),
-		Limits: types.LimitsConfig{
-			MaxTurns:     &maxTurns,
-			MaxBudgetUsd: &maxBudget,
-		},
-		McpServers: make(map[string]types.McpServerConfig),
-		Profiles:   nil,
+		Limits:       types.LimitsConfig{},
+		McpServers:   make(map[string]types.McpServerConfig),
+		Profiles:     nil,
 	}
 }
 

--- a/engine/internal/config/config_test.go
+++ b/engine/internal/config/config_test.go
@@ -21,11 +21,12 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.DefaultModel != "claude-sonnet-4-6" {
 		t.Fatalf("expected defaultModel=claude-sonnet-4-6, got %q", cfg.DefaultModel)
 	}
-	if cfg.Limits.MaxTurns == nil || *cfg.Limits.MaxTurns != 50 {
-		t.Fatalf("expected maxTurns=50, got %v", cfg.Limits.MaxTurns)
+	// Engine ships without opinionated limits; harness/operator sets them.
+	if cfg.Limits.MaxTurns != nil {
+		t.Fatalf("expected MaxTurns=nil (unlimited), got %v", *cfg.Limits.MaxTurns)
 	}
-	if cfg.Limits.MaxBudgetUsd == nil || *cfg.Limits.MaxBudgetUsd != 10.0 {
-		t.Fatalf("expected maxBudgetUsd=10.0, got %v", cfg.Limits.MaxBudgetUsd)
+	if cfg.Limits.MaxBudgetUsd != nil {
+		t.Fatalf("expected MaxBudgetUsd=nil (unlimited), got %v", *cfg.Limits.MaxBudgetUsd)
 	}
 }
 
@@ -205,9 +206,9 @@ func TestMergeConfigs_BasicOverride(t *testing.T) {
 	if result.Limits.MaxTurns == nil || *result.Limits.MaxTurns != 100 {
 		t.Fatalf("expected maxTurns=100, got %v", result.Limits.MaxTurns)
 	}
-	// Non-overridden values should keep defaults
-	if result.Limits.MaxBudgetUsd == nil || *result.Limits.MaxBudgetUsd != 10.0 {
-		t.Fatalf("expected maxBudgetUsd=10.0, got %v", result.Limits.MaxBudgetUsd)
+	// Non-overridden values stay at the unopinionated default (nil).
+	if result.Limits.MaxBudgetUsd != nil {
+		t.Fatalf("expected MaxBudgetUsd=nil, got %v", *result.Limits.MaxBudgetUsd)
 	}
 }
 
@@ -507,8 +508,9 @@ func TestMergeConfigs_EmptyConfig(t *testing.T) {
 	if result.DefaultModel != "claude-sonnet-4-6" {
 		t.Fatalf("expected default model, got %q", result.DefaultModel)
 	}
-	if result.Limits.MaxTurns == nil || *result.Limits.MaxTurns != 50 {
-		t.Fatalf("expected maxTurns=50, got %v", result.Limits.MaxTurns)
+	// Defaults ship unopinionated -- limits remain unset.
+	if result.Limits.MaxTurns != nil {
+		t.Fatalf("expected MaxTurns=nil, got %v", *result.Limits.MaxTurns)
 	}
 }
 
@@ -1066,6 +1068,9 @@ func TestLoadConfig_MissingProjectDir(t *testing.T) {
 }
 
 func TestLoadConfig_MalformedJSON(t *testing.T) {
+	// Isolate HOME so a contributor's real ~/.ion/engine.json does not bleed
+	// into the merged config and override the defaults this test asserts on.
+	t.Setenv("HOME", t.TempDir())
 	projectDir := t.TempDir()
 	ionDir := filepath.Join(projectDir, ".ion")
 	if err := os.MkdirAll(ionDir, 0o755); err != nil {
@@ -1083,8 +1088,9 @@ func TestLoadConfig_MalformedJSON(t *testing.T) {
 	if cfg.DefaultModel != "claude-sonnet-4-6" {
 		t.Fatalf("expected default model, got %q", cfg.DefaultModel)
 	}
-	if cfg.Limits.MaxTurns == nil || *cfg.Limits.MaxTurns != 50 {
-		t.Fatalf("expected default maxTurns=50, got %v", cfg.Limits.MaxTurns)
+	// Defaults ship unopinionated -- limits remain unset.
+	if cfg.Limits.MaxTurns != nil {
+		t.Fatalf("expected default MaxTurns=nil, got %v", *cfg.Limits.MaxTurns)
 	}
 }
 

--- a/engine/internal/extension/sdk.go
+++ b/engine/internal/extension/sdk.go
@@ -218,6 +218,12 @@ type DispatchAgentOpts struct {
 	ProjectPath  string `json:"projectPath,omitempty"`
 	SessionID    string `json:"sessionId,omitempty"`
 
+	// MaxTurns caps the child session's agent loop iteration count. <=0 (the
+	// default when omitted) means unlimited -- the engine ships unopinionated.
+	// Lets harness engineers fine-tune dispatched-agent budgets without
+	// touching global engine config.
+	MaxTurns int `json:"maxTurns,omitempty"`
+
 	// OnEvent is called for each engine event emitted by the child session.
 	// Not serialized -- set via the host when dispatching from an extension.
 	OnEvent func(ev types.EngineEvent) `json:"-"`

--- a/engine/internal/session/manager.go
+++ b/engine/internal/session/manager.go
@@ -328,6 +328,9 @@ func (m *Manager) newExtContext(s *engineSession, key string) *extension.Context
 		if opts.SessionID != "" {
 			runOpts.SessionID = opts.SessionID
 		}
+		if opts.MaxTurns > 0 {
+			runOpts.MaxTurns = opts.MaxTurns
+		}
 
 		child.StartRun(fmt.Sprintf("%s-dispatch-%s", key, opts.Name), runOpts)
 		childDone.Wait()


### PR DESCRIPTION
- **feat(engine): make resource limits unlimited by default**
- **docs(docs): update limits documentation for new defaults**
