### PR TITLE
Engine and desktop feature/fix pack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /engine
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: gomod
+    directory: /relay
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /desktop
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /engine
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: docker
+    directory: /relay
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,144 @@
+name: Quality
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: raven-actions/actionlint@v2
+
+  engine-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: engine/go.mod
+      - name: Unit tests with race detector
+        working-directory: engine
+        run: go test -race ./...
+      - name: Integration tests with race detector
+        working-directory: engine
+        run: go test -race -tags integration ./tests/integration/...
+
+  engine-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: engine/go.mod
+      # only-new-issues lints only diffs vs the base branch so the existing
+      # backlog of issues does not block PRs; new code must stay clean.
+      - name: golangci-lint (engine)
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: engine
+          only-new-issues: true
+      - name: golangci-lint (relay)
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: relay
+          only-new-issues: true
+
+  engine-vuln:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: engine/go.mod
+      - name: govulncheck (engine)
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+        working-directory: engine
+      - name: govulncheck (relay)
+        run: govulncheck ./...
+        working-directory: relay
+
+  relay-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: relay/go.mod
+      - name: Unit tests with race detector
+        working-directory: relay
+        run: go test -race ./...
+
+  desktop-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: desktop/package-lock.json
+      - name: Install dependencies
+        working-directory: desktop
+        run: npm ci --ignore-scripts
+      - name: Run tests
+        working-directory: desktop
+        run: npm test
+
+  desktop-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: npm audit (high+ only, prod deps)
+        working-directory: desktop
+        run: npm audit --audit-level=high --omit=dev
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build engine image
+        uses: docker/build-push-action@v5
+        with:
+          context: engine
+          push: false
+          platforms: linux/amd64
+          tags: ion-engine:ci
+
+  ios-build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build iOS app
+        working-directory: ios
+        run: |
+          xcodebuild \
+            -project IonRemote.xcodeproj \
+            -scheme IonRemote \
+            -destination 'generic/platform=iOS' \
+            build

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Install dependencies
         working-directory: desktop
         run: npm ci --ignore-scripts
+      - name: Type-check
+        working-directory: desktop
+        run: npm run typecheck
       - name: Run tests
         working-directory: desktop
         run: npm test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ Set the model you want in `~/.ion/engine.json` and configure its provider block:
 
 > **How `apiKey` is resolved.** The `apiKey` field accepts three forms:
 >
-> 1. **Omitted** — the engine auto-resolves the key from provider's default environment variables (e.g. `OPENAI_API_KEY`), the system keychain, or its encrypted file store.
-> 2. **An environment variable name** (all-caps, digits, and underscores, e.g. `"OPENAI_API_KEY"`) — expanded from the environment at startup.
-> 3. **A literal key** (e.g. `"sk-proj-..."`) — used directly as-is.
+> 1. **Omitted**: the engine auto-resolves the key from provider's default environment variables (e.g. `OPENAI_API_KEY`), the system keychain, or its encrypted file store.
+> 2. **An environment variable name** (all-caps, digits, and underscores, e.g. `"OPENAI_API_KEY"`): expanded from the environment at startup.
+> 3. **A literal key** (e.g. `"sk-proj-..."`): used directly as-is.
 >
-> The examples above use both form 1 and form 2: the value `"CUSTOM_OPEN_API_KEY_VAR"` is not a literal api key — it tells the engine to read the corresponding environment variable.
+> The examples above use both form 1 and form 2. The value `"CUSTOM_OPEN_API_KEY_VAR"` is not a literal API key; it tells the engine to read the corresponding environment variable.
 
 Need a custom name (a finetune, an OpenRouter route, a tier alias)? Register it under `~/.ion/models.json`:
 
@@ -953,7 +953,7 @@ cat > ~/.ion/engine.json << 'EOF'
 EOF
 
 # A hosted variant, mixing two providers.
-# "OPENAI_API_KEY" here is not a literal key — the engine sees the all-caps
+# "OPENAI_API_KEY" here is not a literal key. The engine sees the all-caps
 # name and expands it from the environment variable exported above.
 # You can also pass a literal key: { "apiKey": "sk-proj-..." }
 cat > ~/.ion/engine.json << 'EOF'

--- a/README.md
+++ b/README.md
@@ -182,11 +182,19 @@ Set the model you want in `~/.ion/engine.json` and configure its provider block:
   "defaultModel": "qwen2.5:14b",
   "providers": {
     "ollama": {},
-    "openai": { "apiKey": "OPENAI_API_KEY" },
-    "anthropic": { "apiKey": "ANTHROPIC_API_KEY" }
+    "openai": { "apiKey": "CUSTOM_OPEN_API_KEY_VAR" },
+    "anthropic": { "apiKey": "sk-ant-..." }
   }
 }
 ```
+
+> **How `apiKey` is resolved.** The `apiKey` field accepts three forms:
+>
+> 1. **Omitted** — the engine auto-resolves the key from provider's default environment variables (e.g. `OPENAI_API_KEY`), the system keychain, or its encrypted file store.
+> 2. **An environment variable name** (all-caps, digits, and underscores, e.g. `"OPENAI_API_KEY"`) — expanded from the environment at startup.
+> 3. **A literal key** (e.g. `"sk-proj-..."`) — used directly as-is.
+>
+> The examples above use both form 1 and form 2: the value `"CUSTOM_OPEN_API_KEY_VAR"` is not a literal api key — it tells the engine to read the corresponding environment variable.
 
 Need a custom name (a finetune, an OpenRouter route, a tier alias)? Register it under `~/.ion/models.json`:
 
@@ -944,7 +952,10 @@ cat > ~/.ion/engine.json << 'EOF'
 }
 EOF
 
-# A hosted variant, mixing two providers:
+# A hosted variant, mixing two providers.
+# "OPENAI_API_KEY" here is not a literal key — the engine sees the all-caps
+# name and expands it from the environment variable exported above.
+# You can also pass a literal key: { "apiKey": "sk-proj-..." }
 cat > ~/.ion/engine.json << 'EOF'
 {
   "defaultModel": "gpt-4o",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -74,7 +74,7 @@
         "to": "engine/ion"
       }
     ],
-    "afterPack": "build/afterPack.js",
+    "afterPack": "scripts/afterPack.js",
     "mac": {
       "icon": "resources/icon.icns",
       "identity": "Ion Local Dev",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,7 @@
     "dist": "electron-vite build --mode production && electron-builder --mac --dir",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "doctor": "bash scripts/doctor.sh",
     "postinstall": "electron-builder install-app-deps && bash scripts/patch-dev-icon.sh && bash scripts/patch-zustand.sh"
   },

--- a/desktop/scripts/afterPack.js
+++ b/desktop/scripts/afterPack.js
@@ -1,0 +1,69 @@
+// ──────────────────────────────────────────────────────
+//  afterPack.js -- electron-builder afterPack hook
+//
+//  Signs the Ion Engine binary embedded as an extraResource.
+//  electron-builder signs the main Electron app and its
+//  frameworks, but does not automatically sign extraResources.
+//  Without this, macOS Gatekeeper quarantines the unsigned
+//  engine binary on first launch.
+// ──────────────────────────────────────────────────────
+
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const IDENTITY = "Ion Local Dev";
+const ENTITLEMENTS = path.join(__dirname, "..", "resources", "entitlements.mac.plist");
+
+exports.default = async function afterPack(context) {
+  if (process.platform !== "darwin") return;
+
+  const appPath = path.join(
+    context.appOutDir,
+    `${context.packager.appInfo.productFilename}.app`
+  );
+  const engineBin = path.join(appPath, "Contents", "Resources", "engine", "ion");
+
+  if (!fs.existsSync(engineBin)) {
+    console.log("  afterPack: engine binary not found, skipping codesign");
+    return;
+  }
+
+  // Build the codesign command. Use the project signing identity if
+  // available, otherwise fall back to ad-hoc signing.
+  const entitlementsArgs = fs.existsSync(ENTITLEMENTS)
+    ? `--entitlements "${ENTITLEMENTS}"`
+    : "";
+
+  const identityAvailable = (() => {
+    try {
+      const out = execSync(
+        `security find-identity -v -p codesigning 2>/dev/null`,
+        { encoding: "utf8" }
+      );
+      return out.includes(IDENTITY);
+    } catch {
+      return false;
+    }
+  })();
+
+  const sign = identityAvailable ? `"${IDENTITY}"` : "-";
+
+  const cmd = `codesign --force --sign ${sign} --options runtime ${entitlementsArgs} "${engineBin}"`;
+
+  console.log(`  afterPack: signing engine binary (identity: ${identityAvailable ? IDENTITY : "ad-hoc"})`);
+  try {
+    execSync(cmd, { stdio: "inherit" });
+    console.log("  afterPack: engine binary signed");
+  } catch (err) {
+    console.error("  afterPack: codesign failed, falling back to ad-hoc");
+    try {
+      execSync(`codesign --force --sign - --options runtime "${engineBin}"`, {
+        stdio: "inherit",
+      });
+      console.log("  afterPack: engine binary signed (ad-hoc fallback)");
+    } catch (fallbackErr) {
+      console.error("  afterPack: ad-hoc codesign also failed:", fallbackErr.message);
+    }
+  }
+};

--- a/desktop/src/main/__tests__/transcription.test.ts
+++ b/desktop/src/main/__tests__/transcription.test.ts
@@ -33,8 +33,8 @@ vi.mock('fs', async (importOriginal) => {
 
 // ─── Typed mock accessors ───
 
-const mockExecFile = childProcess.execFile as unknown as ReturnType<typeof vi.fn>
-const mockExistsSync = fs.existsSync as unknown as ReturnType<typeof vi.fn>
+const mockExecFile = childProcess.execFile as unknown as ReturnType<typeof vi.fn> & ((...args: any[]) => any)
+const mockExistsSync = fs.existsSync as unknown as ReturnType<typeof vi.fn> & ((...args: any[]) => any)
 
 // ─── Helpers ───
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -13,7 +13,7 @@ import { discoverCommands } from './cli-compat/command-discovery'
 import { log as _log, LOG_FILE, flushLogs } from './logger'
 import { getCliEnv } from './cli-env'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, EnrichedError, WorktreeInfo, WorktreeStatus } from '../shared/types'
+import type { RunOptions, NormalizedEvent, EnrichedError, WorktreeInfo, WorktreeStatus, TabStatus } from '../shared/types'
 import { TerminalManager } from './terminal-manager'
 import { isValidProjectPath, isValidSessionId, validateExternalUrl } from './ipc-validation'
 import { atomicWriteFileSync } from './utils/atomicWrite'
@@ -2498,7 +2498,10 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
         if (!dir) {
           // Resolve desktop default from settings, fall back to home
           const s = readSettings()
-          dir = s.defaultBaseDirectory || homedir()
+          dir = s.defaultBaseDirectory || homedir() || ''
+        }
+        if (!dir) {
+          break
         }
         try {
           const escaped = dir.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
@@ -2713,8 +2716,9 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
         let dir = cmd.workingDirectory
         if (!dir) {
           const s = readSettings()
-          dir = s.defaultBaseDirectory || homedir()
+          dir = s.defaultBaseDirectory || homedir() || ''
         }
+        if (!dir) break
         try {
           const escaped = dir.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
           const tabId = await mainWindow?.webContents.executeJavaScript(`
@@ -2742,8 +2746,9 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
         let dir = cmd.workingDirectory
         if (!dir) {
           const s = readSettings()
-          dir = s.defaultBaseDirectory || homedir()
+          dir = s.defaultBaseDirectory || homedir() || ''
         }
+        if (!dir) break
         try {
           const escaped = dir.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
           const tabId = await mainWindow?.webContents.executeJavaScript(`

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -16,6 +16,8 @@ import { IPC } from '../shared/types'
 import type { RunOptions, NormalizedEvent, EnrichedError, WorktreeInfo, WorktreeStatus } from '../shared/types'
 import { TerminalManager } from './terminal-manager'
 import { isValidProjectPath, isValidSessionId, validateExternalUrl } from './ipc-validation'
+import { atomicWriteFileSync } from './utils/atomicWrite'
+import { encryptSensitiveSettings, decryptSensitiveSettings, isSafeStorageReady } from './utils/secretStore'
 
 const gitExec = promisify(execFileCb)
 
@@ -739,10 +741,8 @@ ipcMain.handle(IPC.DISCOVER_COMMANDS, async (_e, projectPath: string) => {
     // Only discover commands when Claude compat is enabled
     let claudeCompat = SETTINGS_DEFAULTS.enableClaudeCompat
     try {
-      if (existsSync(SETTINGS_FILE)) {
-        const s = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'))
-        claudeCompat = s.enableClaudeCompat ?? claudeCompat
-      }
+      const s = readSettings()
+      claudeCompat = s.enableClaudeCompat ?? claudeCompat
     } catch {}
     if (!claudeCompat) return []
     return await discoverCommands(projectPath)
@@ -1906,10 +1906,36 @@ const SETTINGS_DIR = join(homedir(), '.ion')
 const SETTINGS_FILE = join(SETTINGS_DIR, 'settings.json')
 const SETTINGS_DEFAULTS = { themeMode: 'dark', soundEnabled: true, expandedUI: false, ultraWide: false, defaultBaseDirectory: '', showDirLabel: true, preferredOpenWith: 'cli', showImplementClearContext: false, expandToolResults: false, terminalFontFamily: 'Menlo, Monaco, monospace', terminalFontSize: 13, allowSettingsEdits: false, enableClaudeCompat: true, preferredModel: 'claude-opus-4-6' }
 
+// readSettings loads settings.json with sensitive fields decrypted. Use this
+// instead of JSON.parse(readFileSync(SETTINGS_FILE)) so plaintext consumers
+// keep working transparently while disk storage stays encrypted.
+function readSettings(): Record<string, any> {
+  if (!existsSync(SETTINGS_FILE)) return {}
+  try {
+    const raw = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'))
+    return decryptSensitiveSettings(raw)
+  } catch (err) {
+    log(`Failed to read settings: ${err}`)
+    return {}
+  }
+}
+
+// writeSettings persists settings.json atomically (temp+fsync+rename), with
+// sensitive fields encrypted via Electron safeStorage. Mode 0o600 because the
+// file may still contain plaintext on platforms without a keyring.
+function writeSettings(data: Record<string, any>): void {
+  if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true })
+  const encrypted = encryptSensitiveSettings(data)
+  atomicWriteFileSync(SETTINGS_FILE, JSON.stringify(encrypted, null, 2), 0o600)
+  if (!isSafeStorageReady()) {
+    log('[Settings] safeStorage unavailable; secrets stored in plaintext (mode 0600)')
+  }
+}
+
 ipcMain.handle(IPC.LOAD_SETTINGS, () => {
   try {
     if (existsSync(SETTINGS_FILE)) {
-      const settings = { ...SETTINGS_DEFAULTS, ...JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) }
+      const settings: Record<string, any> = { ...SETTINGS_DEFAULTS, ...readSettings() }
       log(`[Settings] loaded: remoteEnabled=${settings.remoteEnabled} remoteTransport=${!!remoteTransport}`)
       // Initialize remote transport from persisted settings on first load.
       if (settings.remoteEnabled && !remoteTransport) {
@@ -1938,7 +1964,7 @@ function readEngineConfig(): Record<string, any> {
 
 function writeEngineConfig(config: Record<string, any>): void {
   if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true })
-  writeFileSync(ENGINE_CONFIG_FILE, JSON.stringify(config, null, 2))
+  atomicWriteFileSync(ENGINE_CONFIG_FILE, JSON.stringify(config, null, 2), 0o644)
 }
 
 function getCurrentBackend(): 'api' | 'cli' {
@@ -2007,7 +2033,7 @@ ipcMain.handle(IPC.LOAD_TABS, () => {
 ipcMain.handle(IPC.SAVE_TABS, (_event, data: Record<string, unknown>) => {
   try {
     if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true })
-    writeFileSync(TABS_FILE, JSON.stringify(data, null, 2))
+    atomicWriteFileSync(TABS_FILE, JSON.stringify(data, null, 2), 0o644)
   } catch (err) {
     log(`Failed to save tabs: ${err}`)
   }
@@ -2031,7 +2057,7 @@ function loadSessionLabels(): Record<string, string> {
 function saveSessionLabels(labels: Record<string, string>): void {
   try {
     if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true })
-    writeFileSync(SESSION_LABELS_FILE, JSON.stringify(labels, null, 2))
+    atomicWriteFileSync(SESSION_LABELS_FILE, JSON.stringify(labels, null, 2), 0o644)
   } catch (err) {
     log(`Failed to save session labels: ${err}`)
   }
@@ -2078,7 +2104,7 @@ function loadSessionChains(): { chains: Record<string, string[]>; reverse: Recor
 function saveSessionChains(data: { chains: Record<string, string[]>; reverse: Record<string, string> }): void {
   try {
     if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true })
-    writeFileSync(SESSION_CHAINS_FILE, JSON.stringify(data, null, 2))
+    atomicWriteFileSync(SESSION_CHAINS_FILE, JSON.stringify(data, null, 2), 0o644)
   } catch (err) {
     log(`Failed to save session chains: ${err}`)
   }
@@ -2127,7 +2153,7 @@ function startTabSnapshotPolling(): void {
     if (!remoteTransport || remoteTransport.state === 'disconnected') return
     try {
       const tabs = await getRemoteTabStates()
-      const settings = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+      const settings = readSettings()
       const recentDirectories: string[] = Array.isArray(settings.recentBaseDirectories) ? settings.recentBaseDirectories : []
       remoteTransport?.send({ type: 'snapshot', tabs, recentDirectories })
     } catch {}
@@ -2336,10 +2362,10 @@ function revokeDeviceLocally(deviceId: string): void {
   log(`[Remote] revoking device locally: ${deviceId}`)
   try {
     if (existsSync(SETTINGS_FILE)) {
-      const settings = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'))
+      const settings = readSettings()
       const devices = Array.isArray(settings.pairedDevices) ? settings.pairedDevices : []
       settings.pairedDevices = devices.filter((d: any) => d.id !== deviceId)
-      writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2))
+      writeSettings(settings)
     }
   } catch (err) {
     log(`[Remote] failed to remove device from settings: ${(err as Error).message}`)
@@ -2373,14 +2399,14 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
     lanPort: (settings.lanServerPort as number) || 19837,
     getPairedDevice: (deviceId: string) => {
       try {
-        const s = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+        const s = readSettings()
         const devices = Array.isArray(s.pairedDevices) ? s.pairedDevices : []
         return devices.find((d: any) => d.id === deviceId) || null
       } catch { return null }
     },
     getAllPairedDevices: () => {
       try {
-        const s = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+        const s = readSettings()
         return Array.isArray(s.pairedDevices) ? s.pairedDevices : []
       } catch { return [] }
     },
@@ -2393,7 +2419,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
     // Without a shared secret there's no authenticated peer, so sending
     // tab state would leak data to any device on the LAN.
     try {
-      const s = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+      const s = readSettings()
       const devices = Array.isArray(s.pairedDevices) ? s.pairedDevices : []
       if (!devices.some((d: any) => d.sharedSecret)) {
         log('[Remote] peer connected but no paired device with shared secret -- skipping snapshot')
@@ -2407,7 +2433,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
 
       // Push current relay config so iOS always has the latest.
       try {
-        const settings = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+        const settings = readSettings()
         const peerRecentDirs: string[] = Array.isArray(settings.recentBaseDirectories) ? settings.recentBaseDirectories : []
         remoteTransport?.send({ type: 'snapshot', tabs, recentDirectories: peerRecentDirs })
         const relayUrl = (settings.relayUrl as string) || ''
@@ -2427,7 +2453,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
     switch (cmd.type) {
       case 'sync': {
         const tabs = await getRemoteTabStates()
-        const syncSettings = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+        const syncSettings = readSettings()
         const recentDirectories: string[] = Array.isArray(syncSettings.recentBaseDirectories) ? syncSettings.recentBaseDirectories : []
         remoteTransport?.send({ type: 'snapshot', tabs, recentDirectories })
         // Send engine profiles so iOS can show a profile picker
@@ -2471,7 +2497,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
         let dir = cmd.workingDirectory
         if (!dir) {
           // Resolve desktop default from settings, fall back to home
-          const s = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+          const s = readSettings()
           dir = s.defaultBaseDirectory || homedir()
         }
         try {
@@ -2686,7 +2712,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
       case 'create_terminal_tab': {
         let dir = cmd.workingDirectory
         if (!dir) {
-          const s = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+          const s = readSettings()
           dir = s.defaultBaseDirectory || homedir()
         }
         try {
@@ -2715,7 +2741,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
       case 'create_engine_tab': {
         let dir = cmd.workingDirectory
         if (!dir) {
-          const s = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+          const s = readSettings()
           dir = s.defaultBaseDirectory || homedir()
         }
         try {
@@ -2953,7 +2979,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
     let existingDevices: any[] = []
     try {
       if (existsSync(SETTINGS_FILE)) {
-        const s = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'))
+        const s = readSettings()
         relayUrl = s.relayUrl || ''
         relayApiKey = s.relayApiKey || ''
         existingDevices = Array.isArray(s.pairedDevices) ? s.pairedDevices : []
@@ -3024,16 +3050,14 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
 
     // Save paired device to settings and notify renderer.
     try {
-      const settings = existsSync(SETTINGS_FILE)
-        ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'))
-        : {}
+      const settings = readSettings()
       const devices = Array.isArray(settings.pairedDevices) ? settings.pairedDevices : []
       // Replace existing device with same id or name (name is stable across re-pairings).
       const idx = devices.findIndex((d: any) => d.id === pairedDevice.id || d.name === pairedDevice.name)
       if (idx >= 0) devices[idx] = pairedDevice
       else devices.push(pairedDevice)
       settings.pairedDevices = devices
-      writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2))
+      writeSettings(settings)
     } catch (err) {
       log(`Failed to save paired device: ${(err as Error).message}`)
     }
@@ -3049,7 +3073,7 @@ function initRemoteTransport(settings: Record<string, unknown>): void {
     // Send a tab snapshot to the newly connected iOS client.
     setTimeout(async () => {
       const tabs = await getRemoteTabStates()
-      const pairSettings = existsSync(SETTINGS_FILE) ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) : {}
+      const pairSettings = readSettings()
       const pairRecentDirs: string[] = Array.isArray(pairSettings.recentBaseDirectories) ? pairSettings.recentBaseDirectories : []
       remoteTransport?.send({ type: 'snapshot', tabs, recentDirectories: pairRecentDirs })
     }, 500)
@@ -3303,9 +3327,7 @@ ipcMain.handle(IPC.REMOTE_START_PAIRING, () => {
   try {
     // Restart transport if it was stopped (e.g. after revoking all devices).
     if (!remoteTransport) {
-      const settings = existsSync(SETTINGS_FILE)
-        ? JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8'))
-        : {}
+      const settings = readSettings()
       if (settings.remoteEnabled) {
         initRemoteTransport(settings)
       }
@@ -3407,10 +3429,9 @@ ipcMain.handle(IPC.SAVE_SETTINGS, (_event, data: Record<string, unknown>) => {
   try {
     // Read previous settings to detect transport-config changes.
     let prev: Record<string, unknown> = {}
-    try { if (existsSync(SETTINGS_FILE)) prev = JSON.parse(readFileSync(SETTINGS_FILE, 'utf-8')) } catch {}
+    try { prev = readSettings() } catch {}
 
-    if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true })
-    writeFileSync(SETTINGS_FILE, JSON.stringify(data, null, 2))
+    writeSettings(data as Record<string, any>)
 
     // Only reinitialize the transport when transport-level config changed
     // (not on every settings save, which includes pairedDevices changes).

--- a/desktop/src/main/remote/lan-server.ts
+++ b/desktop/src/main/remote/lan-server.ts
@@ -32,17 +32,63 @@ export interface LANServerOptions {
  *  - 'client-disconnected' (connectionId: string, code: number, reason: string) -- client left
  *  - 'pair-request' -- pairing request from iOS
  */
+// Per-IP exponential backoff for failed auth attempts. Stops a stale
+// device on the LAN from reconnecting in a tight loop and flooding the log.
+// Backoff schedule: 1s, 5s, 30s, 5min cap. Reset on first successful auth.
+const AUTH_BACKOFF_STEPS_MS: number[] = [1_000, 5_000, 30_000, 300_000]
+
+interface AuthFailureRecord {
+  failCount: number
+  blockUntil: number
+  // Last time we logged a block message for this IP. Used to throttle log
+  // output to one line per cooldown window.
+  lastLoggedAt: number
+}
+
 export class LANServer extends EventEmitter {
   private httpServer: Server | null = null
   private wss: WebSocketServer | null = null
   private clients: Map<string, WebSocket> = new Map()
+  private clientIps: Map<string, string> = new Map()
   private port: number
   private dnssdProc: ChildProcess | null = null
   private nextId = 0
+  private failedAuth: Map<string, AuthFailureRecord> = new Map()
 
   constructor(options: LANServerOptions = {}) {
     super()
     this.port = options.port || DEFAULT_PORT
+  }
+
+  /** Returns ms remaining until this IP can attempt auth again, or 0 if not blocked. */
+  private blockedRemaining(ip: string): number {
+    const rec = this.failedAuth.get(ip)
+    if (!rec) return 0
+    const remaining = rec.blockUntil - Date.now()
+    if (remaining <= 0) return 0
+    return remaining
+  }
+
+  /** Record an auth failure from this IP. Bumps failCount and extends blockUntil. */
+  recordAuthFailure(ip: string): void {
+    if (!ip) return
+    const now = Date.now()
+    const rec = this.failedAuth.get(ip) ?? { failCount: 0, blockUntil: 0, lastLoggedAt: 0 }
+    rec.failCount += 1
+    const stepIdx = Math.min(rec.failCount - 1, AUTH_BACKOFF_STEPS_MS.length - 1)
+    rec.blockUntil = now + AUTH_BACKOFF_STEPS_MS[stepIdx]
+    this.failedAuth.set(ip, rec)
+  }
+
+  /** Clear backoff state for this IP after a successful auth. */
+  recordAuthSuccess(ip: string): void {
+    if (!ip) return
+    this.failedAuth.delete(ip)
+  }
+
+  /** Look up the originating IP for a connection (set on connect). */
+  getClientIp(connectionId: string): string | undefined {
+    return this.clientIps.get(connectionId)
   }
 
   get connected(): boolean {
@@ -64,14 +110,18 @@ export class LANServer extends EventEmitter {
   rekeyClient(oldId: string, newId: string): void {
     const ws = this.clients.get(oldId)
     if (!ws) return
+    const ip = this.clientIps.get(oldId)
     this.clients.delete(oldId)
+    this.clientIps.delete(oldId)
     // If there's already a client with newId, close the old one (latest wins per device).
     const existing = this.clients.get(newId)
     if (existing) {
       log(`replacing existing client for ${newId}`)
       try { existing.close() } catch { /* ignore */ }
+      this.clientIps.delete(newId)
     }
     this.clients.set(newId, ws)
+    if (ip) this.clientIps.set(newId, ip)
   }
 
   async start(): Promise<number> {
@@ -85,16 +135,35 @@ export class LANServer extends EventEmitter {
       this.wss = new WebSocketServer({ server: this.httpServer })
 
       this.wss.on('connection', (ws, req) => {
+        const ip = req.socket.remoteAddress || 'unknown'
+
         // Route /pair connections to the pairing handler.
         if (req.url === '/pair') {
-          log(`pairing connection from ${req.socket.remoteAddress}`)
+          log(`pairing connection from ${ip}`)
           this._handlePairingConnection(ws)
+          return
+        }
+
+        // Reject connections from IPs in auth-failure cooldown without
+        // running the handshake. This stops a stale device from reconnecting
+        // every ~500ms and flooding the log.
+        const remaining = this.blockedRemaining(ip)
+        if (remaining > 0) {
+          const rec = this.failedAuth.get(ip)
+          const now = Date.now()
+          // Log at most once per cooldown window to keep the noise floor low.
+          if (rec && now - rec.lastLoggedAt > 60_000) {
+            log(`auth-blocking ip=${ip} count=${rec.failCount} for=${Math.ceil(remaining / 1000)}s`)
+            rec.lastLoggedAt = now
+          }
+          try { ws.close(1008, `auth cooldown ${Math.ceil(remaining / 1000)}s`) } catch { /* ignore */ }
           return
         }
 
         const connectionId = `lan-${this.nextId++}`
         this.clients.set(connectionId, ws)
-        log(`client connected from ${req.socket.remoteAddress} (${connectionId})`)
+        this.clientIps.set(connectionId, ip)
+        log(`client connected from ${ip} (${connectionId})`)
         this.emit('raw-client-connected', ws, connectionId)
 
         ws.on('message', (raw: Buffer | string) => {
@@ -109,11 +178,13 @@ export class LANServer extends EventEmitter {
         ws.on('close', (code: number, reason: Buffer) => {
           if (this.clients.get(connectionId) === ws) {
             this.clients.delete(connectionId)
+            this.clientIps.delete(connectionId)
           }
           // Also check if the ws was re-keyed to a different id.
           for (const [id, client] of this.clients) {
             if (client === ws) {
               this.clients.delete(id)
+              this.clientIps.delete(id)
               log(`client disconnected ${id} (code=${code} reason=${reason.toString()})`)
               this.emit('client-disconnected', id, code, reason.toString())
               return

--- a/desktop/src/main/remote/transport.ts
+++ b/desktop/src/main/remote/transport.ts
@@ -558,6 +558,8 @@ export class RemoteTransport extends EventEmitter {
       if (this.lanAuthPending.has(connectionId)) {
         log(`LAN auth timed out for ${connectionId}`)
         this.lanAuthPending.delete(connectionId)
+        const ip = this.lan?.getClientIp(connectionId)
+        if (ip) this.lan?.recordAuthFailure(ip)
         this.lan?.disconnectClient(connectionId, 4003, 'auth timeout')
       }
     }, 10_000)
@@ -588,11 +590,14 @@ export class RemoteTransport extends EventEmitter {
       return
     }
 
+    const ip = this.lan?.getClientIp(connectionId)
+
     // Look up the device by ID.
     const device = this.config.getPairedDevice?.(authResp.deviceId)
     if (!device) {
       log(`LAN auth: unknown device ${authResp.deviceId}`)
       this._sendAuthResult(connectionId, false, 'unknown device')
+      if (ip) this.lan?.recordAuthFailure(ip)
       this.lan?.disconnectClient(connectionId, 4003, 'unknown device')
       return
     }
@@ -603,6 +608,7 @@ export class RemoteTransport extends EventEmitter {
     if (!valid) {
       log(`LAN auth: invalid proof from ${authResp.deviceId}`)
       this._sendAuthResult(connectionId, false, 'invalid proof')
+      if (ip) this.lan?.recordAuthFailure(ip)
       this.lan?.disconnectClient(connectionId, 4003, 'invalid proof')
       return
     }
@@ -621,6 +627,7 @@ export class RemoteTransport extends EventEmitter {
     // Reset dedup counter for new LAN session.
     this.lastReceivedSeq.set(device.id, 0)
 
+    if (ip) this.lan?.recordAuthSuccess(ip)
     log(`LAN auth: device ${authResp.deviceId} (${device.name}) authenticated`)
     this._sendAuthResult(device.id, true)
 

--- a/desktop/src/main/remote/transport.ts
+++ b/desktop/src/main/remote/transport.ts
@@ -451,11 +451,12 @@ export class RemoteTransport extends EventEmitter {
     const secret = this.deviceSecrets.get(deviceId)
     let payload: string | undefined
     if (secret && msg.nonce && msg.ciphertext) {
-      payload = decrypt(msg.nonce, msg.ciphertext, secret)
-      if (payload === null) {
+      const decrypted = decrypt(msg.nonce, msg.ciphertext, secret)
+      if (decrypted === null) {
         log(`decryption failed for seq=${msg.seq} from ${deviceId}`)
         return
       }
+      payload = decrypted
     } else if (secret && msg.payload) {
       // Shared secret is set but message is plaintext -- reject it.
       log(`rejecting plaintext message seq=${msg.seq} from ${deviceId} (encryption required)`)

--- a/desktop/src/main/utils/atomicWrite.ts
+++ b/desktop/src/main/utils/atomicWrite.ts
@@ -1,0 +1,53 @@
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from 'fs'
+import { dirname } from 'path'
+
+// atomicWriteFileSync writes data to path atomically: write to a sibling
+// temp file, fsync the temp fd, rename over the destination, then fsync the
+// parent directory so the rename is durable across crashes. Mirrors the
+// engine's writeFileSynced helper at engine/internal/conversation/conversation.go.
+//
+// Mode defaults to 0o600 because most callers persist secrets (settings.json
+// includes relayApiKey and pairedDevices[].sharedSecret). Callers writing
+// non-sensitive data may pass 0o644.
+export function atomicWriteFileSync(
+  path: string,
+  data: string | Uint8Array,
+  mode: number = 0o600,
+): void {
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`
+  const fd = openSync(tmp, 'w', mode)
+  try {
+    const buf =
+      typeof data === 'string'
+        ? Buffer.from(data, 'utf-8')
+        : Buffer.from(data.buffer, data.byteOffset, data.byteLength)
+    writeSync(fd, buf, 0, buf.length, 0)
+    fsyncSync(fd)
+  } catch (err) {
+    try { closeSync(fd) } catch {}
+    try { unlinkSync(tmp) } catch {}
+    throw err
+  }
+  closeSync(fd)
+  try {
+    renameSync(tmp, path)
+  } catch (err) {
+    try { unlinkSync(tmp) } catch {}
+    throw err
+  }
+  // Best-effort fsync the directory so the rename survives a crash. Some
+  // filesystems (notably on macOS) reject directory fsync; treat that as
+  // non-fatal since the rename itself is already on disk.
+  try {
+    const dirFd = openSync(dirname(path), 'r')
+    try { fsyncSync(dirFd) } catch {}
+    closeSync(dirFd)
+  } catch {}
+}

--- a/desktop/src/main/utils/secretStore.ts
+++ b/desktop/src/main/utils/secretStore.ts
@@ -1,0 +1,105 @@
+import { app, safeStorage } from 'electron'
+
+const ENC_PREFIX = 'enc:v1:'
+
+// isSafeStorageReady reports whether Electron's safeStorage backend is
+// available. Returns false on Linux without a keyring or before app.isReady().
+export function isSafeStorageReady(): boolean {
+  if (!app.isReady()) return false
+  try {
+    return safeStorage.isEncryptionAvailable()
+  } catch {
+    return false
+  }
+}
+
+// encryptForDisk returns ciphertext with the enc:v1: prefix when safeStorage
+// is available; otherwise it returns the plaintext unchanged so the caller
+// can choose to fall back. Callers that need a hard guarantee should check
+// isSafeStorageReady() first.
+export function encryptForDisk(plaintext: string): string {
+  if (!plaintext) return plaintext
+  if (!isSafeStorageReady()) return plaintext
+  const buf = safeStorage.encryptString(plaintext)
+  return ENC_PREFIX + buf.toString('base64')
+}
+
+// decryptFromDisk returns the plaintext for a value that was previously
+// passed through encryptForDisk. Values without the enc:v1: prefix are
+// returned unchanged so legacy plaintext settings keep working until the
+// next write.
+export function decryptFromDisk(value: string): string {
+  if (!value || !value.startsWith(ENC_PREFIX)) return value
+  if (!isSafeStorageReady()) return value
+  try {
+    const buf = Buffer.from(value.slice(ENC_PREFIX.length), 'base64')
+    return safeStorage.decryptString(buf)
+  } catch {
+    return value
+  }
+}
+
+// SENSITIVE_TOP_FIELDS lists settings keys whose top-level string value must
+// be encrypted on disk.
+const SENSITIVE_TOP_FIELDS = ['relayApiKey'] as const
+
+// SENSITIVE_DEVICE_FIELDS lists fields on each entry of pairedDevices[] that
+// must be encrypted on disk.
+const SENSITIVE_DEVICE_FIELDS = ['sharedSecret'] as const
+
+// encryptSensitiveSettings returns a copy of settings with sensitive fields
+// replaced by their encrypted forms (where safeStorage is available).
+export function encryptSensitiveSettings(settings: Record<string, any>): Record<string, any> {
+  const out: Record<string, any> = { ...settings }
+  for (const key of SENSITIVE_TOP_FIELDS) {
+    const v = out[key]
+    if (typeof v === 'string' && v && !v.startsWith(ENC_PREFIX)) {
+      out[key] = encryptForDisk(v)
+    }
+  }
+  if (Array.isArray(out.pairedDevices)) {
+    out.pairedDevices = out.pairedDevices.map((device: any) => {
+      if (!device || typeof device !== 'object') return device
+      const next = { ...device }
+      for (const key of SENSITIVE_DEVICE_FIELDS) {
+        const v = next[key]
+        if (typeof v === 'string' && v && !v.startsWith(ENC_PREFIX)) {
+          next[key] = encryptForDisk(v)
+        }
+      }
+      return next
+    })
+  }
+  if (!isSafeStorageReady()) {
+    out.secret_unencrypted = true
+  } else {
+    delete out.secret_unencrypted
+  }
+  return out
+}
+
+// decryptSensitiveSettings returns a copy of settings with sensitive fields
+// replaced by their plaintext forms.
+export function decryptSensitiveSettings(settings: Record<string, any>): Record<string, any> {
+  const out: Record<string, any> = { ...settings }
+  for (const key of SENSITIVE_TOP_FIELDS) {
+    const v = out[key]
+    if (typeof v === 'string' && v.startsWith(ENC_PREFIX)) {
+      out[key] = decryptFromDisk(v)
+    }
+  }
+  if (Array.isArray(out.pairedDevices)) {
+    out.pairedDevices = out.pairedDevices.map((device: any) => {
+      if (!device || typeof device !== 'object') return device
+      const next = { ...device }
+      for (const key of SENSITIVE_DEVICE_FIELDS) {
+        const v = next[key]
+        if (typeof v === 'string' && v.startsWith(ENC_PREFIX)) {
+          next[key] = decryptFromDisk(v)
+        }
+      }
+      return next
+    })
+  }
+  return out
+}

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { IPC } from '../shared/types'
-import type { RunOptions, NormalizedEvent, HealthReport, EnrichedError, FileAttachment, SessionMeta, SessionLoadMessage, GitGraphData, GitChangesData, GitBranchInfo, GitCommitDetail, PersistedTabState, FsEntry, WorktreeInfo, WorktreeStatus, EngineConfig, EngineEvent } from '../shared/types'
+import type { RunOptions, NormalizedEvent, HealthReport, EnrichedError, FileAttachment, SessionMeta, SessionLoadMessage, GitGraphData, GitChangesData, GitBranchInfo, GitCommitDetail, PersistedTabState, FsEntry, WorktreeInfo, WorktreeStatus, EngineConfig, EngineEvent, RemoteTransportState } from '../shared/types'
 import type { DiscoveredCommand } from '../main/cli-compat/command-discovery'
 
 export interface IonAPI {
@@ -25,6 +25,7 @@ export interface IonAPI {
   transcribeAudio(audioBase64: string): Promise<{ error: string | null; transcript: string | null }>
   getDiagnostics(): Promise<any>
   respondPermission(tabId: string, questionId: string, optionId: string): Promise<boolean>
+  approveDeniedTools(tabId: string, toolNames: string[]): Promise<boolean>
   initSession(tabId: string): void
   resetTabSession(tabId: string): void
   listSessions(projectPath?: string): Promise<SessionMeta[]>
@@ -114,7 +115,7 @@ export interface IonAPI {
   onEngineEvent(callback: (key: string, event: EngineEvent) => void): () => void
 
   // ─── Remote control ───
-  remoteGetState(): Promise<{ transportState: string } | null>
+  remoteGetState(): Promise<{ transportState: RemoteTransportState } | null>
   remoteGetMessages(tabId: string): Promise<any[]>
   remoteStartPairing(): Promise<string | null>
   remoteCancelPairing(): void

--- a/desktop/src/renderer/ambient.d.ts
+++ b/desktop/src/renderer/ambient.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mp3' {
+  const src: string
+  export default src
+}

--- a/desktop/src/renderer/components/AgentPanel.tsx
+++ b/desktop/src/renderer/components/AgentPanel.tsx
@@ -42,7 +42,7 @@ function getAgentColor(agent: AgentStateUpdate): string {
 }
 
 function isAgentVisible(agent: AgentStateUpdate): boolean {
-  const visibility = meta(agent, 'visibility', 'ephemeral')
+  const visibility = meta<string>(agent, 'visibility', 'ephemeral')
   switch (visibility) {
     case 'always': return true
     case 'sticky': return meta(agent, 'invited', false)

--- a/desktop/src/renderer/components/ConversationView.tsx
+++ b/desktop/src/renderer/components/ConversationView.tsx
@@ -631,7 +631,7 @@ function MessageAttachments({ attachments }: { attachments: Attachment[] }) {
             <span className="flex-shrink-0" style={{ color: a.type === 'plan' ? 'rgba(34, 197, 94, 0.85)' : colors.textTertiary }}>
               {a.type === 'plan'
                 ? <ListChecks size={12} />
-                : (a.type !== 'plan' && FILE_ICONS[(a as any).mimeType || '']) || <File size={12} />}
+                : FILE_ICONS[(a as any).mimeType || ''] || <File size={12} />}
             </span>
             <span
               className="text-[10px] font-medium truncate"

--- a/desktop/src/renderer/components/GitPanel.tsx
+++ b/desktop/src/renderer/components/GitPanel.tsx
@@ -6,6 +6,7 @@ import {
   ArrowsClockwise, ArrowDown, ArrowUp, GitBranch, Folder, FolderOpen,
   Trash, Robot, Check, CheckCircle, X, SpinnerGap, ListBullets, TreeStructure,
 } from '@phosphor-icons/react'
+import { useShallow } from 'zustand/shallow'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -1293,7 +1294,7 @@ function GitGraphSection({
 
       {/* Commit detail popup */}
       {popoverLayer && hoveredCommit && hoverRect && createPortal(
-        <CommitPopup commit={hoveredCommit} rect={hoverRect} detail={commitDetail} panelRight={scrollRef.current?.getBoundingClientRect().right ?? rect.right} />,
+        <CommitPopup commit={hoveredCommit} rect={hoverRect} detail={commitDetail} panelRight={scrollRef.current?.getBoundingClientRect().right ?? hoverRect.right} />,
         popoverLayer,
       )}
 
@@ -1638,8 +1639,10 @@ export function GitPanel() {
   const colors = useColors()
   const expandedUI = usePreferencesStore((s) => s.expandedUI)
   const tab = useSessionStore(
-    (s) => s.tabs.find((t) => t.id === s.activeTabId),
-    (a, b) => a === b || (!!a && !!b && a.workingDirectory === b.workingDirectory && a.worktree === b.worktree),
+    useShallow((s) => {
+      const t = s.tabs.find((t) => t.id === s.activeTabId)
+      return t ? { workingDirectory: t.workingDirectory, worktree: t.worktree } : undefined
+    }),
   )
   const directory = tab?.workingDirectory || '~'
   const worktree = tab?.worktree ?? null
@@ -1665,7 +1668,7 @@ export function GitPanel() {
     const result = await window.ion.gitCommit(directory, commitMsg.trim())
     if (result.ok) {
       setCommitMsg('')
-      setRefreshKey((k) => k + 1)
+      useGitPollingStore.getState().refresh()
       // Move tab to done group after successful commit
       const { doneGroupId, tabGroupMode } = usePreferencesStore.getState()
       const { activeTabId: tabId, tabs: allTabs, moveTabToGroup } = useSessionStore.getState()
@@ -1770,7 +1773,7 @@ export function GitPanel() {
           </button>
           <span className="text-[10px] font-medium" style={{ color: colors.textTertiary }}>
             Git
-            <span style={{ color: colors.textQuaternary, marginLeft: 4 }}>
+            <span style={{ color: colors.textMuted, marginLeft: 4 }}>
               {directory.split('/').filter(Boolean).pop() || '~'}
             </span>
           </span>

--- a/desktop/src/renderer/components/HistoryPicker.tsx
+++ b/desktop/src/renderer/components/HistoryPicker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { Clock, ChatCircle, Stack } from '@phosphor-icons/react'
+import { useShallow } from 'zustand/shallow'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
@@ -34,8 +35,10 @@ export function HistoryPicker() {
   const tabs = useSessionStore((s) => s.tabs)
   const isExpanded = useSessionStore((s) => s.isExpanded)
   const activeTab = useSessionStore(
-    (s) => s.tabs.find((t) => t.id === s.activeTabId),
-    (a, b) => a === b || (!!a && !!b && a.hasChosenDirectory === b.hasChosenDirectory && a.workingDirectory === b.workingDirectory),
+    useShallow((s) => {
+      const t = s.tabs.find((t) => t.id === s.activeTabId)
+      return t ? { hasChosenDirectory: t.hasChosenDirectory, workingDirectory: t.workingDirectory } : undefined
+    }),
   )
   const staticInfo = useSessionStore((s) => s.staticInfo)
   const popoverLayer = usePopoverLayer()

--- a/desktop/src/renderer/components/SettingsDialog.tsx
+++ b/desktop/src/renderer/components/SettingsDialog.tsx
@@ -32,7 +32,7 @@ const CATEGORIES: Category[] = [
   { id: 'engine', label: 'Engine', icon: Plugs, component: EngineCategory },
 ]
 
-const TRANSITION = { duration: 0.26, ease: [0.4, 0, 0.1, 1] }
+const TRANSITION = { duration: 0.26, ease: [0.4, 0, 0.1, 1] as const }
 
 interface SettingsDialogProps {
   onClose: () => void

--- a/desktop/src/renderer/components/StatusBar.tsx
+++ b/desktop/src/renderer/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CaretDown, Check, FolderOpen, Plus, X, ShieldCheck, ListChecks, GitBranch, Code, TreeStructure, NotePencil, ArrowsOutSimple, ArrowsInSimple, Copy } from '@phosphor-icons/react'
+import { useShallow } from 'zustand/shallow'
 import { useSessionStore, AVAILABLE_MODELS, getModelDisplayLabel } from '../stores/sessionStore'
 import { getModelContextWindow } from '../stores/model-labels'
 import { usePopoverLayer } from './PopoverLayer'
@@ -27,8 +28,10 @@ function ModelPicker() {
   const preferredModel = usePreferencesStore((s) => s.preferredModel)
   const setPreferredModel = usePreferencesStore((s) => s.setPreferredModel)
   const tab = useSessionStore(
-    (s) => s.tabs.find((t) => t.id === s.activeTabId),
-    (a, b) => a === b || (!!a && !!b && a.status === b.status && a.sessionModel === b.sessionModel),
+    useShallow((s) => {
+      const t = s.tabs.find((t) => t.id === s.activeTabId)
+      return t ? { status: t.status, sessionModel: t.sessionModel } : undefined
+    }),
   )
   const popoverLayer = usePopoverLayer()
   const colors = useColors()
@@ -151,11 +154,10 @@ function ContextIndicator() {
   const popoverLayer = usePopoverLayer()
   const preferredModel = usePreferencesStore((s) => s.preferredModel)
   const { contextTokens, contextPercent } = useSessionStore(
-    (s) => {
+    useShallow((s) => {
       const tab = s.tabs.find((t) => t.id === s.activeTabId)
       return { contextTokens: tab?.contextTokens ?? null, contextPercent: tab?.contextPercent ?? null }
-    },
-    (a, b) => a.contextTokens === b.contextTokens && a.contextPercent === b.contextPercent,
+    }),
   )
 
   const [hover, setHover] = useState(false)
@@ -381,8 +383,10 @@ const OPEN_WITH_OPTIONS = [
 
 function OpenWithPicker() {
   const tab = useSessionStore(
-    (s) => s.tabs.find((t) => t.id === s.activeTabId),
-    (a, b) => a === b || (!!a && !!b && a.conversationId === b.conversationId && a.workingDirectory === b.workingDirectory),
+    useShallow((s) => {
+      const t = s.tabs.find((t) => t.id === s.activeTabId)
+      return t ? { conversationId: t.conversationId, workingDirectory: t.workingDirectory } : undefined
+    }),
   )
   const preferredOpenWith = usePreferencesStore((s) => s.preferredOpenWith)
   const setPreferredOpenWith = usePreferencesStore((s) => s.setPreferredOpenWith)
@@ -507,7 +511,7 @@ function OpenWithPicker() {
                 <div className="mx-2 my-1" style={{ borderTop: `1px solid ${colors.popoverBorder}` }} />
                 <button
                   onClick={() => {
-                    navigator.clipboard.writeText(tab.conversationId)
+                    if (tab.conversationId) navigator.clipboard.writeText(tab.conversationId)
                     setOpen(false)
                   }}
                   className="w-full flex items-center px-3 py-1.5 text-[11px] transition-colors"
@@ -559,15 +563,19 @@ function compactPath(fullPath: string): string {
 
 export function StatusBar() {
   const tab = useSessionStore(
-    (s) => s.tabs.find((t) => t.id === s.activeTabId),
-    (a, b) => a === b || (!!a && !!b
-      && a.status === b.status
-      && a.additionalDirs === b.additionalDirs
-      && a.hasChosenDirectory === b.hasChosenDirectory
-      && a.workingDirectory === b.workingDirectory
-      && a.conversationId === b.conversationId
-      && (a.messages.length > 0) === (b.messages.length > 0)
-    ),
+    useShallow((s) => {
+      const t = s.tabs.find((t) => t.id === s.activeTabId)
+      return t
+        ? {
+            status: t.status,
+            additionalDirs: t.additionalDirs,
+            hasChosenDirectory: t.hasChosenDirectory,
+            workingDirectory: t.workingDirectory,
+            conversationId: t.conversationId,
+            messages: t.messages,
+          }
+        : undefined
+    }),
   )
   const addDirectory = useSessionStore((s) => s.addDirectory)
   const removeDirectory = useSessionStore((s) => s.removeDirectory)

--- a/desktop/src/renderer/components/TabStrip.tsx
+++ b/desktop/src/renderer/components/TabStrip.tsx
@@ -2479,17 +2479,6 @@ export function TabStrip() {
     scrollRef.current?.scrollBy({ left: amount, behavior: 'smooth' })
   }, [])
 
-  // Listen for CMD+R "open recent dirs" event from App
-  useEffect(() => {
-    const handler = () => {
-      if (!plusButtonRef.current) return
-      const rect = zoomRect(plusButtonRef.current.getBoundingClientRect())
-      setRecentDirsMenu({ x: rect.left, y: rect.bottom })
-    }
-    window.addEventListener('ion:open-recent-dirs', handler)
-    return () => window.removeEventListener('ion:open-recent-dirs', handler)
-  }, [])
-
   // Convert vertical wheel to horizontal scroll (also allow native horizontal scroll)
   const onWheel = useCallback((e: React.WheelEvent) => {
     if (!scrollRef.current) return
@@ -2527,7 +2516,7 @@ export function TabStrip() {
           <button
             onClick={() => scrollBy(-150)}
             className="absolute left-0 top-0 bottom-0 z-10 flex items-center justify-center w-5 transition-opacity"
-            style={{ color: colors.textTertiary, background: `linear-gradient(to right, ${colors.bgSecondary}, transparent)` }}
+            style={{ color: colors.textTertiary, background: `linear-gradient(to right, ${colors.containerBg}, transparent)` }}
             onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = colors.textPrimary }}
             onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = colors.textTertiary }}
           >
@@ -2538,7 +2527,7 @@ export function TabStrip() {
           <button
             onClick={() => scrollBy(150)}
             className="absolute right-0 top-0 bottom-0 z-10 flex items-center justify-center w-5 transition-opacity"
-            style={{ color: colors.textTertiary, background: `linear-gradient(to left, ${colors.bgSecondary}, transparent)` }}
+            style={{ color: colors.textTertiary, background: `linear-gradient(to left, ${colors.containerBg}, transparent)` }}
             onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.color = colors.textPrimary }}
             onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.color = colors.textTertiary }}
           >

--- a/desktop/src/renderer/hooks/useEngineEvents.ts
+++ b/desktop/src/renderer/hooks/useEngineEvents.ts
@@ -126,10 +126,10 @@ export function useEngineEvents() {
       const tabs = store.tabs.filter((t) => t.id !== tabId)
       const panes = new Map(store.terminalPanes)
       panes.delete(tabId)
-      const selected = store.selectedTabId === tabId
+      const selected = store.activeTabId === tabId
         ? (tabs[0]?.id ?? null)
-        : store.selectedTabId
-      useSessionStore.setState({ tabs, terminalPanes: panes, selectedTabId: selected })
+        : store.activeTabId
+      useSessionStore.setState({ tabs, terminalPanes: panes, activeTabId: selected })
     }
     window.ion.on(IPC.REMOTE_CLOSE_TAB, remoteCloseTabHandler)
 

--- a/desktop/src/renderer/stores/sessionStore.ts
+++ b/desktop/src/renderer/stores/sessionStore.ts
@@ -165,7 +165,7 @@ interface State {
   toggleTerminal: (tabId: string) => void
   runInTerminal: (tabId: string, cmd: string) => void
   consumeTerminalPendingCommand: (key: string) => string | undefined
-  createTerminalTab: () => Promise<string>
+  createTerminalTab: (dir?: string) => Promise<string>
   addTerminalInstance: (tabId: string, kind: string, cwd?: string) => string
   removeTerminalInstance: (tabId: string, instanceId: string) => void
   selectTerminalInstance: (tabId: string, instanceId: string) => void
@@ -2902,6 +2902,7 @@ export const useSessionStore = create<State>((set, get) => ({
     } else {
       // No profile -- start bare session with defaults
       window.ion.engineStart(key, {
+        profileId: '',
         extensions: [],
         workingDirectory: tab.workingDirectory,
       }).catch((err: any) => {
@@ -3166,7 +3167,7 @@ export const useSessionStore = create<State>((set, get) => ({
           const messages = new Map(state.engineMessages)
           const msgs = (messages.get(key) || []).map((m) => {
             if (m.toolId !== event.toolId) return m
-            return { ...m, content: event.result || '', toolStatus: (event.isError ? 'error' : 'completed') as const }
+            return { ...m, content: event.result || '', toolStatus: (event.isError ? 'error' : 'completed') as 'error' | 'completed' }
           })
           messages.set(key, msgs)
           return { engineMessages: messages }

--- a/desktop/src/shared/types.ts
+++ b/desktop/src/shared/types.ts
@@ -298,6 +298,7 @@ export interface EngineConfig {
   extensions: string[]
   workingDirectory: string
   sessionId?: string
+  model?: string
   maxTokens?: number
   thinking?: { enabled: boolean; budgetTokens?: number }
 }
@@ -691,6 +692,8 @@ export interface PersistedTab {
   hasChosenDirectory: boolean
   additionalDirs: string[]
   permissionMode: 'auto' | 'plan'
+  permissionDenied?: { tools: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> } | null
+  planFilePath?: string | null
   bashResults?: Array<{ command: string; stdout: string; stderr: string }>
   pillColor?: string | null
   pillIcon?: string | null

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -7,5 +7,8 @@ RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /ion ./cmd/ion/
 
 FROM scratch
 COPY --from=build /ion /ion
+ENV HOME=/data
+VOLUME ["/data"]
 ENTRYPOINT ["/ion"]
 CMD ["serve"]
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD ["/ion", "health"]

--- a/engine/cmd/ion/main.go
+++ b/engine/cmd/ion/main.go
@@ -279,8 +279,9 @@ func cmdServe() {
 	sock := socketPath()
 	srv := server.NewServer(sock, b)
 
-	// Expose config to server/session layer
+	// Expose config and version to server/session layer
 	srv.SetConfig(cfg)
+	srv.SetVersion(version)
 
 	// Start server (handles stale socket, platform-specific listen)
 	if err := srv.Start(); err != nil {
@@ -717,6 +718,30 @@ func cmdStop(flags map[string]string) {
 	fmt.Println(string(data))
 }
 
+func cmdHealth() {
+	result, err := connectAndSend(socketPath(), map[string]interface{}{
+		"cmd": "health",
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+	if errMsg, _ := result["error"].(string); errMsg != "" {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
+		os.Exit(1)
+	}
+	data, _ := result["data"].(map[string]interface{})
+	if data == nil {
+		fmt.Fprintln(os.Stderr, "Error: empty health response")
+		os.Exit(1)
+	}
+	out, _ := json.MarshalIndent(data, "", "  ")
+	fmt.Println(string(out))
+	if ok, _ := data["ok"].(bool); !ok {
+		os.Exit(1)
+	}
+}
+
 func cmdShutdown() {
 	result, err := connectAndSend(socketPath(), map[string]interface{}{
 		"cmd": "shutdown",
@@ -828,6 +853,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  status                   List sessions")
 	fmt.Fprintln(os.Stderr, "  stop --key               Stop session")
 	fmt.Fprintln(os.Stderr, "  shutdown                 Stop daemon")
+	fmt.Fprintln(os.Stderr, "  health                   Probe daemon liveness (exit 0=ok, 1=down)")
 	fmt.Fprintln(os.Stderr, "  record --output          Record session to NDJSON")
 	fmt.Fprintln(os.Stderr, "  rpc                      JSON-RPC over stdin/stdout")
 	fmt.Fprintln(os.Stderr, "  version                  Show version")
@@ -859,6 +885,8 @@ func main() {
 		cmdStop(flags)
 	case "shutdown":
 		cmdShutdown()
+	case "health":
+		cmdHealth()
 	case "record":
 		cmdRecord(flags)
 	case "rpc":

--- a/engine/go.mod
+++ b/engine/go.mod
@@ -2,6 +2,8 @@ module github.com/dsswift/ion/engine
 
 go 1.25.0
 
+toolchain go1.26.2
+
 require github.com/bmatcuk/doublestar/v4 v4.7.1
 
 require (

--- a/engine/internal/backend/api_backend.go
+++ b/engine/internal/backend/api_backend.go
@@ -183,7 +183,18 @@ func (b *ApiBackend) FlushConversations() {
 	}
 }
 
-// Cancel stops a running agent loop. Returns true if a run was found and cancelled.
+// cancelWatchdogGrace is the grace period after Cancel before the watchdog
+// force-emits an exit and removes the run from activeRuns. Tuned long enough
+// for cooperative tool cancellations to land via ctx, short enough that the
+// frontend tab returns to idle without obvious lag.
+const cancelWatchdogGrace = 5 * time.Second
+
+// Cancel stops a running agent loop. Returns true if a run was found and
+// cancelled. Cancel is a contract: within cancelWatchdogGrace of this call
+// the desktop sees a terminal engine_status idle event regardless of whether
+// the run goroutine has actually returned. If the goroutine is wedged in a
+// blocking call that ignores ctx, the run state is force-cleared anyway and
+// the wedged goroutine is leaked until process exit.
 func (b *ApiBackend) Cancel(requestID string) bool {
 	b.mu.Lock()
 	run, ok := b.activeRuns[requestID]
@@ -196,7 +207,31 @@ func (b *ApiBackend) Cancel(requestID string) bool {
 	}
 	utils.Info("ApiBackend", fmt.Sprintf("Cancel: cancelling requestID=%s (turn=%d)", requestID, run.turnCount.Load()))
 	run.cancel()
+	go b.cancelWatchdog(run, cancelWatchdogGrace)
 	return true
+}
+
+// cancelWatchdog force-clears a run if its goroutine has not returned within
+// the grace period. Idempotent against runLoop's own deferred removeRun.
+func (b *ApiBackend) cancelWatchdog(run *activeRun, grace time.Duration) {
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	<-timer.C
+
+	b.mu.Lock()
+	_, stillActive := b.activeRuns[run.requestID]
+	sessionID := ""
+	if run.conv != nil {
+		sessionID = run.conv.ID
+	}
+	b.mu.Unlock()
+	if !stillActive {
+		return
+	}
+
+	utils.Warn("ApiBackend", fmt.Sprintf("Cancel watchdog: forcing exit for requestID=%s after %s (run goroutine wedged in non-cancellable call)", run.requestID, grace))
+	b.emitExit(run.requestID, intPtr(0), strPtr("cancelled-forced"), sessionID)
+	b.removeRun(run.requestID)
 }
 
 // GetContextUsage returns the context usage for an active run, or nil if not found.
@@ -323,6 +358,39 @@ func (b *ApiBackend) emitError(run *activeRun, err error) {
 
 // contextPercent computes the compaction threshold.
 const compactThreshold = 80
+
+// runHookCtx runs fn on a goroutine and races it against ctx cancellation.
+// On cancel, returns ctx.Err() and discards the eventual result. The inner
+// goroutine continues to completion (it has no way to be cancelled — that's
+// why we need this wrapper) but its return value is dropped. Use to bound
+// per-tool extension hooks (OnToolCall, OnPermissionRequest, etc.) that are
+// implemented by extension subprocesses with no native ctx support.
+func runHookCtx[T any](ctx context.Context, fn func() T) (T, error) {
+	var zero T
+	ch := make(chan T, 1)
+	go func() {
+		defer func() {
+			// Hook callbacks are extension-supplied; recover panics so they
+			// can't take down the run. Drop the result on panic.
+			recover()
+		}()
+		ch <- fn()
+	}()
+	select {
+	case v := <-ch:
+		return v, nil
+	case <-ctx.Done():
+		return zero, ctx.Err()
+	}
+}
+
+// defaultToolTimeout caps how long a single tool call may run. The cap is a
+// belt-and-suspenders backstop against tools that ignore ctx; properly
+// cooperating tools cancel via gCtx far sooner. Bash has its own much-longer
+// inner timeout (long shell commands are legitimate); this cap applies to the
+// surrounding goroutine, so a misbehaving Bash subprocess that ignores SIGTERM
+// will still let executeTools return.
+const defaultToolTimeout = 5 * time.Minute
 
 // runLoop is the core agent loop. It calls the provider, processes the
 // response, executes tools, and loops until the model signals end_turn,
@@ -1212,10 +1280,18 @@ func (b *ApiBackend) executeTools(
 			if permEng != nil {
 				// Classify first so the tier flows into the permission engine
 				// (for tier_rules matching) and onto the permission_request
-				// hook payload (for audit/observation).
+				// hook payload (for audit/observation). The classifier may
+				// invoke an LLM, so race against gCtx so a hung classifier
+				// can't wedge this goroutine.
 				var tier string
 				if permClassifyFn != nil {
-					tier = permClassifyFn(block.Name, block.Input)
+					t, hookErr := runHookCtx(gCtx, func() string {
+						return permClassifyFn(block.Name, block.Input)
+					})
+					if hookErr != nil {
+						return hookErr
+					}
+					tier = t
 				}
 				checkResult := permEng.Check(permissions.CheckInfo{
 					Tool:  block.Name,
@@ -1232,15 +1308,25 @@ func (b *ApiBackend) executeTools(
 					if tier != "" {
 						payload["tier"] = tier
 					}
-					permReqFn(run.requestID, payload)
+					if _, hookErr := runHookCtx(gCtx, func() struct{} {
+						permReqFn(run.requestID, payload)
+						return struct{}{}
+					}); hookErr != nil {
+						return hookErr
+					}
 				}
 				if checkResult.Decision == "deny" {
 					if permDenyFn != nil {
-						permDenyFn(run.requestID, map[string]interface{}{
-							"tool_name": block.Name,
-							"input":     block.Input,
-							"reason":    checkResult.Reason,
-						})
+						if _, hookErr := runHookCtx(gCtx, func() struct{} {
+							permDenyFn(run.requestID, map[string]interface{}{
+								"tool_name": block.Name,
+								"input":     block.Input,
+								"reason":    checkResult.Reason,
+							})
+							return struct{}{}
+						}); hookErr != nil {
+							return hookErr
+						}
 					}
 					results[i] = conversation.ToolResultEntry{
 						ToolUseID: block.ID,
@@ -1285,13 +1371,26 @@ func (b *ApiBackend) executeTools(
 				}
 			}
 
-			// Call onToolCall hook (extension hook)
+			// Call onToolCall hook (extension hook). Race against gCtx so a
+			// hung extension subprocess can't wedge this goroutine; the run's
+			// per-tool 5min timeout is the outer backstop.
 			if hookFn != nil {
-				result, err := hookFn(ToolCallInfo{
-					ToolName: block.Name,
-					ToolID:   block.ID,
-					Input:    block.Input,
+				type hookRet struct {
+					result *ToolCallResult
+					err    error
+				}
+				ret, hookErr := runHookCtx(gCtx, func() hookRet {
+					r, e := hookFn(ToolCallInfo{
+						ToolName: block.Name,
+						ToolID:   block.ID,
+						Input:    block.Input,
+					})
+					return hookRet{r, e}
 				})
+				if hookErr != nil {
+					return hookErr
+				}
+				result, err := ret.result, ret.err
 				if err != nil {
 					results[i] = conversation.ToolResultEntry{
 						ToolUseID: block.ID,
@@ -1317,7 +1416,12 @@ func (b *ApiBackend) executeTools(
 
 			// Pre-tool hook
 			if perToolHook != nil {
-				_, _ = perToolHook(block.Name, block.Input, "before")
+				if _, hookErr := runHookCtx(gCtx, func() struct{} {
+					_, _ = perToolHook(block.Name, block.Input, "before")
+					return struct{}{}
+				}); hookErr != nil {
+					return hookErr
+				}
 			}
 
 			// Telemetry span for tool execution
@@ -1377,22 +1481,56 @@ func (b *ApiBackend) executeTools(
 				return nil
 			}
 
-			// Route to built-in, extension, or MCP tool (Step 5)
+			// Route to built-in, extension, or MCP tool (Step 5).
+			// Each tool call is bounded by defaultToolTimeout. A tool that
+			// observes ctx will cancel cleanly; a tool that ignores ctx will
+			// be left running but its result is dropped, and executeTools
+			// returns once errgroup's children all return.
+			toolCtx, toolCancel := context.WithTimeout(gCtx, defaultToolTimeout)
+			defer toolCancel()
+
 			var toolResult *types.ToolResult
 			var err error
 
 			if tools.GetTool(block.Name) != nil {
-				toolResult, err = tools.ExecuteTool(gCtx, block.Name, block.Input, cwd)
+				toolResult, err = tools.ExecuteTool(toolCtx, block.Name, block.Input, cwd)
 			} else if mcpRouter != nil {
-				content, isErr, routeErr := mcpRouter(block.Name, block.Input)
-				if routeErr != nil {
-					err = routeErr
-				} else {
-					toolResult = &types.ToolResult{Content: content, IsError: isErr}
+				// mcpRouter does not yet take ctx; race its return against
+				// toolCtx so a hung MCP server cannot wedge the run.
+				type mcpRet struct {
+					content string
+					isErr   bool
+					err     error
+				}
+				resCh := make(chan mcpRet, 1)
+				go func() {
+					content, isErr, routeErr := mcpRouter(block.Name, block.Input)
+					resCh <- mcpRet{content, isErr, routeErr}
+				}()
+				select {
+				case r := <-resCh:
+					if r.err != nil {
+						err = r.err
+					} else {
+						toolResult = &types.ToolResult{Content: r.content, IsError: r.isErr}
+					}
+				case <-toolCtx.Done():
+					err = toolCtx.Err()
 				}
 			} else {
 				toolResult = &types.ToolResult{
 					Content: fmt.Sprintf("Unknown tool: %s", block.Name),
+					IsError: true,
+				}
+			}
+
+			// Surface per-tool deadline as a tool-result error rather than
+			// failing the whole run, so the LLM sees a clear "this tool timed
+			// out" message and can adapt.
+			if err != nil && toolCtx.Err() == context.DeadlineExceeded {
+				err = nil
+				toolResult = &types.ToolResult{
+					Content: fmt.Sprintf("Error: tool %q exceeded %s deadline. Narrow the request or split it into smaller calls.", block.Name, defaultToolTimeout),
 					IsError: true,
 				}
 			}
@@ -1422,21 +1560,36 @@ func (b *ApiBackend) executeTools(
 
 			// Fire file_changed hook for write/edit tools
 			if fileChangedFn != nil && !results[i].IsError {
+				var p string
+				var changeKind string
 				switch block.Name {
 				case "Write", "write":
-					if p, ok := block.Input["file_path"].(string); ok {
-						fileChangedFn(run.requestID, p, "write")
+					if v, ok := block.Input["file_path"].(string); ok {
+						p, changeKind = v, "write"
 					}
 				case "Edit", "edit":
-					if p, ok := block.Input["file_path"].(string); ok {
-						fileChangedFn(run.requestID, p, "edit")
+					if v, ok := block.Input["file_path"].(string); ok {
+						p, changeKind = v, "edit"
+					}
+				}
+				if p != "" {
+					if _, hookErr := runHookCtx(gCtx, func() struct{} {
+						fileChangedFn(run.requestID, p, changeKind)
+						return struct{}{}
+					}); hookErr != nil {
+						return hookErr
 					}
 				}
 			}
 
 			// Post-tool hook
 			if perToolHook != nil {
-				_, _ = perToolHook(block.Name, results[i], "after")
+				if _, hookErr := runHookCtx(gCtx, func() struct{} {
+					_, _ = perToolHook(block.Name, results[i], "after")
+					return struct{}{}
+				}); hookErr != nil {
+					return hookErr
+				}
 			}
 
 			// Emit tool_result event

--- a/engine/internal/backend/api_backend_test.go
+++ b/engine/internal/backend/api_backend_test.go
@@ -394,6 +394,61 @@ func TestCancelReturnsFalseForUnknown(t *testing.T) {
 	}
 }
 
+// TestCancelWatchdogForcesExitWhenRunGoroutineWedges is the regression test
+// for the stuck-tab class of bug. It simulates the scenario where the run
+// goroutine is wedged in a non-cancellable call (e.g. a tool that ignores
+// ctx, like the unfixed doublestar Glob walk): activeRuns still contains an
+// entry, but the run goroutine never returns. The cancel watchdog must
+// emit a synthetic exit so the desktop can return the tab to idle.
+func TestCancelWatchdogForcesExitWhenRunGoroutineWedges(t *testing.T) {
+	b := NewApiBackend()
+
+	// Manually populate activeRuns to simulate a wedged run with no real
+	// goroutine. Cancel will call run.cancel() (no-op since context is not
+	// observed by anyone), then the watchdog should still fire.
+	_, cancelFn := context.WithCancel(context.Background())
+	wedged := &activeRun{
+		requestID: "req-wedged",
+		cancel:    cancelFn,
+		startTime: time.Now(),
+		// conv intentionally nil — exercises the "no session ID" branch
+		// of cancelWatchdog.
+	}
+	b.mu.Lock()
+	b.activeRuns["req-wedged"] = wedged
+	b.mu.Unlock()
+
+	c := collectEvents(b, "req-wedged")
+
+	if !b.Cancel("req-wedged") {
+		t.Fatal("Cancel returned false for active run")
+	}
+
+	// Watchdog grace is 5s; allow generous slack.
+	if !waitForExit(c, 7*time.Second) {
+		t.Fatal("Cancel watchdog did not force exit within grace period")
+	}
+
+	// Verify the synthetic signal so future audits can grep for forced exits.
+	c.mu.Lock()
+	gotSignal := ""
+	if c.exitSignal != nil {
+		gotSignal = *c.exitSignal
+	}
+	c.mu.Unlock()
+	if gotSignal != "cancelled-forced" {
+		t.Errorf("expected exit signal %q, got %q", "cancelled-forced", gotSignal)
+	}
+
+	// activeRuns must be empty after the watchdog runs.
+	b.mu.Lock()
+	_, stillThere := b.activeRuns["req-wedged"]
+	b.mu.Unlock()
+	if stillThere {
+		t.Error("watchdog left run in activeRuns")
+	}
+}
+
 func TestCancelReturnsTrueAndStopsRun(t *testing.T) {
 	// Create a provider that blocks by sleeping in the stream goroutine
 	blockingProvider := &slowMockProvider{

--- a/engine/internal/protocol/protocol.go
+++ b/engine/internal/protocol/protocol.go
@@ -74,6 +74,7 @@ var validCommands = map[string]bool{
 	"get_conversation":      true,
 	"generate_title":        true,
 	"elicitation_response":  true,
+	"health":                true,
 }
 
 // ParseClientCommand parses a single NDJSON line into a ClientCommand.
@@ -220,7 +221,7 @@ func validateRaw(cmd string, raw map[string]json.RawMessage) bool {
 		return hasNonEmptyString(raw, "key") && hasString(raw, "targetId")
 	case "permission_response":
 		return hasNonEmptyString(raw, "key") && hasNonEmptyString(raw, "questionId") && hasNonEmptyString(raw, "optionId")
-	case "list_sessions", "shutdown", "list_stored_sessions":
+	case "list_sessions", "shutdown", "list_stored_sessions", "health":
 		return true
 	case "get_conversation":
 		return hasNonEmptyString(raw, "key")

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dsswift/ion/engine/internal/backend"
 	"github.com/dsswift/ion/engine/internal/conversation"
@@ -44,12 +45,19 @@ type Server struct {
 	broadcastListeners []func(line string)
 	done               chan struct{}
 	stopOnce           sync.Once
+	version            string
+	startedAt          time.Time
 }
 
 // SetConfig stores the engine runtime config for use by sessions.
 func (s *Server) SetConfig(cfg *types.EngineRuntimeConfig) {
 	s.config = cfg
 	s.manager.SetConfig(cfg)
+}
+
+// SetVersion stores the engine binary version for the health command.
+func (s *Server) SetVersion(v string) {
+	s.version = v
 }
 
 // NewServer creates a Server backed by the given RunBackend.
@@ -62,6 +70,7 @@ func NewServer(socketPath string, b backend.RunBackend) *Server {
 		clients:    make(map[net.Conn]struct{}),
 		manager:    mgr,
 		done:       make(chan struct{}),
+		startedAt:  time.Now(),
 	}
 
 	// Wire manager events to broadcast
@@ -391,6 +400,9 @@ func (s *Server) dispatch(conn net.Conn, cmd *protocol.ClientCommand) {
 	case "shutdown":
 		_ = s.Stop()
 
+	case "health":
+		s.sendResult(conn, cmd, nil, s.healthSnapshot())
+
 	default:
 		utils.Warn("Server", "unknown command: "+cmd.Cmd)
 		s.sendResult(conn, cmd, fmt.Errorf("unknown command: %s", cmd.Cmd), nil)
@@ -432,6 +444,22 @@ func (s *Server) sendForkResult(conn net.Conn, cmd *protocol.ClientCommand, err 
 	}
 	line := protocol.SerializeServerResult(result)
 	s.writeToClient(conn, line)
+}
+
+// healthSnapshot returns daemon liveness data for the health command.
+func (s *Server) healthSnapshot() map[string]interface{} {
+	version := s.version
+	if version == "" {
+		version = "dev"
+	}
+	return map[string]interface{}{
+		"ok":           true,
+		"version":      version,
+		"startedAt":    s.startedAt.UTC().Format(time.RFC3339),
+		"uptimeSec":    int64(time.Since(s.startedAt).Seconds()),
+		"sessionCount": len(s.manager.ListSessions()),
+		"socketPath":   s.socketPath,
+	}
 }
 
 // OnBroadcast registers a listener that receives every broadcast line.

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dsswift/ion/engine/internal/backend"
@@ -33,16 +34,45 @@ func DefaultSocketPath() string {
 	return filepath.Join(home, ".ion", "engine.sock")
 }
 
+// broadcastQueueSize bounds per-client and per-listener event queues. A slow
+// consumer may lag this many events before the server starts dropping for it.
+const broadcastQueueSize = 256
+
+// broadcastWriteDeadline is how long a single per-client write may take before
+// the drainer treats the connection as dead and evicts it.
+const broadcastWriteDeadline = 5 * time.Second
+
+// clientWriter owns a connected client's outbound queue. A drain goroutine
+// reads from queue and writes to conn under a per-write deadline. Slow or
+// stalled consumers drop events at the enqueue site (non-blocking send) and,
+// once the write deadline trips, are evicted entirely.
+type clientWriter struct {
+	conn    net.Conn
+	queue   chan []byte
+	done    chan struct{}
+	dropped int64
+}
+
+// listenerHandle wraps a registered broadcast listener with its own queue and
+// drain goroutine so a slow listener (e.g. a backed-up relay) cannot stall
+// delivery to socket clients or to other listeners.
+type listenerHandle struct {
+	fn      func(line string)
+	queue   chan string
+	done    chan struct{}
+	dropped int64
+}
+
 // Server listens on a Unix domain socket (or TCP on Windows), accepts NDJSON
 // commands from clients, and broadcasts session events back to all connected clients.
 type Server struct {
 	socketPath         string
 	listener           net.Listener
-	clients            map[net.Conn]struct{}
+	clients            map[net.Conn]*clientWriter
 	mu                 sync.RWMutex
 	manager            *session.Manager
 	config             *types.EngineRuntimeConfig
-	broadcastListeners []func(line string)
+	broadcastListeners []*listenerHandle
 	done               chan struct{}
 	stopOnce           sync.Once
 	version            string
@@ -67,7 +97,7 @@ func NewServer(socketPath string, b backend.RunBackend) *Server {
 
 	s := &Server{
 		socketPath: socketPath,
-		clients:    make(map[net.Conn]struct{}),
+		clients:    make(map[net.Conn]*clientWriter),
 		manager:    mgr,
 		done:       make(chan struct{}),
 		startedAt:  time.Now(),
@@ -139,10 +169,15 @@ func (s *Server) Stop() error {
 		_ = s.manager.StopAll()
 
 		s.mu.Lock()
-		for conn := range s.clients {
+		for conn, cw := range s.clients {
+			close(cw.done)
 			conn.Close()
 		}
-		s.clients = make(map[net.Conn]struct{})
+		s.clients = make(map[net.Conn]*clientWriter)
+		for _, lh := range s.broadcastListeners {
+			close(lh.done)
+		}
+		s.broadcastListeners = nil
 		s.mu.Unlock()
 
 		if s.listener != nil {
@@ -195,21 +230,79 @@ func (s *Server) acceptLoop() {
 			}
 		}
 
+		cw := &clientWriter{
+			conn:  conn,
+			queue: make(chan []byte, broadcastQueueSize),
+			done:  make(chan struct{}),
+		}
 		s.mu.Lock()
-		s.clients[conn] = struct{}{}
+		s.clients[conn] = cw
 		s.mu.Unlock()
 
+		go s.drainClient(cw)
 		go s.handleClient(conn)
 	}
 }
 
-func (s *Server) handleClient(conn net.Conn) {
-	defer func() {
-		s.mu.Lock()
+// drainClient reads from cw.queue and writes to the underlying conn under a
+// per-write deadline. A failed write evicts the client.
+func (s *Server) drainClient(cw *clientWriter) {
+	for {
+		select {
+		case line, ok := <-cw.queue:
+			if !ok {
+				return
+			}
+			if err := cw.conn.SetWriteDeadline(time.Now().Add(broadcastWriteDeadline)); err != nil {
+				utils.Log("Server", "set write deadline failed: "+err.Error())
+			}
+			if _, err := cw.conn.Write(line); err != nil {
+				utils.Log("Server", fmt.Sprintf("broadcast write error (evicting client, %d events dropped): %s", atomic.LoadInt64(&cw.dropped), err.Error()))
+				s.evictClient(cw.conn)
+				return
+			}
+		case <-cw.done:
+			return
+		}
+	}
+}
+
+// evictClient removes a client from the broadcast set and closes its conn.
+// Safe to call multiple times.
+func (s *Server) evictClient(conn net.Conn) {
+	s.mu.Lock()
+	cw, ok := s.clients[conn]
+	if ok {
 		delete(s.clients, conn)
-		s.mu.Unlock()
+	}
+	s.mu.Unlock()
+	if ok {
+		select {
+		case <-cw.done:
+		default:
+			close(cw.done)
+		}
 		conn.Close()
-	}()
+	}
+}
+
+// drainListener calls the listener fn for each queued line until done is closed.
+func (s *Server) drainListener(lh *listenerHandle) {
+	for {
+		select {
+		case line, ok := <-lh.queue:
+			if !ok {
+				return
+			}
+			lh.fn(line)
+		case <-lh.done:
+			return
+		}
+	}
+}
+
+func (s *Server) handleClient(conn net.Conn) {
+	defer s.evictClient(conn)
 
 	scanner := bufio.NewScanner(conn)
 	// Allow large messages (1MB)
@@ -463,35 +556,86 @@ func (s *Server) healthSnapshot() map[string]interface{} {
 }
 
 // OnBroadcast registers a listener that receives every broadcast line.
-// Used by relay transport to forward engine events to mobile peers.
+// Used by relay transport to forward engine events to mobile peers. Each
+// listener gets its own bounded queue + drain goroutine so a slow listener
+// cannot stall delivery to socket clients or other listeners.
 func (s *Server) OnBroadcast(fn func(line string)) {
+	lh := &listenerHandle{
+		fn:    fn,
+		queue: make(chan string, broadcastQueueSize),
+		done:  make(chan struct{}),
+	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.broadcastListeners = append(s.broadcastListeners, fn)
+	s.broadcastListeners = append(s.broadcastListeners, lh)
+	s.mu.Unlock()
+	go s.drainListener(lh)
 }
 
+// broadcast delivers line to every connected client and registered listener.
+// Per-client and per-listener delivery is non-blocking: each side has its own
+// bounded queue, drained by a dedicated goroutine. The Server lock is held
+// only for the snapshot read; no I/O happens under lock.
 func (s *Server) broadcast(line string) {
+	payload := []byte(line)
 	s.mu.RLock()
-	defer s.mu.RUnlock()
+	clients := make([]*clientWriter, 0, len(s.clients))
+	for _, cw := range s.clients {
+		clients = append(clients, cw)
+	}
+	listeners := make([]*listenerHandle, len(s.broadcastListeners))
+	copy(listeners, s.broadcastListeners)
+	s.mu.RUnlock()
 
-	for conn := range s.clients {
-		_, err := conn.Write([]byte(line))
-		if err != nil {
-			utils.Log("Server", "broadcast write error: "+err.Error())
+	for _, cw := range clients {
+		select {
+		case cw.queue <- payload:
+		default:
+			n := atomic.AddInt64(&cw.dropped, 1)
+			if n == 1 || n%256 == 0 {
+				utils.Log("Server", fmt.Sprintf("broadcast queue full; dropped %d events for slow client", n))
+			}
 		}
 	}
 
-	for _, fn := range s.broadcastListeners {
-		fn(line)
+	for _, lh := range listeners {
+		select {
+		case lh.queue <- line:
+		default:
+			n := atomic.AddInt64(&lh.dropped, 1)
+			if n == 1 || n%256 == 0 {
+				utils.Log("Server", fmt.Sprintf("broadcast listener queue full; dropped %d events", n))
+			}
+		}
 	}
 }
 
+// writeToClient routes a single line to the given conn through its queue, so
+// it is serialized with broadcast traffic on the same connection. A nil conn
+// is a relay-dispatched command with no socket reply (results go via
+// broadcast listeners).
 func (s *Server) writeToClient(conn net.Conn, line string) {
 	if conn == nil {
-		return // relay dispatch: results go via broadcast listeners
+		return
 	}
-	_, err := conn.Write([]byte(line))
-	if err != nil {
-		utils.Log("Server", "write error: "+err.Error())
+	s.mu.RLock()
+	cw, ok := s.clients[conn]
+	s.mu.RUnlock()
+	if !ok {
+		// Conn is not (or no longer) registered. Fall back to a direct write
+		// with a deadline so a wedged peer cannot stall the caller.
+		_ = conn.SetWriteDeadline(time.Now().Add(broadcastWriteDeadline))
+		if _, err := conn.Write([]byte(line)); err != nil {
+			utils.Log("Server", "write error (untracked client): "+err.Error())
+		}
+		return
+	}
+	payload := []byte(line)
+	select {
+	case cw.queue <- payload:
+	default:
+		n := atomic.AddInt64(&cw.dropped, 1)
+		if n == 1 || n%256 == 0 {
+			utils.Log("Server", fmt.Sprintf("client queue full; dropped %d events", n))
+		}
 	}
 }

--- a/engine/internal/server/server_broadcast_test.go
+++ b/engine/internal/server/server_broadcast_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestBroadcastSlowClientDoesNotBlock verifies that one stalled consumer cannot
+// block broadcast delivery to other clients or to the broadcast caller. The
+// fast client must keep receiving events promptly, and the broadcast loop
+// itself must return quickly even when one client never reads.
+func TestBroadcastSlowClientDoesNotBlock(t *testing.T) {
+	mb := newMockBackend()
+	srv := newShortPathTestServer(t, mb)
+
+	fast, err := net.Dial("unix", srv.SocketPath())
+	if err != nil {
+		t.Fatalf("dial fast: %v", err)
+	}
+	defer fast.Close()
+
+	slow, err := net.Dial("unix", srv.SocketPath())
+	if err != nil {
+		t.Fatalf("dial slow: %v", err)
+	}
+	defer slow.Close()
+
+	// Wait for the server to register both clients.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		srv.mu.RLock()
+		n := len(srv.clients)
+		srv.mu.RUnlock()
+		if n >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Fast client drains in a goroutine, counting events.
+	var received int64
+	doneFast := make(chan struct{})
+	go func() {
+		scanner := bufio.NewScanner(fast)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			atomic.AddInt64(&received, 1)
+		}
+		close(doneFast)
+	}()
+
+	// Slow client never reads. Fill its queue + OS socket buffer with many
+	// broadcasts, then verify the broadcast call returned quickly and the
+	// fast client kept up.
+	const events = broadcastQueueSize * 8
+	const lineSize = 512
+	payload := make([]byte, lineSize-1)
+	for i := range payload {
+		payload[i] = 'x'
+	}
+	line := string(payload) + "\n"
+
+	start := time.Now()
+	for i := 0; i < events; i++ {
+		srv.broadcast(line)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("broadcast loop blocked on slow client: %v for %d events", elapsed, events)
+	}
+
+	// The broadcast queue is bounded, so under heavy spam some events drop on
+	// both clients; the property we care about is that the fast reader is not
+	// starved. Require it to have received a meaningful share within the
+	// deadline (>= queue capacity proves the drainer kept progressing).
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(&received) >= int64(broadcastQueueSize) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&received); got < int64(broadcastQueueSize) {
+		t.Fatalf("fast client received %d events; expected at least queue capacity %d -- drainer stalled", got, broadcastQueueSize)
+	}
+}
+
+// TestBroadcastEvictsDeadClient verifies that a client whose socket has been
+// abruptly closed is removed from the broadcast set after a write error, so
+// we do not leak clientWriter goroutines.
+func TestBroadcastEvictsDeadClient(t *testing.T) {
+	mb := newMockBackend()
+	srv := newShortPathTestServer(t, mb)
+
+	conn, err := net.Dial("unix", srv.SocketPath())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// Wait for registration.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		srv.mu.RLock()
+		n := len(srv.clients)
+		srv.mu.RUnlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Force the client off the network. handleClient's defer will evict.
+	conn.Close()
+
+	// Server should observe the disconnect and remove the client.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		srv.mu.RLock()
+		n := len(srv.clients)
+		srv.mu.RUnlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	srv.mu.RLock()
+	n := len(srv.clients)
+	srv.mu.RUnlock()
+	t.Fatalf("client not evicted after disconnect; clients=%d", n)
+}
+
+// TestOnBroadcastListenerIsolation verifies that a slow OnBroadcast listener
+// does not stall delivery to other listeners or to socket clients.
+func TestOnBroadcastListenerIsolation(t *testing.T) {
+	mb := newMockBackend()
+	dir, err := os.MkdirTemp("/tmp", "ion-iso-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	sockPath := filepath.Join(dir, "t.sock")
+	srv := NewServer(sockPath, mb)
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	t.Cleanup(func() { srv.Stop() })
+
+	var fastCount int64
+	gate := make(chan struct{})
+
+	srv.OnBroadcast(func(line string) {
+		<-gate // never receives, simulating a stalled listener
+	})
+	srv.OnBroadcast(func(line string) {
+		atomic.AddInt64(&fastCount, 1)
+	})
+
+	const events = broadcastQueueSize * 4
+	start := time.Now()
+	for i := 0; i < events; i++ {
+		srv.broadcast("event\n")
+	}
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("broadcast blocked on slow listener: %v", elapsed)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(&fastCount) >= int64(broadcastQueueSize) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&fastCount); got < int64(broadcastQueueSize) {
+		t.Fatalf("fast listener processed %d events; expected at least queue capacity %d -- slow listener stalled the path", got, broadcastQueueSize)
+	}
+
+	// Release the slow listener so its drain goroutine can exit at Stop.
+	close(gate)
+}

--- a/engine/internal/tools/edit.go
+++ b/engine/internal/tools/edit.go
@@ -91,7 +91,7 @@ func replaceRunes(s string, m map[rune]rune) string {
 	return sb.String()
 }
 
-func executeEdit(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeEdit(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	filePath, _ := input["file_path"].(string)
 	if filePath == "" {
 		return &types.ToolResult{Content: "Error: file_path is required", IsError: true}, nil
@@ -102,6 +102,9 @@ func executeEdit(_ context.Context, input map[string]any, cwd string) (*types.To
 
 	filePath = resolvePath(cwd, filePath)
 
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: Edit cancelled.", IsError: true}, nil
+	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return &types.ToolResult{Content: fmt.Sprintf("Error editing file: %s", err), IsError: true}, nil

--- a/engine/internal/tools/glob.go
+++ b/engine/internal/tools/glob.go
@@ -1,18 +1,28 @@
 package tools
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/dsswift/ion/engine/internal/types"
 )
 
+const (
+	maxGlobMatches = 10000
+	globTimeout    = 60 * time.Second
+)
+
 // GlobTool returns a ToolDef that finds files matching a glob pattern.
-// Uses doublestar for ** support.
 func GlobTool() *types.ToolDef {
 	return &types.ToolDef{
 		Name:        "Glob",
@@ -29,12 +39,84 @@ func GlobTool() *types.ToolDef {
 	}
 }
 
-func executeGlob(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+// executeGlob walks files matching the pattern. The walk is anchored to
+// searchDir, honors the run's context (kills the ripgrep subprocess on
+// cancel), enforces a 60s wall-clock deadline, and caps results at
+// maxGlobMatches. If ripgrep is not on PATH, falls back to a context-aware
+// doublestar walk.
+func executeGlob(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	pattern, _ := input["pattern"].(string)
 	if pattern == "" {
 		return &types.ToolResult{Content: "Error: pattern is required", IsError: true}, nil
 	}
 
+	searchDir, err := resolveSearchDir(input, cwd)
+	if err != nil {
+		return &types.ToolResult{Content: "Error: " + err.Error(), IsError: true}, nil
+	}
+
+	// If pattern is absolute, split into static base + relative pattern so the
+	// walk is anchored as tightly as possible. (Mirrors Claude Code's
+	// extractGlobBaseDirectory.) The extracted base must still live under cwd
+	// so a wide absolute pattern cannot escape the working directory.
+	if filepath.IsAbs(pattern) {
+		baseDir, relPattern := extractGlobBase(pattern)
+		if baseDir != "" {
+			cleanBase := filepath.Clean(baseDir)
+			cwdClean := filepath.Clean(cwd)
+			if cwdClean != "" && cwdClean != "." {
+				rel, relErr := filepath.Rel(cwdClean, cleanBase)
+				if relErr != nil || strings.HasPrefix(rel, "..") {
+					return &types.ToolResult{
+						Content: fmt.Sprintf("Error: pattern base %q escapes cwd %q", cleanBase, cwdClean),
+						IsError: true,
+					}, nil
+				}
+			}
+			searchDir = cleanBase
+			pattern = relPattern
+		}
+	}
+
+	// Bound the walk by wall clock, regardless of caller ctx.
+	walkCtx, cancel := context.WithTimeout(ctx, globTimeout)
+	defer cancel()
+
+	matches, truncated, err := globWithRipgrep(walkCtx, searchDir, pattern)
+	if err != nil && errors.Is(err, errRipgrepUnavailable) {
+		matches, truncated, err = globWithDoublestar(walkCtx, searchDir, pattern)
+	}
+	if err != nil {
+		// Surface ctx errors as a normal tool result so the LLM sees the
+		// timeout/cancel rather than crashing the run loop.
+		if errors.Is(err, context.DeadlineExceeded) {
+			return &types.ToolResult{
+				Content: fmt.Sprintf("Error: Glob exceeded %s deadline (pattern=%q under %q). Narrow the pattern or path.", globTimeout, pattern, searchDir),
+				IsError: true,
+			}, nil
+		}
+		if errors.Is(err, context.Canceled) {
+			return &types.ToolResult{Content: "Error: Glob cancelled.", IsError: true}, nil
+		}
+		return &types.ToolResult{Content: "Error: " + err.Error(), IsError: true}, nil
+	}
+
+	sort.Strings(matches)
+
+	if len(matches) == 0 {
+		return &types.ToolResult{Content: "(no matches)"}, nil
+	}
+
+	out := strings.Join(matches, "\n")
+	if truncated {
+		out += fmt.Sprintf("\n(truncated at %d results; use a more specific path or pattern)", maxGlobMatches)
+	}
+	return &types.ToolResult{Content: out}, nil
+}
+
+// resolveSearchDir resolves the input "path" argument to an absolute directory
+// rooted under cwd. Returns an error if the path escapes cwd via "..".
+func resolveSearchDir(input map[string]any, cwd string) (string, error) {
 	searchDir := stringFromInput(input, "path", cwd)
 	if searchDir == "" {
 		searchDir = cwd
@@ -42,37 +124,142 @@ func executeGlob(_ context.Context, input map[string]any, cwd string) (*types.To
 	if !filepath.IsAbs(searchDir) {
 		searchDir = filepath.Join(cwd, searchDir)
 	}
+	searchDir = filepath.Clean(searchDir)
+	// Reject paths that escape cwd. cwd may itself be a non-canonical absolute
+	// path; canonicalize before comparing.
+	cwdClean := filepath.Clean(cwd)
+	if cwdClean != "" && cwdClean != "." {
+		rel, relErr := filepath.Rel(cwdClean, searchDir)
+		if relErr == nil && strings.HasPrefix(rel, "..") {
+			return "", fmt.Errorf("path %q escapes cwd %q", searchDir, cwdClean)
+		}
+	}
+	return searchDir, nil
+}
 
-	// Combine search dir with pattern for doublestar.
-	fullPattern := filepath.Join(searchDir, pattern)
+// extractGlobBase splits an absolute pattern into the longest static prefix
+// (used as the walk root) and the remaining pattern. Mirrors Claude Code's
+// utility of the same intent.
+func extractGlobBase(pattern string) (baseDir, relPattern string) {
+	idx := strings.IndexAny(pattern, "*?[{")
+	if idx < 0 {
+		return filepath.Dir(pattern), filepath.Base(pattern)
+	}
+	staticPrefix := pattern[:idx]
+	lastSep := strings.LastIndex(staticPrefix, string(filepath.Separator))
+	if lastSep < 0 {
+		return "", pattern
+	}
+	baseDir = staticPrefix[:lastSep]
+	if baseDir == "" {
+		baseDir = string(filepath.Separator)
+	}
+	relPattern = pattern[lastSep+1:]
+	return baseDir, relPattern
+}
 
-	fsys := os.DirFS("/")
-	// doublestar.Glob needs a relative pattern against the fsys root.
-	// Since fsys is rooted at "/", strip the leading slash.
-	relPattern := strings.TrimPrefix(fullPattern, "/")
+var errRipgrepUnavailable = errors.New("ripgrep not available")
 
-	matches, err := doublestar.Glob(fsys, relPattern)
+// globWithRipgrep runs `rg --files --glob <pattern>` rooted at searchDir.
+// Streams stdout, kills the subprocess at maxGlobMatches. Honors ctx.
+func globWithRipgrep(ctx context.Context, searchDir, pattern string) ([]string, bool, error) {
+	rgPath, err := exec.LookPath("rg")
 	if err != nil {
-		return &types.ToolResult{Content: "Error: " + err.Error(), IsError: true}, nil
+		return nil, false, errRipgrepUnavailable
 	}
 
-	// Filter out node_modules and .git, add leading slash back, cap at 500.
-	filtered := make([]string, 0, len(matches))
-	for _, m := range matches {
-		if strings.Contains(m, "/node_modules/") || strings.Contains(m, "/.git/") {
+	args := []string{
+		"--files",
+		"--glob", pattern,
+		"--hidden",      // include dotfiles
+		"--color=never", // never emit ANSI codes
+		// .gitignore/.ignore honored by default. node_modules and other
+		// vendor dirs are typically gitignored, so this is the natural way
+		// to prune them.
+	}
+
+	cmd := exec.CommandContext(ctx, rgPath, args...)
+	cmd.Dir = searchDir
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, false, fmt.Errorf("ripgrep stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, false, fmt.Errorf("ripgrep start: %w", err)
+	}
+
+	matches := make([]string, 0, 128)
+	truncated := false
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
 			continue
 		}
-		filtered = append(filtered, "/"+m)
+		// ripgrep returns paths relative to searchDir; promote to absolute so
+		// downstream consumers (LLM / desktop) see canonical paths.
+		matches = append(matches, filepath.Join(searchDir, line))
+		if len(matches) >= maxGlobMatches {
+			truncated = true
+			// Kill the subprocess promptly to avoid wasting work.
+			_ = cmd.Process.Kill()
+			break
+		}
 	}
+	// Drain any remaining output to allow the subprocess to exit cleanly.
+	_ = scanner.Err()
+	waitErr := cmd.Wait()
 
-	sort.Strings(filtered)
-	if len(filtered) > 500 {
-		filtered = filtered[:500]
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return matches, truncated, ctxErr
 	}
-
-	if len(filtered) == 0 {
-		return &types.ToolResult{Content: "(no matches)"}, nil
+	if waitErr != nil && !truncated {
+		// Exit code 1 from ripgrep with --files just means no files; treat as
+		// empty rather than error.
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) && exitErr.ExitCode() == 1 {
+			return matches, truncated, nil
+		}
+		// If we killed the process for truncation, ignore the resulting error.
+		if !truncated {
+			return matches, truncated, fmt.Errorf("ripgrep: %w", waitErr)
+		}
 	}
-
-	return &types.ToolResult{Content: strings.Join(filtered, "\n")}, nil
+	return matches, truncated, nil
 }
+
+// globWithDoublestar is the fallback walker for systems without ripgrep. It
+// honors ctx by checking ctx.Err() on every directory entry.
+func globWithDoublestar(ctx context.Context, searchDir, pattern string) ([]string, bool, error) {
+	matches := make([]string, 0, 128)
+	truncated := false
+	fsys := os.DirFS(searchDir)
+	walkErr := doublestar.GlobWalk(fsys, pattern, func(path string, d fs.DirEntry) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Skip the noisiest dirs explicitly since fallback can't read .gitignore.
+		if strings.Contains(path, "/node_modules/") || strings.Contains(path, "/.git/") || strings.HasPrefix(path, "node_modules/") || strings.HasPrefix(path, ".git/") {
+			return nil
+		}
+		matches = append(matches, filepath.Join(searchDir, path))
+		if len(matches) >= maxGlobMatches {
+			truncated = true
+			return errStopWalk
+		}
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, errStopWalk) {
+		if errors.Is(walkErr, context.Canceled) || errors.Is(walkErr, context.DeadlineExceeded) {
+			return matches, truncated, walkErr
+		}
+		return nil, false, walkErr
+	}
+	return matches, truncated, nil
+}
+
+// errStopWalk is a sentinel returned from the GlobWalk callback to stop the
+// walk early once we hit the result cap.
+var errStopWalk = errors.New("stop walk")

--- a/engine/internal/tools/grep.go
+++ b/engine/internal/tools/grep.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -29,7 +30,7 @@ func GrepTool() *types.ToolDef {
 	}
 }
 
-func executeGrep(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeGrep(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	pattern, _ := input["pattern"].(string)
 	if pattern == "" {
 		return &types.ToolResult{Content: "Error: pattern is required", IsError: true}, nil
@@ -39,15 +40,20 @@ func executeGrep(_ context.Context, input map[string]any, cwd string) (*types.To
 	glob := stringFromInput(input, "glob", "")
 	outputMode := stringFromInput(input, "output_mode", "content")
 
+	// Bound the search by wall clock so a pathological pattern can't wedge.
+	// The user-cancel context still cancels before the deadline.
+	cmdCtx, cancel := context.WithTimeout(ctx, globTimeout)
+	defer cancel()
+
 	// Try ripgrep first, fall back to grep.
 	rgPath, rgErr := exec.LookPath("rg")
 	if rgErr == nil {
-		return execRipgrep(rgPath, pattern, searchPath, glob, outputMode, cwd)
+		return execRipgrep(cmdCtx, rgPath, pattern, searchPath, glob, outputMode, cwd)
 	}
-	return execGrepFallback(pattern, searchPath, glob, outputMode, cwd)
+	return execGrepFallback(cmdCtx, pattern, searchPath, glob, outputMode, cwd)
 }
 
-func execRipgrep(rgPath, pattern, searchPath, glob, outputMode, cwd string) (*types.ToolResult, error) {
+func execRipgrep(ctx context.Context, rgPath, pattern, searchPath, glob, outputMode, cwd string) (*types.ToolResult, error) {
 	args := []string{"--no-heading"}
 
 	switch outputMode {
@@ -68,11 +74,17 @@ func execRipgrep(rgPath, pattern, searchPath, glob, outputMode, cwd string) (*ty
 		args = append(args, searchPath)
 	}
 
-	cmd := exec.Command(rgPath, args...)
+	cmd := exec.CommandContext(ctx, rgPath, args...)
 	cmd.Dir = cwd
 
 	out, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				return &types.ToolResult{Content: fmt.Sprintf("Error: Grep exceeded %s deadline.", globTimeout), IsError: true}, nil
+			}
+			return &types.ToolResult{Content: "Error: Grep cancelled.", IsError: true}, nil
+		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			// rg returns exit code 1 for "no matches"
 			if exitErr.ExitCode() == 1 {
@@ -89,7 +101,7 @@ func execRipgrep(rgPath, pattern, searchPath, glob, outputMode, cwd string) (*ty
 	return &types.ToolResult{Content: result}, nil
 }
 
-func execGrepFallback(pattern, searchPath, glob, outputMode, cwd string) (*types.ToolResult, error) {
+func execGrepFallback(ctx context.Context, pattern, searchPath, glob, outputMode, cwd string) (*types.ToolResult, error) {
 	// -E enables extended regex so patterns like foo[0-9]+bar work the same
 	// way they do under ripgrep.
 	args := []string{"-rEn"}
@@ -112,11 +124,17 @@ func execGrepFallback(pattern, searchPath, glob, outputMode, cwd string) (*types
 		args = append(args, ".")
 	}
 
-	cmd := exec.Command("grep", args...)
+	cmd := exec.CommandContext(ctx, "grep", args...)
 	cmd.Dir = cwd
 
 	out, err := cmd.Output()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			if errors.Is(ctxErr, context.DeadlineExceeded) {
+				return &types.ToolResult{Content: fmt.Sprintf("Error: Grep exceeded %s deadline.", globTimeout), IsError: true}, nil
+			}
+			return &types.ToolResult{Content: "Error: Grep cancelled.", IsError: true}, nil
+		}
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return &types.ToolResult{Content: "(no matches)"}, nil
 		}

--- a/engine/internal/tools/lsp.go
+++ b/engine/internal/tools/lsp.go
@@ -83,12 +83,16 @@ func LspTool() *types.ToolDef {
 	}
 }
 
-func executeLsp(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeLsp(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	if lspManager == nil {
 		return &types.ToolResult{
 			Content: "LSP not configured. Harness must call SetLspManager() to enable LSP features.",
 			IsError: true,
 		}, nil
+	}
+
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: LSP cancelled.", IsError: true}, nil
 	}
 
 	operation, _ := input["operation"].(string)

--- a/engine/internal/tools/mcp_resources.go
+++ b/engine/internal/tools/mcp_resources.go
@@ -51,10 +51,13 @@ func ReadMcpResourceTool() *types.ToolDef {
 	}
 }
 
-func executeListMcpResources(_ context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+func executeListMcpResources(ctx context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
 	server, _ := input["server"].(string)
 	if server == "" {
 		return &types.ToolResult{Content: "Error: server is required", IsError: true}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: ListMcpResources cancelled.", IsError: true}, nil
 	}
 
 	resources, err := mcp.ListMcpResources(server)
@@ -77,7 +80,7 @@ func executeListMcpResources(_ context.Context, input map[string]any, _ string) 
 	return &types.ToolResult{Content: strings.Join(lines, "\n")}, nil
 }
 
-func executeReadMcpResource(_ context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+func executeReadMcpResource(ctx context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
 	server, _ := input["server"].(string)
 	if server == "" {
 		return &types.ToolResult{Content: "Error: server is required", IsError: true}, nil
@@ -85,6 +88,9 @@ func executeReadMcpResource(_ context.Context, input map[string]any, _ string) (
 	uri, _ := input["uri"].(string)
 	if uri == "" {
 		return &types.ToolResult{Content: "Error: uri is required", IsError: true}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: ReadMcpResource cancelled.", IsError: true}, nil
 	}
 
 	content, err := mcp.ReadMcpResource(server, uri)

--- a/engine/internal/tools/notebook.go
+++ b/engine/internal/tools/notebook.go
@@ -126,7 +126,7 @@ func NotebookTool() *types.ToolDef {
 	}
 }
 
-func executeNotebook(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeNotebook(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	action, _ := input["action"].(string)
 	path, _ := input["path"].(string)
 	if action == "" || path == "" {
@@ -134,6 +134,9 @@ func executeNotebook(_ context.Context, input map[string]any, cwd string) (*type
 	}
 
 	filePath := resolvePath(cwd, path)
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: Notebook cancelled.", IsError: true}, nil
+	}
 
 	switch action {
 	case "read":

--- a/engine/internal/tools/read.go
+++ b/engine/internal/tools/read.go
@@ -30,13 +30,17 @@ func ReadTool() *types.ToolDef {
 	}
 }
 
-func executeRead(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeRead(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	filePath, _ := input["file_path"].(string)
 	if filePath == "" {
 		return &types.ToolResult{Content: "Error: file_path is required", IsError: true}, nil
 	}
 
 	filePath = resolvePath(cwd, filePath)
+
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: Read cancelled.", IsError: true}, nil
+	}
 
 	info, err := os.Stat(filePath)
 	if err != nil {
@@ -51,6 +55,9 @@ func executeRead(_ context.Context, input map[string]any, cwd string) (*types.To
 		return readPdf(filePath, input, info)
 	}
 
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: Read cancelled.", IsError: true}, nil
+	}
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return &types.ToolResult{Content: fmt.Sprintf("Error reading file: %s", err), IsError: true}, nil

--- a/engine/internal/tools/skill.go
+++ b/engine/internal/tools/skill.go
@@ -32,7 +32,10 @@ func SkillTool() *types.ToolDef {
 	}
 }
 
-func executeSkill(_ context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+func executeSkill(ctx context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: Skill cancelled.", IsError: true}, nil
+	}
 	name, _ := input["skill"].(string)
 	if name == "" {
 		return &types.ToolResult{Content: "Missing required parameter: skill", IsError: true}, nil

--- a/engine/internal/tools/tasks.go
+++ b/engine/internal/tools/tasks.go
@@ -55,7 +55,10 @@ func TaskCreateTool() *types.ToolDef {
 	}
 }
 
-func executeTaskCreate(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeTaskCreate(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: TaskCreate cancelled.", IsError: true}, nil
+	}
 	prompt, _ := input["prompt"].(string)
 	if prompt == "" {
 		return &types.ToolResult{Content: "Error: prompt is required", IsError: true}, nil
@@ -132,7 +135,10 @@ func TaskListTool() *types.ToolDef {
 	}
 }
 
-func executeTaskList(_ context.Context, _ map[string]any, _ string) (*types.ToolResult, error) {
+func executeTaskList(ctx context.Context, _ map[string]any, _ string) (*types.ToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: TaskList cancelled.", IsError: true}, nil
+	}
 	tasksMu.RLock()
 	defer tasksMu.RUnlock()
 
@@ -176,7 +182,10 @@ func TaskGetTool() *types.ToolDef {
 	}
 }
 
-func executeTaskGet(_ context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+func executeTaskGet(ctx context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: TaskGet cancelled.", IsError: true}, nil
+	}
 	taskID, _ := input["taskId"].(string)
 	if taskID == "" {
 		return &types.ToolResult{Content: "Error: taskId is required", IsError: true}, nil
@@ -235,7 +244,10 @@ func TaskStopTool() *types.ToolDef {
 	}
 }
 
-func executeTaskStop(_ context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+func executeTaskStop(ctx context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: TaskStop cancelled.", IsError: true}, nil
+	}
 	taskID, _ := input["taskId"].(string)
 	if taskID == "" {
 		return &types.ToolResult{Content: "Error: taskId is required", IsError: true}, nil

--- a/engine/internal/tools/tools_test.go
+++ b/engine/internal/tools/tools_test.go
@@ -1155,6 +1155,84 @@ func TestGlobToolMultipleExtensions(t *testing.T) {
 	}
 }
 
+// TestGlobToolHonorsCtxCancel verifies that executeGlob returns promptly when
+// the caller's context is cancelled before the call. This proves the ctx
+// propagation path that prevents the stuck-tab class of bug: a long-running
+// glob (e.g. a wide pattern over a huge subtree) must abort on cancel rather
+// than wedging the goroutine.
+func TestGlobToolHonorsCtxCancel(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.go"), []byte("x"), 0o644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	start := time.Now()
+	result, err := ExecuteTool(ctx, "Glob", map[string]any{
+		"pattern": "**/*",
+		"path":    dir,
+	}, dir)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Errorf("expected IsError=true on cancelled ctx, got %q", result.Content)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected fast return on cancelled ctx, took %s", elapsed)
+	}
+}
+
+// TestGlobToolHonorsCtxDeadline verifies the wall-clock deadline path. With
+// a 1ms deadline, even a successful walk should be cut off and surface the
+// deadline as a tool-result error rather than running to completion.
+func TestGlobToolHonorsCtxDeadline(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 10; i++ {
+		os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%d.txt", i)), []byte("x"), 0o644)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	// Sleep past the deadline to guarantee it has fired before the call.
+	time.Sleep(5 * time.Millisecond)
+
+	start := time.Now()
+	result, _ := ExecuteTool(ctx, "Glob", map[string]any{
+		"pattern": "**/*",
+		"path":    dir,
+	}, dir)
+	elapsed := time.Since(start)
+
+	if !result.IsError {
+		t.Errorf("expected IsError=true after deadline, got %q", result.Content)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected fast return after deadline, took %s", elapsed)
+	}
+}
+
+// TestGlobToolRejectsPathEscapingCwd verifies the safety gate that prevents
+// a search-dir argument from walking outside the working directory.
+func TestGlobToolRejectsPathEscapingCwd(t *testing.T) {
+	cwd := t.TempDir()
+	parent := filepath.Dir(cwd)
+
+	result, _ := ExecuteTool(context.Background(), "Glob", map[string]any{
+		"pattern": "*",
+		"path":    parent,
+	}, cwd)
+
+	if !result.IsError {
+		t.Errorf("expected IsError=true when path escapes cwd, got %q", result.Content)
+	}
+	if !strings.Contains(result.Content, "escape") {
+		t.Errorf("expected error message to mention escape, got %q", result.Content)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Grep Tool Tests
 // ---------------------------------------------------------------------------

--- a/engine/internal/tools/web_search.go
+++ b/engine/internal/tools/web_search.go
@@ -22,7 +22,7 @@ type SearchResult struct {
 
 // SearchBackend is a pluggable web search provider.
 type SearchBackend interface {
-	Search(query string, maxResults int) ([]SearchResult, error)
+	Search(ctx context.Context, query string, maxResults int) ([]SearchResult, error)
 }
 
 // BraveSearchBackend uses the Brave Search API.
@@ -30,11 +30,11 @@ type BraveSearchBackend struct {
 	APIKey string
 }
 
-func (b *BraveSearchBackend) Search(query string, maxResults int) ([]SearchResult, error) {
+func (b *BraveSearchBackend) Search(ctx context.Context, query string, maxResults int) ([]SearchResult, error) {
 	u := fmt.Sprintf("https://api.search.brave.com/res/v1/web/search?q=%s&count=%d",
 		url.QueryEscape(query), maxResults)
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -85,14 +85,19 @@ type TavilyBackend struct {
 	APIKey string
 }
 
-func (t *TavilyBackend) Search(query string, maxResults int) ([]SearchResult, error) {
+func (t *TavilyBackend) Search(ctx context.Context, query string, maxResults int) ([]SearchResult, error) {
 	payload, _ := json.Marshal(map[string]any{
 		"api_key":     t.APIKey,
 		"query":       query,
 		"max_results": maxResults,
 	})
 
-	resp, err := http.Post("https://api.tavily.com/search", "application/json", strings.NewReader(string(payload)))
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.tavily.com/search", strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,11 +139,15 @@ type SearXNGBackend struct {
 	BaseURL string
 }
 
-func (s *SearXNGBackend) Search(query string, maxResults int) ([]SearchResult, error) {
+func (s *SearXNGBackend) Search(ctx context.Context, query string, maxResults int) ([]SearchResult, error) {
 	u := fmt.Sprintf("%s/search?q=%s&format=json&pageno=1",
 		s.BaseURL, url.QueryEscape(query))
 
-	resp, err := http.Get(u)
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +220,7 @@ func WebSearchTool() *types.ToolDef {
 	}
 }
 
-func executeWebSearch(_ context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
+func executeWebSearch(ctx context.Context, input map[string]any, _ string) (*types.ToolResult, error) {
 	query, _ := input["query"].(string)
 	if query == "" {
 		return &types.ToolResult{Content: "Error: query is required", IsError: true}, nil
@@ -227,7 +236,7 @@ func executeWebSearch(_ context.Context, input map[string]any, _ string) (*types
 		}, nil
 	}
 
-	results, err := backend.Search(query, maxResults)
+	results, err := backend.Search(ctx, query, maxResults)
 	if err != nil {
 		return &types.ToolResult{Content: fmt.Sprintf("Search error: %s", err), IsError: true}, nil
 	}

--- a/engine/internal/tools/write.go
+++ b/engine/internal/tools/write.go
@@ -26,7 +26,7 @@ func WriteTool() *types.ToolDef {
 	}
 }
 
-func executeWrite(_ context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
+func executeWrite(ctx context.Context, input map[string]any, cwd string) (*types.ToolResult, error) {
 	filePath, _ := input["file_path"].(string)
 	if filePath == "" {
 		return &types.ToolResult{Content: "Error: file_path is required", IsError: true}, nil
@@ -35,6 +35,9 @@ func executeWrite(_ context.Context, input map[string]any, cwd string) (*types.T
 
 	filePath = resolvePath(cwd, filePath)
 
+	if err := ctx.Err(); err != nil {
+		return &types.ToolResult{Content: "Error: Write cancelled.", IsError: true}, nil
+	}
 	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 		return &types.ToolResult{Content: fmt.Sprintf("Error writing file: %s", err), IsError: true}, nil
 	}

--- a/relay/go.mod
+++ b/relay/go.mod
@@ -2,6 +2,8 @@ module github.com/dsswift/ion/relay
 
 go 1.22
 
+toolchain go1.26.2
+
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
- **feat(desktop): add auth backoff for lan server clients**
- **fix(engine): prevent stuck runs from wedged tools**
- **feat(engine): add health command + bump go to 1.25**
- **feat(engine): add broadcast queuing with backpressure**
- **feat(desktop): add atomic writes and secret encryption**
- **chore(desktop): add typecheck script to package.json**
- **chore(repo): add dependabot and quality ci workflows**
- **chore(desktop): fix tsc errors across renderer and main**
- **chore(engine): bump dockerfile to golang 1.26-alpine**
- **chore(relay): add toolchain go1.26.2 directive**
- **chore(repo): add typecheck step to quality workflow**
- **chore(desktop): fix types and add afterPack codesign hook**
