### PR TITLE
fix(desktop): fix _getLanConnectionForDevice to return rekeyed device.id

### DIFF
--- a/desktop/src/main/remote/transport.ts
+++ b/desktop/src/main/remote/transport.ts
@@ -545,6 +545,9 @@ export class RemoteTransport extends EventEmitter {
 
   /** Get the LAN connectionId for a device, if it has an authenticated LAN connection. */
   private _getLanConnectionForDevice(deviceId: string): string | null {
+    // After auth, rekeyClient() moves the WebSocket from "lan-N" to device.id
+    // in LANServer.clients. Prefer device.id directly so send() finds the socket.
+    if (this.lanDeviceMap.has(deviceId)) return deviceId
     for (const [connectionId, devId] of this.lanDeviceMap) {
       if (devId === deviceId) return connectionId
     }


### PR DESCRIPTION
## Problem

After LAN auth completes, `rekeyClient()` moves the WebSocket entry from `"lan-N"` to `device.id` in `LANServer.clients`. The `_getLanConnectionForDevice` loop iterated in insertion order and returned `"lan-N"` first. `hasClient("lan-N")` was then `false`, so `lan.send()` returned silently without delivering the snapshot.

Result: iOS received no snapshot after LAN auth and remained stuck at `.connecting` indefinitely.

## Fix

Check `lanDeviceMap.has(deviceId)` directly before falling back to the linear scan. After rekeying, the device ID is already the connection ID, so the direct lookup finds the socket immediately.

```ts
if (this.lanDeviceMap.has(deviceId)) return deviceId
```

## Testing

- iOS app connects over LAN
- After auth handshake completes, snapshot arrives and app transitions from `.connecting` to `.connected`
- No regression on relay path (relay doesn't use `_getLanConnectionForDevice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)