### PR TITLE
Use parent backend type for child agent dispatch #37

### DIFF
--- a/engine/internal/session/backend_helpers.go
+++ b/engine/internal/session/backend_helpers.go
@@ -1,0 +1,16 @@
+package session
+
+import (
+	"github.com/dsswift/ion/engine/internal/backend"
+)
+
+// newChildBackend returns a fresh RunBackend of the same kind as the
+// Manager's parent backend. All child-agent dispatch paths must use this
+// instead of calling NewApiBackend()/NewCliBackend() directly, so that
+// backend: "cli" sessions produce CLI children.
+func (m *Manager) newChildBackend() backend.RunBackend {
+	if _, ok := m.backend.(*backend.CliBackend); ok {
+		return backend.NewCliBackend()
+	}
+	return backend.NewApiBackend()
+}

--- a/engine/internal/session/backend_helpers_test.go
+++ b/engine/internal/session/backend_helpers_test.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/backend"
+)
+
+func TestNewChildBackend_ApiParent(t *testing.T) {
+	mgr := NewManager(backend.NewApiBackend())
+	child := mgr.newChildBackend()
+	if _, ok := child.(*backend.ApiBackend); !ok {
+		t.Errorf("expected *ApiBackend child, got %T", child)
+	}
+}
+
+func TestNewChildBackend_CliParent(t *testing.T) {
+	mgr := NewManager(backend.NewCliBackend())
+	child := mgr.newChildBackend()
+	if _, ok := child.(*backend.CliBackend); !ok {
+		t.Errorf("expected *CliBackend child, got %T", child)
+	}
+}
+
+func TestNewChildBackend_MockParent(t *testing.T) {
+	mgr := NewManager(newMockBackend())
+	child := mgr.newChildBackend()
+	// Mock is neither CliBackend nor ApiBackend; should default to ApiBackend
+	if _, ok := child.(*backend.ApiBackend); !ok {
+		t.Errorf("expected *ApiBackend child for unknown parent, got %T", child)
+	}
+}

--- a/engine/internal/session/manager_cli_hooks_test.go
+++ b/engine/internal/session/manager_cli_hooks_test.go
@@ -522,3 +522,140 @@ func TestHandleNormalizedEvent_TaskUpdateFiresTurnEnd(t *testing.T) {
 		t.Errorf("expected turn_end(1) via handleNormalizedEvent, got %v", ends)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// wireAgentToolServer tests
+// ---------------------------------------------------------------------------
+
+func TestWireAgentToolServer_RegistersToolForCliBackend(t *testing.T) {
+	cb := backend.NewCliBackend()
+	mgr := NewManager(cb)
+	s := newCliSession("agent-ts1")
+
+	mgr.mu.Lock()
+	mgr.sessions["agent-ts1"] = s
+	mgr.mu.Unlock()
+
+	opts := types.RunOptions{}
+	mgr.wireAgentToolServer(s, "agent-ts1", &opts)
+
+	mgr.mu.Lock()
+	ts := s.toolServer
+	mgr.mu.Unlock()
+
+	if ts == nil {
+		t.Fatal("expected ToolServer to be created")
+	}
+	if opts.McpConfig == "" {
+		t.Error("expected McpConfig to be set")
+	}
+
+	// Cleanup
+	ts.Stop()
+}
+
+func TestWireAgentToolServer_NoopForNonCliBackend(t *testing.T) {
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	s := newCliSession("agent-ts2")
+
+	opts := types.RunOptions{}
+	mgr.wireAgentToolServer(s, "agent-ts2", &opts)
+
+	mgr.mu.Lock()
+	ts := s.toolServer
+	mgr.mu.Unlock()
+
+	if ts != nil {
+		t.Error("expected no ToolServer for non-CLI backend")
+	}
+	if opts.McpConfig != "" {
+		t.Error("expected no McpConfig for non-CLI backend")
+	}
+}
+
+func TestWireAgentToolServer_ReusesExistingToolServer(t *testing.T) {
+	cb := backend.NewCliBackend()
+	mgr := NewManager(cb)
+	s := newCliSession("agent-ts3")
+
+	// Pre-create a ToolServer (as wireToolServer would)
+	existingTS := backend.NewToolServer("agent-ts3")
+	if err := existingTS.Start(); err != nil {
+		t.Fatalf("failed to start existing ToolServer: %v", err)
+	}
+	mgr.mu.Lock()
+	s.toolServer = existingTS
+	mgr.sessions["agent-ts3"] = s
+	mgr.mu.Unlock()
+
+	opts := types.RunOptions{}
+	mgr.wireAgentToolServer(s, "agent-ts3", &opts)
+
+	mgr.mu.Lock()
+	ts := s.toolServer
+	mgr.mu.Unlock()
+
+	// Should be the same ToolServer instance
+	if ts != existingTS {
+		t.Error("expected wireAgentToolServer to reuse existing ToolServer")
+	}
+
+	// McpConfig should NOT be set again (it was already set by wireToolServer)
+	if opts.McpConfig != "" {
+		t.Error("expected McpConfig not to be overwritten when ToolServer already exists")
+	}
+
+	// Cleanup
+	existingTS.Stop()
+}
+
+func TestWireAgentToolServer_SpecResolution(t *testing.T) {
+	cb := backend.NewCliBackend()
+	mgr := NewManager(cb)
+	s := newCliSession("agent-ts4")
+
+	// Register an agent spec
+	s.agentSpecs["researcher"] = types.AgentSpec{
+		Name:         "researcher",
+		Model:        "test-model",
+		SystemPrompt: "You are a researcher.",
+		Tools:        []string{"Read", "Grep"},
+	}
+
+	mgr.mu.Lock()
+	mgr.sessions["agent-ts4"] = s
+	mgr.mu.Unlock()
+
+	// Build the handler directly and test spec resolution
+	handler := mgr.buildAgentToolHandler(s, "agent-ts4")
+
+	// Test with unknown spec name
+	result, err := handler(map[string]interface{}{
+		"prompt": "test task",
+		"name":   "nonexistent",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for unregistered agent name")
+	}
+	if !strings.Contains(result.Content, "not registered") {
+		t.Errorf("expected 'not registered' error, got %q", result.Content)
+	}
+
+	// Test with missing prompt
+	result, err = handler(map[string]interface{}{
+		"name": "researcher",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for missing prompt")
+	}
+	if !strings.Contains(result.Content, "prompt is required") {
+		t.Errorf("expected 'prompt is required' error, got %q", result.Content)
+	}
+}

--- a/engine/internal/session/prompt_agent_spawner.go
+++ b/engine/internal/session/prompt_agent_spawner.go
@@ -74,7 +74,7 @@ func (m *Manager) wireAgentSpawner(s *engineSession, key string, parentModel str
 		m.emit(capturedKey, types.EngineEvent{Type: "engine_agent_state", Agents: snapshot})
 
 		start := time.Now()
-		child := backend.NewApiBackend()
+		child := m.newChildBackend()
 		var result string
 		var childErr error
 		var childDone sync.WaitGroup

--- a/engine/internal/session/prompt_cli_hooks.go
+++ b/engine/internal/session/prompt_cli_hooks.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/dsswift/ion/engine/internal/backend"
@@ -105,4 +107,144 @@ func (m *Manager) wireToolServer(s *engineSession, key string, opts *types.RunOp
 	s.toolServer = ts
 	m.mu.Unlock()
 	utils.Log("Session", fmt.Sprintf("ToolServer started for CLI backend (%d tools)", len(extTools)))
+}
+
+// wireAgentToolServer registers an ion_agent tool on the ToolServer for CLI
+// backend sessions. This exposes the engine's agent-spec system (spec
+// resolution from ~/.ion/agents/, capability_match hooks, model/system-prompt
+// overrides from spec frontmatter) to the CLI subprocess via MCP. The tool
+// appears as mcp__ion-extensions__ion_agent to the LLM.
+//
+// If wireToolServer already created a ToolServer (because extension tools
+// exist), the ion_agent tool is added to it. Otherwise a new ToolServer is
+// created and started.
+func (m *Manager) wireAgentToolServer(s *engineSession, key string, opts *types.RunOptions) {
+	if _, isCli := m.backend.(*backend.CliBackend); !isCli {
+		return
+	}
+
+	m.mu.Lock()
+	ts := s.toolServer
+	m.mu.Unlock()
+
+	needsStart := false
+	if ts == nil {
+		ts = backend.NewToolServer(key)
+		needsStart = true
+	}
+
+	ts.RegisterTool("ion_agent", m.buildAgentToolHandler(s, key))
+
+	if needsStart {
+		if err := ts.Start(); err != nil {
+			utils.Log("Session", "ToolServer start failed (agent tool): "+err.Error())
+			return
+		}
+		mcpPath, err := ts.McpConfigPath(key)
+		if err != nil {
+			utils.Log("Session", "ToolServer MCP config failed (agent tool): "+err.Error())
+			ts.Stop()
+			return
+		}
+		opts.McpConfig = mcpPath
+		m.mu.Lock()
+		s.toolServer = ts
+		m.mu.Unlock()
+	}
+
+	utils.Log("Session", "ion_agent tool registered on ToolServer for CLI backend")
+}
+
+// buildAgentToolHandler returns a ToolHandler closure that resolves ion agent
+// specs and runs child agents synchronously. It mirrors the spawner logic in
+// wireAgentSpawner but runs over MCP so the CLI subprocess can invoke it.
+func (m *Manager) buildAgentToolHandler(s *engineSession, key string) backend.ToolHandler {
+	return func(input map[string]interface{}) (*types.ToolResult, error) {
+		prompt, _ := input["prompt"].(string)
+		name, _ := input["name"].(string)
+		description, _ := input["description"].(string)
+		model, _ := input["model"].(string)
+
+		if prompt == "" {
+			return &types.ToolResult{Content: "error: prompt is required", IsError: true}, nil
+		}
+
+		// Resolve agent spec by name if provided.
+		var spec types.AgentSpec
+		var specMatched bool
+		if name != "" {
+			if matched, ok := m.resolveAgentSpec(s, key, name); ok {
+				spec = matched
+				specMatched = true
+			} else {
+				return &types.ToolResult{
+					Content: fmt.Sprintf("agent %q is not registered (capability_match returned no match)", name),
+					IsError: true,
+				}, nil
+			}
+		}
+
+		// Determine model: explicit > spec > parent config default.
+		childModel := model
+		if childModel == "" && specMatched {
+			childModel = spec.Model
+		}
+		if childModel == "" && m.config != nil {
+			childModel = m.config.DefaultModel
+		}
+
+		cwd := s.config.WorkingDirectory
+
+		runOpts := types.RunOptions{
+			Prompt:      prompt,
+			Model:       childModel,
+			ProjectPath: cwd,
+		}
+		if specMatched {
+			if spec.SystemPrompt != "" {
+				runOpts.AppendSystemPrompt = spec.SystemPrompt
+			}
+			if len(spec.Tools) > 0 {
+				runOpts.AllowedTools = spec.Tools
+			}
+		}
+		if description != "" && !specMatched {
+			runOpts.AppendSystemPrompt = description
+		}
+
+		child := m.newChildBackend()
+		var result string
+		var childErr error
+		var childDone sync.WaitGroup
+		childDone.Add(1)
+
+		child.OnNormalized(func(_ string, ev types.NormalizedEvent) {
+			if tc, ok := ev.Data.(*types.TaskCompleteEvent); ok {
+				result = tc.Result
+			}
+		})
+		child.OnExit(func(_ string, _ *int, _ *string, _ string) {
+			childDone.Done()
+		})
+		child.OnError(func(_ string, err error) {
+			childErr = err
+		})
+
+		childRequestID := fmt.Sprintf("%s-ion-agent-%s-%d", key, name, time.Now().UnixMilli())
+		child.StartRun(childRequestID, runOpts)
+		childDone.Wait()
+
+		if childErr != nil {
+			errParts := []string{"agent"}
+			if name != "" {
+				errParts = append(errParts, name)
+			}
+			return &types.ToolResult{
+				Content: fmt.Sprintf("%s failed: %s", strings.Join(errParts, " "), childErr.Error()),
+				IsError: true,
+			}, nil
+		}
+
+		return &types.ToolResult{Content: result, IsError: false}, nil
+	}
 }

--- a/engine/internal/session/prompt_dispatch.go
+++ b/engine/internal/session/prompt_dispatch.go
@@ -129,6 +129,7 @@ func (m *Manager) SendPrompt(key, text string, overrides *PromptOverrides) (retE
 
 	m.wirePermissionHookServer(s, key, &opts, permEng)
 	m.wireToolServer(s, key, &opts, extGroup)
+	m.wireAgentToolServer(s, key, &opts)
 
 	// Fire before_prompt for CliBackend (ApiBackend wires this inside buildRunConfig).
 	m.fireBeforePromptCli(s, key, extGroup, skipExtensions, &opts)

--- a/engine/internal/session/start_session.go
+++ b/engine/internal/session/start_session.go
@@ -131,8 +131,9 @@ func (m *Manager) newExtContext(s *engineSession, key string) *extension.Context
 			projectPath = s.config.WorkingDirectory
 		}
 
-		// Create child backend
-		child := backend.NewApiBackend()
+		// Create child backend matching the parent session's backend type.
+		// Uses the factory so CliBackend sessions spawn CLI children.
+		child := m.newChildBackend()
 		var childCfg *backend.RunConfig
 
 		// Load extension if specified
@@ -246,7 +247,12 @@ func (m *Manager) newExtContext(s *engineSession, key string) *extension.Context
 			runOpts.MaxTurns = opts.MaxTurns
 		}
 
-		child.StartRunWithConfig(fmt.Sprintf("%s-dispatch-%s", key, opts.Name), runOpts, childCfg)
+		childReqID := fmt.Sprintf("%s-dispatch-%s", key, opts.Name)
+		if apiChild, ok := child.(*backend.ApiBackend); ok && childCfg != nil {
+			apiChild.StartRunWithConfig(childReqID, runOpts, childCfg)
+		} else {
+			child.StartRun(childReqID, runOpts)
+		}
 		childDone.Wait()
 
 		elapsed := time.Since(start).Seconds()

--- a/engine/internal/session/testing_helpers.go
+++ b/engine/internal/session/testing_helpers.go
@@ -1,0 +1,80 @@
+package session
+
+import (
+	"github.com/dsswift/ion/engine/internal/backend"
+	"github.com/dsswift/ion/engine/internal/extension"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// TestNewExtContext builds a fully-populated extension Context for the given
+// session key. Exported for integration tests only.
+func (m *Manager) TestNewExtContext(key string) *extension.Context {
+	m.mu.RLock()
+	s, ok := m.sessions[key]
+	m.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return m.newExtContext(s, key)
+}
+
+// TestSetExtGroup wires an ExtensionGroup onto an existing session.
+// Exported for integration tests only.
+func (m *Manager) TestSetExtGroup(key string, group *extension.ExtensionGroup) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.sessions[key]; ok {
+		s.extGroup = group
+	}
+}
+
+// TestRegisterAgentSpec registers an agent spec on the session.
+// Exported for integration tests only.
+func (m *Manager) TestRegisterAgentSpec(key string, spec types.AgentSpec) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if s, ok := m.sessions[key]; ok {
+		s.agentSpecs[spec.Name] = spec
+	}
+}
+
+// TestWireAgentToolServer calls wireAgentToolServer for the given session.
+// Exported for integration tests only.
+func (m *Manager) TestWireAgentToolServer(key string, opts *types.RunOptions) {
+	m.mu.RLock()
+	s, ok := m.sessions[key]
+	m.mu.RUnlock()
+	if !ok {
+		return
+	}
+	m.wireAgentToolServer(s, key, opts)
+}
+
+// TestGetToolServerSocketPath returns the ToolServer's socket path for the session.
+// Exported for integration tests only.
+func (m *Manager) TestGetToolServerSocketPath(key string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	s, ok := m.sessions[key]
+	if !ok || s.toolServer == nil {
+		return ""
+	}
+	return s.toolServer.SocketPath()
+}
+
+// TestNewChildBackend exposes newChildBackend for integration tests.
+func (m *Manager) TestNewChildBackend() backend.RunBackend {
+	return m.newChildBackend()
+}
+
+// TestBuildAgentToolHandler exposes buildAgentToolHandler for e2e tests.
+// Returns the handler closure, or nil if the session does not exist.
+func (m *Manager) TestBuildAgentToolHandler(key string) backend.ToolHandler {
+	m.mu.RLock()
+	s, ok := m.sessions[key]
+	m.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return m.buildAgentToolHandler(s, key)
+}

--- a/engine/tests/e2e/live_cli_backend_test.go
+++ b/engine/tests/e2e/live_cli_backend_test.go
@@ -1,0 +1,461 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsswift/ion/engine/internal/backend"
+	"github.com/dsswift/ion/engine/internal/extension"
+	"github.com/dsswift/ion/engine/internal/session"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// cliEventCollector collects normalized events from a CliBackend run.
+type cliEventCollector struct {
+	mu         sync.Mutex
+	normalized []types.NormalizedEvent
+	exits      []cliExitInfo
+	errors     []error
+}
+
+type cliExitInfo struct {
+	code      *int
+	signal    *string
+	sessionID string
+}
+
+func newCliEventCollector(b *backend.CliBackend) *cliEventCollector {
+	ec := &cliEventCollector{}
+	b.OnNormalized(func(runID string, event types.NormalizedEvent) {
+		ec.mu.Lock()
+		ec.normalized = append(ec.normalized, event)
+		ec.mu.Unlock()
+	})
+	b.OnExit(func(runID string, code *int, signal *string, sessionID string) {
+		ec.mu.Lock()
+		ec.exits = append(ec.exits, cliExitInfo{code, signal, sessionID})
+		ec.mu.Unlock()
+	})
+	b.OnError(func(runID string, err error) {
+		ec.mu.Lock()
+		ec.errors = append(ec.errors, err)
+		ec.mu.Unlock()
+	})
+	return ec
+}
+
+func (ec *cliEventCollector) waitForExit(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ec.mu.Lock()
+		n := len(ec.exits)
+		ec.mu.Unlock()
+		if n > 0 {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for CLI exit event")
+}
+
+func (ec *cliEventCollector) getNormalized() []types.NormalizedEvent {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	out := make([]types.NormalizedEvent, len(ec.normalized))
+	copy(out, ec.normalized)
+	return out
+}
+
+func (ec *cliEventCollector) getErrors() []error {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	out := make([]error, len(ec.errors))
+	copy(out, ec.errors)
+	return out
+}
+
+func (ec *cliEventCollector) getExits() []cliExitInfo {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	out := make([]cliExitInfo, len(ec.exits))
+	copy(out, ec.exits)
+	return out
+}
+
+// ─── Test 1: CliBackend simple prompt ───────────────────────────────────────
+//
+// Sanity baseline: a bare CliBackend runs a simple prompt via the Claude CLI
+// using OAuth (no API key), receives text events, and exits with code 0.
+// This confirms the Claude CLI is available and authenticated.
+func TestLiveCliBackendSimplePrompt(t *testing.T) {
+	b := backend.NewCliBackend()
+	ec := newCliEventCollector(b)
+
+	b.StartRun("cli-simple", types.RunOptions{
+		Prompt:      "What is 2+2? Reply with just the number, nothing else.",
+		MaxTurns:    1,
+		ProjectPath: t.TempDir(),
+	})
+
+	ec.waitForExit(t, 60*time.Second)
+
+	// No errors
+	errs := ec.getErrors()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+
+	// Exit code 0
+	exits := ec.getExits()
+	if len(exits) == 0 {
+		t.Fatal("no exit event received")
+	}
+	if exits[0].code == nil || *exits[0].code != 0 {
+		codeStr := "nil"
+		if exits[0].code != nil {
+			codeStr = string(rune(*exits[0].code + '0'))
+		}
+		t.Fatalf("expected exit code 0, got %s", codeStr)
+	}
+
+	// Received text events with response containing "4"
+	events := ec.getNormalized()
+	var fullText strings.Builder
+	for _, ev := range events {
+		if tc, ok := ev.Data.(*types.TextChunkEvent); ok {
+			fullText.WriteString(tc.Text)
+		}
+	}
+	if !strings.Contains(fullText.String(), "4") {
+		t.Errorf("expected response to contain '4', got: %q", fullText.String())
+	}
+
+	// Got a TaskCompleteEvent
+	foundComplete := false
+	for _, ev := range events {
+		if _, ok := ev.Data.(*types.TaskCompleteEvent); ok {
+			foundComplete = true
+		}
+	}
+	if !foundComplete {
+		t.Error("did not receive task_complete event")
+	}
+
+	t.Logf("CLI simple prompt OK: response=%q", strings.TrimSpace(fullText.String()))
+}
+
+// ─── Test 2: CliBackend child via newChildBackend factory ───────────────────
+//
+// Verifies that a Manager with CliBackend parent creates a CliBackend child
+// via newChildBackend(), and the child actually runs a real prompt via the
+// Claude CLI, produces text output, and exits cleanly.
+func TestLiveCliBackendChildFactory(t *testing.T) {
+	parentBackend := backend.NewCliBackend()
+	mgr := session.NewManager(parentBackend)
+
+	// The factory should return a CliBackend
+	child := mgr.TestNewChildBackend()
+	cliChild, ok := child.(*backend.CliBackend)
+	if !ok {
+		t.Fatalf("expected *CliBackend child, got %T", child)
+	}
+
+	// Run a real prompt on the child
+	ec := newCliEventCollector(cliChild)
+
+	cliChild.StartRun("child-factory", types.RunOptions{
+		Prompt:      "What is 3+5? Reply with just the number.",
+		MaxTurns:    1,
+		ProjectPath: t.TempDir(),
+	})
+
+	ec.waitForExit(t, 60*time.Second)
+
+	errs := ec.getErrors()
+	if len(errs) > 0 {
+		t.Fatalf("child errors: %v", errs)
+	}
+
+	exits := ec.getExits()
+	if len(exits) == 0 || exits[0].code == nil || *exits[0].code != 0 {
+		t.Fatal("child did not exit cleanly")
+	}
+
+	events := ec.getNormalized()
+	var fullText strings.Builder
+	for _, ev := range events {
+		if tc, ok := ev.Data.(*types.TextChunkEvent); ok {
+			fullText.WriteString(tc.Text)
+		}
+	}
+	if !strings.Contains(fullText.String(), "8") {
+		t.Errorf("expected child response to contain '8', got: %q", fullText.String())
+	}
+
+	t.Logf("CLI child factory OK: response=%q", strings.TrimSpace(fullText.String()))
+}
+
+// ─── Test 3: DispatchAgent via extension context (the #37 fix) ──────────────
+//
+// This is the core issue #37 reproduction. Creates a Manager with CliBackend,
+// starts a session, wires an extension that calls ctx.DispatchAgent, and
+// verifies the child agent runs to completion via the CLI subprocess (not API).
+//
+// Before the fix, this would fail with "no API key found for provider
+// anthropic" because DispatchAgent hardcoded NewApiBackend().
+func TestLiveCliBackendDispatchAgent(t *testing.T) {
+	parentBackend := backend.NewCliBackend()
+	mgr := session.NewManager(parentBackend)
+
+	cfg := types.EngineConfig{
+		ProfileID:        "e2e-dispatch",
+		WorkingDirectory: t.TempDir(),
+	}
+
+	if _, err := mgr.StartSession("e2e-da", cfg); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { mgr.StopSession("e2e-da") })
+
+	// Collect events emitted by the manager
+	var mu sync.Mutex
+	var managerEvents []types.EngineEvent
+	mgr.OnEvent(func(key string, ev types.EngineEvent) {
+		mu.Lock()
+		managerEvents = append(managerEvents, ev)
+		mu.Unlock()
+	})
+
+	// Create an extension tool that calls ctx.DispatchAgent
+	host := extension.NewHost()
+	sdk := host.SDK()
+
+	var dispatchResult *extension.DispatchAgentResult
+	var dispatchErr error
+	dispatchDone := make(chan struct{})
+
+	sdk.RegisterTool(extension.ToolDefinition{
+		Name:        "trigger_dispatch",
+		Description: "calls DispatchAgent to spawn a CLI child",
+		Parameters:  map[string]interface{}{"type": "object"},
+		Execute: func(params interface{}, ctx *extension.Context) (*types.ToolResult, error) {
+			defer close(dispatchDone)
+			if ctx.DispatchAgent == nil {
+				return &types.ToolResult{Content: "DispatchAgent not wired", IsError: true}, nil
+			}
+			dispatchResult, dispatchErr = ctx.DispatchAgent(extension.DispatchAgentOpts{
+				Name: "e2e-child",
+				Task: "What is 7*6? Reply with just the number, nothing else.",
+			})
+			return &types.ToolResult{Content: "dispatched"}, nil
+		},
+	})
+
+	group := extension.NewExtensionGroup()
+	group.Add(host)
+	mgr.TestSetExtGroup("e2e-da", group)
+
+	// Get the wired context and invoke the tool
+	ctx := mgr.TestNewExtContext("e2e-da")
+	if ctx == nil {
+		t.Fatal("TestNewExtContext returned nil")
+	}
+
+	tools := host.Tools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	// Execute the tool — this calls DispatchAgent which spawns a CliBackend child
+	_, err := tools[0].Execute(map[string]interface{}{}, ctx)
+	if err != nil {
+		t.Fatalf("tool Execute: %v", err)
+	}
+
+	// Wait for dispatch to finish (child runs a real CLI prompt)
+	select {
+	case <-dispatchDone:
+	case <-time.After(120 * time.Second):
+		t.Fatal("DispatchAgent timed out after 120s")
+	}
+
+	// Verify no dispatch error
+	if dispatchErr != nil {
+		// THE BUG: if this says "no API key found", the fix didn't work
+		if strings.Contains(dispatchErr.Error(), "API key") || strings.Contains(dispatchErr.Error(), "api key") {
+			t.Fatalf("REGRESSION: DispatchAgent used ApiBackend instead of CliBackend: %s", dispatchErr)
+		}
+		t.Fatalf("DispatchAgent error: %v", dispatchErr)
+	}
+
+	if dispatchResult == nil {
+		t.Fatal("DispatchAgent returned nil result")
+	}
+
+	// Exit code must be 0
+	if dispatchResult.ExitCode != 0 {
+		t.Fatalf("child exit code %d, output: %s", dispatchResult.ExitCode, dispatchResult.Output)
+	}
+
+	// Output should contain "42"
+	if !strings.Contains(dispatchResult.Output, "42") {
+		t.Errorf("expected child output to contain '42', got: %q", dispatchResult.Output)
+	}
+
+	t.Logf("DispatchAgent OK: exitCode=%d output=%q cost=%.6f elapsed=%.2fs",
+		dispatchResult.ExitCode, dispatchResult.Output,
+		dispatchResult.Cost, dispatchResult.Elapsed)
+}
+
+// ─── Test 4: ion_agent tool via MCP sidecar (the #37 agent-spec gap) ────────
+//
+// Creates a Manager with CliBackend, wires the agent tool server, registers
+// an agent spec, then calls the ion_agent tool handler directly to verify
+// the full spec resolution → child CLI spawn → result pipeline.
+//
+// This verifies Part D of the fix: the engine's agent-spec system is
+// reachable for CliBackend sessions via the MCP ToolServer.
+func TestLiveCliBackendIonAgentTool(t *testing.T) {
+	parentBackend := backend.NewCliBackend()
+	mgr := session.NewManager(parentBackend)
+
+	cfg := types.EngineConfig{
+		ProfileID:        "e2e-ion-agent",
+		WorkingDirectory: t.TempDir(),
+	}
+
+	if _, err := mgr.StartSession("e2e-ia", cfg); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { mgr.StopSession("e2e-ia") })
+
+	// Register an agent spec (simulates ~/.ion/agents/math-helper.md)
+	mgr.TestRegisterAgentSpec("e2e-ia", types.AgentSpec{
+		Name:         "math-helper",
+		SystemPrompt: "You are a math helper. Always respond with just the numeric answer, nothing else.",
+		Tools:        []string{"Read"},
+	})
+
+	// Wire the agent tool server to get the handler registered
+	opts := types.RunOptions{}
+	mgr.TestWireAgentToolServer("e2e-ia", &opts)
+
+	if opts.McpConfig == "" {
+		t.Fatal("wireAgentToolServer did not set McpConfig")
+	}
+
+	// Get the tool handler and call it directly (simulates what the CLI
+	// subprocess would do when invoking mcp__ion-extensions__ion_agent)
+	handler := mgr.TestBuildAgentToolHandler("e2e-ia")
+	if handler == nil {
+		t.Fatal("TestBuildAgentToolHandler returned nil")
+	}
+
+	result, err := handler(map[string]interface{}{
+		"prompt": "What is 12*12? Reply with just the number.",
+		"name":   "math-helper",
+	})
+	if err != nil {
+		t.Fatalf("ion_agent handler error: %v", err)
+	}
+
+	if result.IsError {
+		t.Fatalf("ion_agent returned error: %s", result.Content)
+	}
+
+	if !strings.Contains(result.Content, "144") {
+		t.Errorf("expected result to contain '144', got: %q", result.Content)
+	}
+
+	t.Logf("ion_agent tool OK: result=%q", result.Content)
+}
+
+// ─── Test 5: CliBackend SendPrompt full pipeline ────────────────────────────
+//
+// End-to-end test through the Manager's SendPrompt path with a CliBackend.
+// This exercises the full dispatch pipeline: buildRunOptions, wireToolServer,
+// wireAgentToolServer, fireBeforePromptCli, and the CliBackend.StartRun.
+func TestLiveCliBackendSendPrompt(t *testing.T) {
+	parentBackend := backend.NewCliBackend()
+	mgr := session.NewManager(parentBackend)
+
+	cfg := types.EngineConfig{
+		ProfileID:        "e2e-sendprompt",
+		WorkingDirectory: t.TempDir(),
+	}
+
+	if _, err := mgr.StartSession("e2e-sp", cfg); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { mgr.StopSession("e2e-sp") })
+
+	// Collect events
+	var mu sync.Mutex
+	var events []types.EngineEvent
+	done := make(chan struct{})
+
+	mgr.OnEvent(func(key string, ev types.EngineEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+
+		// The run is done when we see engine_status with state=idle after running
+		if ev.Type == "engine_status" && ev.Fields != nil && ev.Fields.State == "idle" && ev.Fields.SessionID != "" {
+			select {
+			case <-done:
+			default:
+				close(done)
+			}
+		}
+	})
+
+	// Send a prompt through the full pipeline
+	if err := mgr.SendPrompt("e2e-sp", "What is 9+10? Reply with just the number.", nil); err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+
+	// Wait for completion
+	select {
+	case <-done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("SendPrompt timed out after 60s")
+	}
+
+	mu.Lock()
+	allEvents := make([]types.EngineEvent, len(events))
+	copy(allEvents, events)
+	mu.Unlock()
+
+	// Should have text_delta events
+	var fullText strings.Builder
+	for _, ev := range allEvents {
+		if ev.Type == "engine_text_delta" {
+			fullText.WriteString(ev.TextDelta)
+		}
+	}
+
+	if !strings.Contains(fullText.String(), "19") {
+		t.Errorf("expected response containing '19', got: %q", fullText.String())
+	}
+
+	// Should NOT have any engine_error events
+	for _, ev := range allEvents {
+		if ev.Type == "engine_error" {
+			t.Errorf("unexpected engine_error: %s (code: %s)", ev.EventMessage, ev.ErrorCode)
+		}
+	}
+
+	// Should NOT have engine_dead
+	for _, ev := range allEvents {
+		if ev.Type == "engine_dead" {
+			t.Errorf("unexpected engine_dead event (exit code: %v)", ev.ExitCode)
+		}
+	}
+
+	t.Logf("SendPrompt OK: response=%q", strings.TrimSpace(fullText.String()))
+}

--- a/engine/tests/integration/cli_backend_dispatch_test.go
+++ b/engine/tests/integration/cli_backend_dispatch_test.go
@@ -1,0 +1,341 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dsswift/ion/engine/internal/backend"
+	"github.com/dsswift/ion/engine/internal/extension"
+	"github.com/dsswift/ion/engine/internal/session"
+	"github.com/dsswift/ion/engine/internal/types"
+	"github.com/dsswift/ion/engine/tests/helpers"
+)
+
+// ─── DispatchAgent: CliBackend parent spawns CLI child ───
+//
+// When the Manager's parent backend is CliBackend, ctx.DispatchAgent must
+// create a CliBackend child (not ApiBackend). The child will fail because
+// the claude CLI binary isn't available in the test env, but the error
+// message proves it attempted to use the CLI path ("claude CLI not found")
+// rather than the API path ("no API key found").
+func TestDispatchAgent_CliBackendParent_SpawnsCliChild(t *testing.T) {
+	cb := backend.NewCliBackend()
+	mgr := session.NewManager(cb)
+
+	cfg := types.EngineConfig{
+		ProfileID:        "cli-dispatch-test",
+		WorkingDirectory: t.TempDir(),
+	}
+
+	if _, err := mgr.StartSession("cli-da", cfg); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { mgr.StopSession("cli-da") })
+
+	// Collect events to observe the child backend's behavior.
+	var mu sync.Mutex
+	var events []types.EngineEvent
+	mgr.OnEvent(func(key string, ev types.EngineEvent) {
+		mu.Lock()
+		events = append(events, ev)
+		mu.Unlock()
+	})
+
+	// Invoke DispatchAgent through the session's wired context.
+	// We can't call newExtContext directly (unexported), so we use the
+	// extension host trick: register a tool that calls ctx.DispatchAgent
+	// and invoke it through the session's tool call pipeline.
+	//
+	// Simpler: DispatchAgent is wired on the Context. We can test by
+	// triggering an extension that calls ext/dispatch_agent. But there's a
+	// cleaner way: use the ctx directly via an in-process extension.
+
+	host := extension.NewHost()
+	sdk := host.SDK()
+
+	var dispatchResult *extension.DispatchAgentResult
+	var dispatchErr error
+	var dispatchDone sync.WaitGroup
+	dispatchDone.Add(1)
+
+	sdk.RegisterTool(extension.ToolDefinition{
+		Name:        "test_dispatch",
+		Description: "calls ctx.dispatchAgent",
+		Parameters:  map[string]interface{}{"type": "object"},
+		Execute: func(params interface{}, ctx *extension.Context) (*types.ToolResult, error) {
+			defer dispatchDone.Done()
+			if ctx.DispatchAgent == nil {
+				return &types.ToolResult{Content: "DispatchAgent not wired", IsError: true}, nil
+			}
+			dispatchResult, dispatchErr = ctx.DispatchAgent(extension.DispatchAgentOpts{
+				Name: "test-agent",
+				Task: "say hello",
+			})
+			return &types.ToolResult{Content: "dispatched"}, nil
+		},
+	})
+
+	group := extension.NewExtensionGroup()
+	group.Add(host)
+
+	// Wire the extension group onto the session so tools and context are available
+	mgr.TestSetExtGroup("cli-da", group)
+
+	// Execute the tool through the session's tool pipeline.
+	// The tool's Execute runs ctx.DispatchAgent, which creates a child backend.
+	tools := host.Tools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	// Build a context that mirrors what newExtContext builds — we need DispatchAgent wired.
+	// Since we can't call newExtContext, trigger via SendPrompt + mock or direct tool call.
+	// Actually: the cleanest approach is to wire extensions, send a prompt, and let the
+	// mock backend trigger tool execution. But that requires an ApiBackend run loop.
+	//
+	// For CliBackend tests, we can use a direct approach: call the extension tool
+	// with a properly wired Context from the session manager.
+	ctx := mgr.TestNewExtContext("cli-da")
+	if ctx == nil {
+		t.Fatal("TestNewExtContext returned nil (session not found)")
+	}
+
+	// Execute the tool. This calls DispatchAgent which creates a CliBackend child.
+	_, err := tools[0].Execute(map[string]interface{}{}, ctx)
+	if err != nil {
+		t.Fatalf("tool Execute: %v", err)
+	}
+
+	// Wait for the dispatch to complete (the child will fail quickly since claude CLI isn't available).
+	dispatchDone.Wait()
+
+	// The child should have failed because claude CLI is not in path.
+	// The key assertion: error mentions "claude CLI" or "claude" (not "API key").
+	if dispatchErr == nil && dispatchResult != nil && dispatchResult.ExitCode == 0 {
+		// If somehow claude CLI is available and succeeds, that's also fine.
+		t.Log("dispatch succeeded (claude CLI available in test env)")
+		return
+	}
+
+	if dispatchErr != nil {
+		errMsg := dispatchErr.Error()
+		if strings.Contains(errMsg, "API key") || strings.Contains(errMsg, "api key") {
+			t.Fatalf("child used ApiBackend instead of CliBackend: %s", errMsg)
+		}
+		if strings.Contains(errMsg, "claude") || strings.Contains(errMsg, "CLI") {
+			t.Logf("correctly used CliBackend child (error: %s)", errMsg)
+		} else {
+			t.Logf("dispatch error (may be expected in test env): %s", errMsg)
+		}
+	} else if dispatchResult != nil && dispatchResult.ExitCode != 0 {
+		output := dispatchResult.Output
+		if strings.Contains(output, "API key") || strings.Contains(output, "api key") {
+			t.Fatalf("child used ApiBackend instead of CliBackend: %s", output)
+		}
+		t.Logf("dispatch completed with exit code %d (expected in test env)", dispatchResult.ExitCode)
+	}
+}
+
+// ─── wireAgentToolServer: ion_agent tool discoverable via MCP ───
+//
+// Creates a CliBackend Manager, wires the agent tool server, then connects
+// to the ToolServer's Unix socket and verifies:
+// 1. tools/list includes "ion_agent"
+// 2. tools/call with missing prompt returns an error
+// 3. tools/call with unknown agent name returns spec resolution error
+func TestWireAgentToolServer_McpRoundTrip(t *testing.T) {
+	cb := backend.NewCliBackend()
+	mgr := session.NewManager(cb)
+
+	cfg := types.EngineConfig{
+		ProfileID:        "mcp-agent-test",
+		WorkingDirectory: t.TempDir(),
+	}
+
+	if _, err := mgr.StartSession("mcp-at", cfg); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { mgr.StopSession("mcp-at") })
+
+	// Register an agent spec so we can test spec resolution
+	mgr.TestRegisterAgentSpec("mcp-at", types.AgentSpec{
+		Name:         "researcher",
+		Model:        "test-model",
+		SystemPrompt: "You are a research assistant.",
+		Tools:        []string{"Read", "Grep"},
+	})
+
+	// Wire the agent tool server
+	opts := types.RunOptions{}
+	mgr.TestWireAgentToolServer("mcp-at", &opts)
+
+	if opts.McpConfig == "" {
+		t.Fatal("expected McpConfig to be set after wireAgentToolServer")
+	}
+
+	// Get the ToolServer's socket path
+	sockPath := mgr.TestGetToolServerSocketPath("mcp-at")
+	if sockPath == "" {
+		t.Fatal("expected ToolServer socket path")
+	}
+
+	// Connect to the Unix socket
+	conn, err := net.DialTimeout("unix", sockPath, 2*time.Second)
+	if err != nil {
+		t.Fatalf("connect to ToolServer: %v", err)
+	}
+	defer conn.Close()
+
+	decoder := json.NewDecoder(conn)
+	encoder := json.NewEncoder(conn)
+
+	// 1. tools/list should include "ion_agent"
+	encoder.Encode(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	})
+
+	var listResp struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := decoder.Decode(&listResp); err != nil {
+		t.Fatalf("decode tools/list response: %v", err)
+	}
+
+	foundIonAgent := false
+	for _, tool := range listResp.Result.Tools {
+		if tool.Name == "ion_agent" {
+			foundIonAgent = true
+		}
+	}
+	if !foundIonAgent {
+		t.Fatalf("ion_agent not found in tools/list response: %+v", listResp.Result.Tools)
+	}
+
+	// 2. tools/call with missing prompt → error
+	encoder.Encode(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]interface{}{
+			"name":      "ion_agent",
+			"arguments": map[string]interface{}{},
+		},
+	})
+
+	var callResp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := decoder.Decode(&callResp); err != nil {
+		t.Fatalf("decode tools/call response (no prompt): %v", err)
+	}
+	if !callResp.Result.IsError {
+		t.Error("expected isError=true for missing prompt")
+	}
+	if len(callResp.Result.Content) > 0 && !strings.Contains(callResp.Result.Content[0].Text, "prompt is required") {
+		t.Errorf("expected 'prompt is required' error, got %q", callResp.Result.Content[0].Text)
+	}
+
+	// 3. tools/call with unknown agent name → spec resolution error
+	encoder.Encode(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      3,
+		"method":  "tools/call",
+		"params": map[string]interface{}{
+			"name": "ion_agent",
+			"arguments": map[string]interface{}{
+				"prompt": "test task",
+				"name":   "nonexistent_agent",
+			},
+		},
+	})
+
+	var specResp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := decoder.Decode(&specResp); err != nil {
+		t.Fatalf("decode tools/call response (unknown agent): %v", err)
+	}
+	if !specResp.Result.IsError {
+		t.Error("expected isError=true for unknown agent name")
+	}
+	if len(specResp.Result.Content) > 0 && !strings.Contains(specResp.Result.Content[0].Text, "not registered") {
+		t.Errorf("expected 'not registered' error, got %q", specResp.Result.Content[0].Text)
+	}
+}
+
+// ─── newChildBackend factory: type-correctness ───
+//
+// Verifies the factory returns the correct concrete type for both
+// CliBackend and ApiBackend parents at the integration level.
+func TestNewChildBackend_TypeCorrectness(t *testing.T) {
+	// CliBackend parent → CliBackend child
+	cliMgr := session.NewManager(backend.NewCliBackend())
+	cliChild := cliMgr.TestNewChildBackend()
+	if _, ok := cliChild.(*backend.CliBackend); !ok {
+		t.Errorf("CliBackend parent: expected *CliBackend child, got %T", cliChild)
+	}
+
+	// ApiBackend parent → ApiBackend child
+	apiMgr := session.NewManager(backend.NewApiBackend())
+	apiChild := apiMgr.TestNewChildBackend()
+	if _, ok := apiChild.(*backend.ApiBackend); !ok {
+		t.Errorf("ApiBackend parent: expected *ApiBackend child, got %T", apiChild)
+	}
+
+	// MockBackend parent → ApiBackend child (default fallback)
+	mockMgr := session.NewManager(helpers.NewMockBackend())
+	mockChild := mockMgr.TestNewChildBackend()
+	if _, ok := mockChild.(*backend.ApiBackend); !ok {
+		t.Errorf("MockBackend parent: expected *ApiBackend child (fallback), got %T", mockChild)
+	}
+}
+
+// ─── wireAgentToolServer: no-op for non-CLI backend ───
+//
+// Verifies wireAgentToolServer does nothing when the parent backend
+// is not CliBackend.
+func TestWireAgentToolServer_NoopForApiBackend(t *testing.T) {
+	apiMgr := session.NewManager(backend.NewApiBackend())
+
+	cfg := types.EngineConfig{
+		ProfileID:        "api-noop-test",
+		WorkingDirectory: t.TempDir(),
+	}
+	if _, err := apiMgr.StartSession("api-at", cfg); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	t.Cleanup(func() { apiMgr.StopSession("api-at") })
+
+	opts := types.RunOptions{}
+	apiMgr.TestWireAgentToolServer("api-at", &opts)
+
+	if opts.McpConfig != "" {
+		t.Error("expected no McpConfig for ApiBackend")
+	}
+	sockPath := apiMgr.TestGetToolServerSocketPath("api-at")
+	if sockPath != "" {
+		t.Error("expected no ToolServer for ApiBackend")
+	}
+}


### PR DESCRIPTION
- **fix(engine): use parent backend type for child agent dispatch**
- **test(engine): add e2e tests for cli backend agent dispatch**
