### PR TITLE
iOS and desktop features and fixes

### DIFF
--- a/desktop/src/main/remote/command-handler.ts
+++ b/desktop/src/main/remote/command-handler.ts
@@ -12,6 +12,7 @@ import {
   handleLoadConversation,
   handleSetTabGroupMode,
   handleMoveTabToGroup,
+  handleDiscoverCommands,
 } from './handlers/tabs'
 import {
   handleEnginePrompt,
@@ -101,6 +102,7 @@ export async function handleRemoteCommand(cmd: RemoteCommand, deviceId: string):
     case 'fs_list_dir': await handleFsListDir(cmd); break
     case 'fs_read_file': await handleFsReadFile(cmd); break
     case 'fs_write_file': await handleFsWriteFile(cmd); break
+    case 'discover_commands': await handleDiscoverCommands(cmd); break
     case 'unpair': handleUnpair(deviceId); break
   }
 }

--- a/desktop/src/main/remote/handlers/tabs.ts
+++ b/desktop/src/main/remote/handlers/tabs.ts
@@ -7,6 +7,7 @@ import { broadcast } from '../../broadcast'
 import { terminalManager } from '../../terminal-manager-instance'
 import { readSettings, writeSettings } from '../../settings-store'
 import { getRemoteTabStates } from '../snapshot'
+import { discoverCommands } from '../../cli-compat/command-discovery'
 import type { RemoteCommand } from '../protocol'
 
 function log(msg: string): void {
@@ -394,4 +395,15 @@ export async function handleMoveTabToGroup(cmd: Extract<RemoteCommand, { type: '
     log('move_tab_to_group error: ' + (err as Error).message)
   }
   await handleSync()
+}
+
+export async function handleDiscoverCommands(cmd: Extract<RemoteCommand, { type: 'discover_commands' }>): Promise<void> {
+  const { directory } = cmd
+  try {
+    const commands = await discoverCommands(directory)
+    state.remoteTransport?.send({ type: 'discover_commands_response', directory, commands })
+  } catch (err) {
+    log(`discover_commands error: ${(err as Error).message}`)
+    state.remoteTransport?.send({ type: 'discover_commands_response', directory, commands: [] })
+  }
 }

--- a/desktop/src/main/remote/protocol.ts
+++ b/desktop/src/main/remote/protocol.ts
@@ -107,6 +107,7 @@ export type RemoteCommand =
   | { type: 'fs_list_dir'; directory: string; includeHidden?: boolean }
   | { type: 'fs_read_file'; filePath: string }
   | { type: 'fs_write_file'; filePath: string; content: string }
+  | { type: 'discover_commands'; directory: string }
 
 // ─── Ion → iOS events ───
 
@@ -160,6 +161,7 @@ export type RemoteEvent =
   | { type: 'fs_dir_listing'; directory: string; entries: Array<{ name: string; path: string; isDirectory: boolean; size: number; modifiedMs: number }>; error?: string }
   | { type: 'fs_file_content'; filePath: string; content: string | null; error?: string }
   | { type: 'fs_write_result'; filePath: string; ok: boolean; error?: string }
+  | { type: 'discover_commands_response'; directory: string; commands: Array<{ name: string; description: string; scope: 'user' | 'project'; source: 'command' | 'skill' }> }
 
 // ─── Relay control frames (injected by relay, not by Ion) ───
 

--- a/desktop/src/renderer/components/TerminalInstance.tsx
+++ b/desktop/src/renderer/components/TerminalInstance.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef } from 'react'
-import { Terminal } from '@xterm/xterm'
+import { Terminal, ILinkProvider, ILink } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { SerializeAddon } from '@xterm/addon-serialize'
 import { useColors } from '../theme'
 import { usePreferencesStore } from '../preferences'
 import { useSessionStore } from '../stores/sessionStore'
+import { LINK_RE, isCmdHeld, EDITABLE_EXTS } from '../hooks/useNavigableLinks'
 import '@xterm/xterm/css/xterm.css'
 
 interface TerminalEntry {
@@ -16,6 +17,7 @@ interface TerminalEntry {
   hostEl: HTMLDivElement
   unsubData: () => void
   unsubExit: () => void
+  unsubLinks: () => void
 }
 
 // Module-level pool: one xterm instance per compound key, survives React re-renders
@@ -26,6 +28,7 @@ export function destroyTerminalInstance(key: string): void {
   if (entry) {
     entry.unsubData()
     entry.unsubExit()
+    entry.unsubLinks()
     entry.hostEl.remove()
     entry.terminal.dispose()
     terminalInstances.delete(key)
@@ -60,6 +63,75 @@ export function serializeTerminalBuffer(key: string): string | undefined {
     return entry.serializeAddon.serialize()
   } catch {
     return undefined
+  }
+}
+
+// ─── Cmd+Click link provider for file paths & URLs in terminal output ───
+
+function registerTerminalLinks(terminal: Terminal, cwd: string, tabId: string): () => void {
+  const provider: ILinkProvider = {
+    provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void) {
+      const line = terminal.buffer.active.getLine(bufferLineNumber - 1)
+      if (!line) { callback(undefined); return }
+      const text = line.translateToString()
+      if (!text.trim()) { callback(undefined); return }
+
+      const links: ILink[] = []
+      // Reset lastIndex since LINK_RE is a global regex
+      const re = new RegExp(LINK_RE.source, 'g')
+      let match: RegExpExecArray | null
+      while ((match = re.exec(text)) !== null) {
+        const raw = match[0]
+        const trimmed = raw.replace(/[.,;:!?)]+$/, '')
+        const isUrl = trimmed.startsWith('http')
+        const startX = match.index + 1 // 1-based
+        const endX = match.index + trimmed.length
+
+        const decorations = { pointerCursor: isCmdHeld(), underline: isCmdHeld() }
+        links.push({
+          range: {
+            start: { x: startX, y: bufferLineNumber },
+            end: { x: endX, y: bufferLineNumber },
+          },
+          text: trimmed,
+          decorations,
+          activate(event: MouseEvent, linkText: string) {
+            if (!event.metaKey) return
+            if (isUrl) {
+              window.ion.openExternal(linkText)
+            } else {
+              openTerminalFile(linkText, cwd, tabId)
+            }
+          },
+          hover() {
+            decorations.pointerCursor = isCmdHeld()
+            decorations.underline = isCmdHeld()
+          },
+          leave() {
+            decorations.pointerCursor = false
+            decorations.underline = false
+          },
+        })
+      }
+
+      callback(links.length > 0 ? links : undefined)
+    },
+  }
+
+  const disposable = terminal.registerLinkProvider(provider)
+  return () => disposable.dispose()
+}
+
+function openTerminalFile(path: string, cwd: string, tabId: string): void {
+  const homeDir = useSessionStore.getState().staticInfo?.homePath
+    || '/Users/' + (process.env.USER || 'user')
+  const expanded = path.startsWith('~/') ? homeDir + path.slice(1) : path
+  const resolved = expanded.startsWith('/') ? expanded : cwd + '/' + expanded
+  const ext = resolved.includes('.') ? '.' + resolved.split('.').pop()!.toLowerCase() : ''
+  if (EDITABLE_EXTS.has(ext)) {
+    useSessionStore.getState().openFileInEditor(cwd, tabId, resolved)
+  } else {
+    window.ion.fsOpenNative(resolved)
   }
 }
 
@@ -146,6 +218,9 @@ export function TerminalInstanceView({ tabId, instanceId, cwd, readOnly }: Props
         terminal.write(restoredBuffer)
       }
 
+      // Cmd+Click link provider for file paths & URLs
+      const unsubLinks = registerTerminalLinks(terminal, cwd, tabId)
+
       // Module-level IPC listeners -- stay active even when component is unmounted
       const unsubData = window.ion.onTerminalData((k, data) => {
         if (k === key) terminal.write(data)
@@ -161,7 +236,7 @@ export function TerminalInstanceView({ tabId, instanceId, cwd, readOnly }: Props
         })
       })
 
-      entry = { terminal, fitAddon, serializeAddon, created: false, cwd, hostEl, unsubData, unsubExit }
+      entry = { terminal, fitAddon, serializeAddon, created: false, cwd, hostEl, unsubData, unsubExit, unsubLinks }
       terminalInstances.set(key, entry)
     }
 

--- a/desktop/src/renderer/hooks/useEngineEvents.ts
+++ b/desktop/src/renderer/hooks/useEngineEvents.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
+import { usePreferencesStore } from '../preferences'
 import { IPC, type NormalizedEvent } from '../../shared/types'
 
 /**
@@ -104,13 +105,27 @@ export function useEngineEvents() {
     }
     window.ion.on(IPC.REMOTE_BASH_COMMAND, remoteBashCommandHandler)
 
-    // Remote permission mode change (from iOS toggle) — update store without calling back to main
+    // Remote permission mode change (from iOS toggle or slash-command expansion) —
+    // update store without calling back to main, then re-evaluate auto group placement
     const remoteSetModeHandler = (_e: any, data: { tabId: string; mode: 'auto' | 'plan' }) => {
       useSessionStore.setState((s) => ({
         tabs: s.tabs.map((t) =>
           t.id === data.tabId ? { ...t, permissionMode: data.mode } : t
         ),
       }))
+
+      // Re-evaluate auto group movement after the mode change
+      const { autoGroupMovement, tabGroupMode, planningGroupId, inProgressGroupId } = usePreferencesStore.getState()
+      if (autoGroupMovement && tabGroupMode === 'manual') {
+        const tab = useSessionStore.getState().tabs.find((t) => t.id === data.tabId)
+        if (tab) {
+          if (data.mode === 'plan' && planningGroupId && tab.groupId !== planningGroupId) {
+            useSessionStore.getState().moveTabToGroup(data.tabId, planningGroupId)
+          } else if (data.mode === 'auto' && inProgressGroupId && tab.groupId !== inProgressGroupId) {
+            useSessionStore.getState().moveTabToGroup(data.tabId, inProgressGroupId)
+          }
+        }
+      }
     }
     window.ion.on(IPC.REMOTE_SET_PERMISSION_MODE, remoteSetModeHandler)
 

--- a/desktop/src/renderer/hooks/useNavigableLinks.tsx
+++ b/desktop/src/renderer/hooks/useNavigableLinks.tsx
@@ -24,13 +24,18 @@ export function useCmdHeld(): boolean {
   )
 }
 
+/** Non-React getter for CMD key state (use in non-component code like xterm link providers) */
+export function isCmdHeld(): boolean {
+  return _cmdHeld
+}
+
 // ─── Text segmentation — detect file paths and URLs in plain text ───
 
 type TextSegment = { type: 'plain' | 'file' | 'url'; value: string }
 
 // Matches: URLs (https://...), absolute paths (/foo/bar), home-relative paths (~/foo/bar), and relative paths (src/foo/bar.ext)
 // Relative paths require a file extension to avoid false positives on plain text with slashes
-const LINK_RE = /(https?:\/\/[^\s<>"')\]]+|~\/(?:[a-zA-Z0-9._~-]+\/)*[a-zA-Z0-9._~-]+|\/(?:[a-zA-Z0-9._~-]+\/)+[a-zA-Z0-9._~-]+|[a-zA-Z0-9._~-]+(?:\/[a-zA-Z0-9._~-]+)+\.[a-zA-Z0-9]+)/g
+export const LINK_RE = /(https?:\/\/[^\s<>"')\]]+|~\/(?:[a-zA-Z0-9._~-]+\/)*[a-zA-Z0-9._~-]+|\/(?:[a-zA-Z0-9._~-]+\/)+[a-zA-Z0-9._~-]+|[a-zA-Z0-9._~-]+(?:\/[a-zA-Z0-9._~-]+)+\.[a-zA-Z0-9]+)/g
 
 function segmentText(text: string): TextSegment[] {
   const segments: TextSegment[] = []

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		A1B2C3D4E5F60001000242AA /* NormalizedEventPermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000243AA /* NormalizedEventPermissionTests.swift */; };
 		A1B2C3D4E5F60001000244AA /* NormalizedEventLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000245AA /* NormalizedEventLifecycleTests.swift */; };
 		A1B2C3D4E5F60001000246AA /* NormalizedEventTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000247AA /* NormalizedEventTerminalTests.swift */; };
+		A1B2C3D4E5F60001000600AA /* DiscoveredSlashCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000601AA /* DiscoveredSlashCommand.swift */; };
+		A1B2C3D4E5F60001000602AA /* SlashCommandMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000603AA /* SlashCommandMenu.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -167,6 +169,8 @@
 		A1B2C3D4E5F60001000243AA /* NormalizedEventPermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventPermissionTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000245AA /* NormalizedEventLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventLifecycleTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000247AA /* NormalizedEventTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventTerminalTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001000601AA /* DiscoveredSlashCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveredSlashCommand.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001000603AA /* SlashCommandMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandMenu.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -243,6 +247,7 @@
 				A1B2C3D4E5F60001000300AA /* GitTypes.swift */,
 				A1B2C3D4E5F60001000400AA /* FileTypes.swift */,
 				A1B2C3D4E5F60001000500AA /* ConnectionQuality.swift */,
+				A1B2C3D4E5F60001000601AA /* DiscoveredSlashCommand.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -299,6 +304,7 @@
 				A1B2C3D4E5F60001000406AA /* FileExplorerRowView.swift */,
 				A1B2C3D4E5F60001000408AA /* FileEditorView.swift */,
 				A1B2C3D4E5F60001000502AA /* ConnectionQualityView.swift */,
+				A1B2C3D4E5F60001000603AA /* SlashCommandMenu.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -517,6 +523,8 @@
 				A1B2C3D4E5F600010000FAAA /* MarkdownContentView.swift in Sources */,
 				A1B2C3D4E5F60001000501AA /* ConnectionQuality.swift in Sources */,
 				A1B2C3D4E5F60001000503AA /* ConnectionQualityView.swift in Sources */,
+				A1B2C3D4E5F60001000600AA /* DiscoveredSlashCommand.swift in Sources */,
+				A1B2C3D4E5F60001000602AA /* SlashCommandMenu.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IonRemote/Models/DiscoveredSlashCommand.swift
+++ b/ios/IonRemote/Models/DiscoveredSlashCommand.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// A slash command discovered from filesystem command/skill directories.
+/// Mirrors the `DiscoveredCommand` interface in `types-events.ts`.
+struct DiscoveredSlashCommand: Codable, Sendable, Identifiable {
+    var id: String { name }
+    let name: String
+    let description: String
+    let scope: String       // "user" | "project"
+    let source: String      // "command" | "skill"
+}

--- a/ios/IonRemote/Models/NormalizedEvent+Files.swift
+++ b/ios/IonRemote/Models/NormalizedEvent+Files.swift
@@ -31,6 +31,11 @@ extension RemoteEvent {
             let response = FsWriteResultResponse(filePath: filePath, ok: ok, error: error)
             return .fsWriteResult(filePath: filePath, response: response)
 
+        case .discoverCommandsResponse:
+            let directory = try container.decode(String.self, forKey: .directory)
+            let commands = try container.decode([DiscoveredSlashCommand].self, forKey: .commands)
+            return .discoverCommandsResponse(directory: directory, commands: commands)
+
         default:
             return nil
         }
@@ -58,6 +63,12 @@ extension RemoteEvent {
             try container.encode(response.filePath, forKey: .filePath)
             try container.encode(response.ok, forKey: .ok)
             try container.encodeIfPresent(response.error, forKey: .error)
+            return true
+
+        case .discoverCommandsResponse(let directory, let commands):
+            try container.encode(TypeKey.discoverCommandsResponse, forKey: .type)
+            try container.encode(directory, forKey: .directory)
+            try container.encode(commands, forKey: .commands)
             return true
 
         default:

--- a/ios/IonRemote/Models/NormalizedEvent.swift
+++ b/ios/IonRemote/Models/NormalizedEvent.swift
@@ -73,6 +73,8 @@ enum RemoteEvent: Codable, Sendable {
     case fsDirListing(directory: String, response: FsDirListingResponse)
     case fsFileContent(filePath: String, response: FsFileContentResponse)
     case fsWriteResult(filePath: String, response: FsWriteResultResponse)
+    // Command discovery events
+    case discoverCommandsResponse(directory: String, commands: [DiscoveredSlashCommand])
 
     // MARK: - Codable keys
 
@@ -128,6 +130,7 @@ enum RemoteEvent: Codable, Sendable {
         case fsDirListing = "fs_dir_listing"
         case fsFileContent = "fs_file_content"
         case fsWriteResult = "fs_write_result"
+        case discoverCommandsResponse = "discover_commands_response"
     }
 
     enum CodingKeys: String, CodingKey {
@@ -146,6 +149,7 @@ enum RemoteEvent: Codable, Sendable {
         case directory, files, branch, isGitRepo, ahead, behind
         case commits, totalCount, diff, fileName
         case entries, filePath, ok, error
+        case commands
         case ts, buffered
     }
 

--- a/ios/IonRemote/Models/RemoteCommand.swift
+++ b/ios/IonRemote/Models/RemoteCommand.swift
@@ -43,6 +43,7 @@ enum RemoteCommand: Codable, Sendable {
     case fsListDir(directory: String, includeHidden: Bool = false)
     case fsReadFile(filePath: String)
     case fsWriteFile(filePath: String, content: String)
+    case discoverCommands(directory: String)
 
     // MARK: - Codable
 
@@ -87,6 +88,7 @@ enum RemoteCommand: Codable, Sendable {
         case fsListDir = "fs_list_dir"
         case fsReadFile = "fs_read_file"
         case fsWriteFile = "fs_write_file"
+        case discoverCommands = "discover_commands"
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -299,6 +301,10 @@ enum RemoteCommand: Codable, Sendable {
             let filePath = try container.decode(String.self, forKey: .filePath)
             let content = try container.decode(String.self, forKey: .content)
             self = .fsWriteFile(filePath: filePath, content: content)
+
+        case .discoverCommands:
+            let directory = try container.decode(String.self, forKey: .directory)
+            self = .discoverCommands(directory: directory)
         }
     }
 
@@ -505,6 +511,10 @@ enum RemoteCommand: Codable, Sendable {
             try container.encode(TypeKey.fsWriteFile, forKey: .type)
             try container.encode(filePath, forKey: .filePath)
             try container.encode(content, forKey: .content)
+
+        case .discoverCommands(let directory):
+            try container.encode(TypeKey.discoverCommands, forKey: .type)
+            try container.encode(directory, forKey: .directory)
         }
     }
 }

--- a/ios/IonRemote/ViewModels/SessionViewModel+Commands.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Commands.swift
@@ -306,6 +306,13 @@ extension SessionViewModel {
         send(.fsWriteFile(filePath: filePath, content: content))
     }
 
+    // MARK: - Command Discovery
+
+    func discoverCommands(directory: String) {
+        guard !directory.isEmpty else { return }
+        send(.discoverCommands(directory: directory))
+    }
+
     // MARK: - Send
 
     func send(_ command: RemoteCommand) {

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -267,6 +267,10 @@ extension SessionViewModel {
 
         case .fsWriteResult(_, let response):
             fileWriteResult = response
+
+        // Command discovery events
+        case .discoverCommandsResponse(let directory, let commands):
+            discoveredCommands[directory] = commands
         }
     }
 

--- a/ios/IonRemote/ViewModels/SessionViewModel.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel.swift
@@ -174,6 +174,9 @@ final class SessionViewModel {
     var fileListingLoading: Set<String> = []
     var fileContentLoading: Set<String> = []
 
+    // Discovered slash commands (per working directory)
+    var discoveredCommands: [String: [DiscoveredSlashCommand]] = [:]
+
     /// Tab group mode synced from the desktop: "off", "auto", or "manual".
     var tabGroupMode: String = "auto"
     /// Manual tab group definitions from the desktop (only meaningful when tabGroupMode == "manual").

--- a/ios/IonRemote/Views/ConversationView.swift
+++ b/ios/IonRemote/Views/ConversationView.swift
@@ -329,19 +329,20 @@ struct MessageBubble: View {
                     }
                     .foregroundStyle(.secondary)
                 }
-                Text(message.content)
-                    .textSelection(.enabled)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(Color(hex: 0x4ECDC4).opacity(0.15))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                    .overlay(
-                        message.content.hasPrefix("! ")
-                            ? RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color(hex: 0xF472B6, opacity: 0.5), lineWidth: 2)
-                            : nil
-                    )
+                MarkdownContentView(
+                    blocks: MarkdownBlockCache.shared.blocks(for: message.content)
+                )
+                .textSelection(.enabled)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(Color(hex: 0x4ECDC4).opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    message.content.hasPrefix("! ")
+                        ? RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color(hex: 0xF472B6, opacity: 0.5), lineWidth: 2)
+                        : nil
+                )
             }
             .padding(.trailing, 12)
             .padding(.vertical, 2)

--- a/ios/IonRemote/Views/ConversationView.swift
+++ b/ios/IonRemote/Views/ConversationView.swift
@@ -380,15 +380,10 @@ struct MessageBubble: View {
     private var assistantBubble: some View {
         VStack(alignment: .leading, spacing: 4) {
             if !message.content.isEmpty {
-                if let attributed = MarkdownCache.shared.attributedString(for: message.content) {
-                    Text(attributed)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                } else {
-                    Text(message.content)
-                        .textSelection(.enabled)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
+                MarkdownContentView(
+                    blocks: MarkdownBlockCache.shared.blocks(for: message.content)
+                )
+                .textSelection(.enabled)
             }
 
             // Blinking cursor for streaming
@@ -537,34 +532,31 @@ extension Color {
     }
 }
 
-// MARK: - MarkdownCache
+// MARK: - MarkdownBlockCache
 
-/// Caches parsed AttributedStrings so markdown is only parsed once per unique
-/// content string, not on every SwiftUI re-render.
+/// Caches parsed `[MarkdownBlock]` arrays so full block-level markdown is only
+/// parsed once per unique content string, not on every SwiftUI re-render.
 @MainActor
-final class MarkdownCache {
-    static let shared = MarkdownCache()
+final class MarkdownBlockCache {
+    static let shared = MarkdownBlockCache()
 
     private let cache = NSCache<NSString, CacheEntry>()
 
     private class CacheEntry {
-        let value: AttributedString
-        init(_ value: AttributedString) { self.value = value }
+        let value: [MarkdownBlock]
+        init(_ value: [MarkdownBlock]) { self.value = value }
     }
 
     init() {
         cache.countLimit = 200
     }
 
-    func attributedString(for content: String) -> AttributedString? {
+    func blocks(for content: String) -> [MarkdownBlock] {
         let key = content as NSString
         if let entry = cache.object(forKey: key) {
             return entry.value
         }
-        guard let result = try? AttributedString(
-            markdown: content,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        ) else { return nil }
+        let result = MarkdownFormatter.parse(content)
         cache.setObject(CacheEntry(result), forKey: key)
         return result
     }

--- a/ios/IonRemote/Views/ConversationView.swift
+++ b/ios/IonRemote/Views/ConversationView.swift
@@ -336,6 +336,12 @@ struct MessageBubble: View {
                     .padding(.vertical, 8)
                     .background(Color(hex: 0x4ECDC4).opacity(0.15))
                     .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        message.content.hasPrefix("! ")
+                            ? RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color(hex: 0xF472B6, opacity: 0.5), lineWidth: 2)
+                            : nil
+                    )
             }
             .padding(.trailing, 12)
             .padding(.vertical, 2)

--- a/ios/IonRemote/Views/InputBar.swift
+++ b/ios/IonRemote/Views/InputBar.swift
@@ -8,6 +8,7 @@ struct InputBar: View {
     @State private var promptText = ""
     @FocusState private var isFocused: Bool
     @State private var keyboardVisible = false
+    @State private var slashFilter: String?
 
     private var tab: RemoteTabState? {
         viewModel.tab(for: tabId)
@@ -25,8 +26,28 @@ struct InputBar: View {
         isRunning  // Will queue behind current run
     }
 
+    private var workingDirectory: String {
+        tab?.workingDirectory ?? ""
+    }
+
+    private var slashCommands: [DiscoveredSlashCommand] {
+        viewModel.discoveredCommands[workingDirectory] ?? []
+    }
+
     var body: some View {
         VStack(spacing: 0) {
+            if let filter = slashFilter, !slashCommands.isEmpty {
+                SlashCommandMenu(
+                    filter: filter,
+                    commands: slashCommands,
+                    onSelect: { cmd in
+                        promptText = "/\(cmd.name) "
+                        slashFilter = nil
+                    }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+
             if keyboardVisible {
                 KeyboardUtilityBar(
                     onDismiss: { isFocused = false },
@@ -81,6 +102,7 @@ struct InputBar: View {
         }
         .background(.ultraThinMaterial)
         .animation(.easeInOut(duration: 0.15), value: keyboardVisible)
+        .animation(.easeInOut(duration: 0.15), value: slashFilter)
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
             keyboardVisible = true
         }
@@ -93,6 +115,15 @@ struct InputBar: View {
                 viewModel.pendingInputByTab.removeValue(forKey: tabId)
             }
         }
+        .onChange(of: promptText) { _, newText in
+            updateSlashFilter(newText)
+        }
+        .onAppear {
+            fetchCommandsIfNeeded()
+        }
+        .onChange(of: workingDirectory) {
+            fetchCommandsIfNeeded()
+        }
     }
 
     private var sendButtonColor: Color {
@@ -100,5 +131,22 @@ struct InputBar: View {
             return .gray
         }
         return isQueued ? .orange : Color(hex: 0x4ECDC4)
+    }
+
+    /// Detect if the user is typing a slash command prefix.
+    private func updateSlashFilter(_ text: String) {
+        // Match a lone slash-prefixed token: /foo, /e2e:setup, etc.
+        let pattern = #"^\/[a-zA-Z0-9_:\-]*$"#
+        if text.range(of: pattern, options: .regularExpression) != nil {
+            slashFilter = text
+        } else {
+            slashFilter = nil
+        }
+    }
+
+    private func fetchCommandsIfNeeded() {
+        let dir = workingDirectory
+        guard !dir.isEmpty, viewModel.discoveredCommands[dir] == nil else { return }
+        viewModel.discoverCommands(directory: dir)
     }
 }

--- a/ios/IonRemote/Views/SlashCommandMenu.swift
+++ b/ios/IonRemote/Views/SlashCommandMenu.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Popup menu showing filtered slash commands above the input bar.
+struct SlashCommandMenu: View {
+    let filter: String
+    let commands: [DiscoveredSlashCommand]
+    let onSelect: (DiscoveredSlashCommand) -> Void
+
+    private var filteredCommands: [DiscoveredSlashCommand] {
+        let query = filter.lowercased()
+        let matches = commands.filter { cmd in
+            "/\(cmd.name)".lowercased().hasPrefix(query)
+        }
+        // Sort: project commands first, then user, alphabetical within each group
+        return matches.sorted { a, b in
+            let scopeOrder = ["project": 0, "user": 1]
+            let aOrder = scopeOrder[a.scope] ?? 2
+            let bOrder = scopeOrder[b.scope] ?? 2
+            if aOrder != bOrder { return aOrder < bOrder }
+            return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+        }
+    }
+
+    var body: some View {
+        let items = filteredCommands
+        if items.isEmpty {
+            EmptyView()
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(items.enumerated()), id: \.element.name) { index, cmd in
+                        let showHeader = index == 0 || items[index - 1].scope != cmd.scope
+
+                        if showHeader {
+                            sectionHeader(cmd.scope)
+                        }
+
+                        commandRow(cmd)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 260)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .shadow(color: .black.opacity(0.15), radius: 8, y: -2)
+            .padding(.horizontal)
+        }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ scope: String) -> some View {
+        Text(scope == "project" ? "Project" : "User")
+            .font(.caption2)
+            .fontWeight(.medium)
+            .textCase(.uppercase)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 2)
+    }
+
+    private func commandRow(_ cmd: DiscoveredSlashCommand) -> some View {
+        Button {
+            onSelect(cmd)
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: cmd.scope == "project" ? "folder.fill" : "person.fill")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 20)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("/\(cmd.name)")
+                        .font(.system(.caption, design: .monospaced))
+                        .fontWeight(.medium)
+                        .foregroundStyle(.primary)
+
+                    if !cmd.description.isEmpty {
+                        Text(cmd.description)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/ios/IonRemote/Views/TabListView.swift
+++ b/ios/IonRemote/Views/TabListView.swift
@@ -6,6 +6,8 @@ struct TabListView: View {
     @State private var showNewTab = false
     @State private var navigationPath = NavigationPath()
     @State private var enginePickerDirectory: String? = nil
+    @State private var renamingTabId: String?
+    @State private var renameText: String = ""
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -17,6 +19,12 @@ struct TabListView: View {
                                 TabRowView(tab: tab, showDirectory: viewModel.tabGroupMode == "manual")
                             }
                             .contextMenu {
+                                Button {
+                                    renameText = tab.displayTitle
+                                    renamingTabId = tab.id
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
                                 if viewModel.tabGroupMode == "manual" {
                                     let targets = viewModel.tabGroups.filter { $0.id != tab.groupId }
                                     if !targets.isEmpty {
@@ -76,6 +84,24 @@ struct TabListView: View {
                 }
             }
             .navigationTitle("Ion")
+            .alert("Rename Tab", isPresented: .init(
+                get: { renamingTabId != nil },
+                set: { if !$0 { renamingTabId = nil } }
+            )) {
+                TextField("Name", text: $renameText)
+                Button("Rename") {
+                    if let id = renamingTabId {
+                        let title = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+                        viewModel.renameTab(tabId: id, customTitle: title.isEmpty ? nil : title)
+                    }
+                    renamingTabId = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    renamingTabId = nil
+                }
+            } message: {
+                Text("Enter a new name for this tab.")
+            }
             .navigationDestination(for: String.self) { tabId in
                 if viewModel.tab(for: tabId)?.isEngine == true {
                     EngineView(tabId: tabId)


### PR DESCRIPTION
- **feat(desktop): auto-move tabs on remote mode change**
- **feat(ios): use block-based markdown rendering**
- **feat(desktop): add discover_commands remote protocol**
- **feat(ios): add slash command autocomplete**
- **feat(ios): add tab renaming via context menu**
- **feat(ios): add pink border to messages starting with '! '**
- **feat(ios): add markdown rendering to user message bubbles**
- **feat(desktop): add cmd+click links in terminal output**
