### PR TITLE
fix(ios): transport stability fixes — Bonjour crashes, auth timeout, reconnect lifecycle

### DIFF
--- a/ios/IonRemote/App/IonRemoteApp.swift
+++ b/ios/IonRemote/App/IonRemoteApp.swift
@@ -5,6 +5,7 @@ struct IonRemoteApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var viewModel = SessionViewModel()
     @Environment(\.scenePhase) private var scenePhase
+    @State private var didGoToBackground = false
 
     var body: some Scene {
         WindowGroup {
@@ -17,11 +18,24 @@ struct IonRemoteApp: App {
                 .onChange(of: scenePhase) { _, newPhase in
                     switch newPhase {
                     case .active:
-                        if viewModel.connectionState == .disconnected
-                            && !viewModel.pairedDevices.isEmpty {
-                            viewModel.reconnect()
+                        guard !viewModel.pairedDevices.isEmpty else { break }
+                        if didGoToBackground {
+                            didGoToBackground = false
+                            // Returning from a true app switch (went through .background).
+                            // disconnect() already fired; only reconnect if a retry loop
+                            // hasn't already started a new attempt.
+                            if viewModel.connectionState == .disconnected {
+                                viewModel.reconnect()
+                            }
+                        } else {
+                            // Returning from screen lock (.inactive only, no .background).
+                            // Reconnect on any non-connected state to recover silent relay drops.
+                            if viewModel.connectionState != .connected {
+                                viewModel.reconnect()
+                            }
                         }
                     case .background:
+                        didGoToBackground = true
                         viewModel.disconnect()
                     default:
                         break
@@ -73,16 +87,30 @@ struct ContentView: View {
             .font(.footnote)
             .padding(.bottom, 32)
         }
-        .task(id: viewModel.connectionState == .disconnected) {
-            // Auto-retry every 5 seconds while on the disconnected screen.
-            guard viewModel.connectionState == .disconnected,
-                  !viewModel.pairedDevices.isEmpty else { return }
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(5))
-                guard !Task.isCancelled,
-                      viewModel.connectionState == .disconnected,
-                      !viewModel.pairedDevices.isEmpty else { break }
-                viewModel.reconnect()
+        .task(id: viewModel.connectionState) {
+            guard !viewModel.pairedDevices.isEmpty else { return }
+            switch viewModel.connectionState {
+            case .disconnected:
+                // Auto-retry every 5 seconds while on the disconnected screen.
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(5))
+                    guard !Task.isCancelled,
+                          viewModel.connectionState == .disconnected else { break }
+                    viewModel.reconnect()
+                }
+            case .connecting, .reconnecting:
+                // Break out of a stuck handshake after 15 seconds and keep retrying.
+                // Loop because reconnect() may batch .connecting→.disconnected→.connecting
+                // in a single SwiftUI update so .task(id:) wouldn't restart.
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(15))
+                    guard !Task.isCancelled,
+                          viewModel.connectionState == .connecting
+                              || viewModel.connectionState == .reconnecting else { return }
+                    viewModel.reconnect()
+                }
+            default:
+                break
             }
         }
     }

--- a/ios/IonRemote/Networking/LANClient.swift
+++ b/ios/IonRemote/Networking/LANClient.swift
@@ -72,7 +72,6 @@ final class LANClient {
         self.task = wsTask
 
         wsTask.resume()
-        isConnected = true
         receiveLoop(wsTask)
     }
 
@@ -101,6 +100,7 @@ final class LANClient {
 
             switch result {
             case .success(let message):
+                if !self.isConnected { self.isConnected = true }
                 switch message {
                 case .data(let data):
                     self.messageContinuation?.yield(data)

--- a/ios/IonRemote/Networking/TransportManager+Receive.swift
+++ b/ios/IonRemote/Networking/TransportManager+Receive.swift
@@ -58,8 +58,10 @@ extension TransportManager {
                 guard !Task.isCancelled, let self else { break }
                 self.handleIncomingData(data, isRelay: false)
             }
-            // LAN stream ended -- the WebSocket closed.
-            // Emit peerDisconnected if we have no relay fallback.
+            // LAN stream ended naturally -- emit peerDisconnected if no relay fallback.
+            // Skip if cancelled (transport.stop() was called): yielding peerDisconnected
+            // here would call disconnect() and clobber a new connection being set up.
+            guard !Task.isCancelled else { return }
             if let self, self.relay == nil || !(self.relay?.isConnected ?? false) {
                 self.eventContinuation.yield(.peerDisconnected)
             }

--- a/ios/IonRemote/Networking/TransportManager+Send.swift
+++ b/ios/IonRemote/Networking/TransportManager+Send.swift
@@ -27,8 +27,23 @@ extension TransportManager {
 
     /// Perform challenge-response authentication on the active LAN connection.
     /// Waits for AuthChallenge from Ion, proves we hold the shared secret,
-    /// and waits for AuthResult.
+    /// and waits for AuthResult. Races against an 8-second timeout.
     func performLANAuth() async -> Bool {
+        await withTaskGroup(of: Bool.self) { [weak self] group in
+            guard let self else { return false }
+            group.addTask { await self.performLANAuthCore() }
+            group.addTask { [weak self] in
+                try? await Task.sleep(for: .seconds(8))
+                self?.lan.disconnect()
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func performLANAuthCore() async -> Bool {
         // Wait for the first message (should be AuthChallenge).
         for await data in lan.messages {
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/ios/IonRemote/Networking/TransportManager+Send.swift
+++ b/ios/IonRemote/Networking/TransportManager+Send.swift
@@ -34,6 +34,7 @@ extension TransportManager {
             group.addTask { await self.performLANAuthCore() }
             group.addTask { [weak self] in
                 try? await Task.sleep(for: .seconds(8))
+                guard !Task.isCancelled else { return false }
                 self?.lan.disconnect()
                 return false
             }

--- a/ios/IonRemote/Networking/TransportManager+Send.swift
+++ b/ios/IonRemote/Networking/TransportManager+Send.swift
@@ -93,10 +93,10 @@ extension TransportManager {
     // MARK: - Wire message builder
 
     func buildWireMessage(payload: Data) throws -> WireMessage {
-        seqLock.lock()
-        seq += 1
-        let currentSeq = seq
-        seqLock.unlock()
+        let currentSeq = _seqLock.withLock { state -> UInt64 in
+            state += 1
+            return state
+        }
 
         let (nonce, ciphertext) = try E2ECrypto.encrypt(plaintext: payload, key: sharedKey)
         return WireMessage(

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -325,23 +325,25 @@ final class TransportManager {
         let monitor = NWPathMonitor()
         self.pathMonitor = monitor
 
+        var isFirstUpdate = true
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self, !self.isStopped else { return }
+            defer { isFirstUpdate = false }
 
             if path.status == .satisfied {
                 // Network restored. Reconnect relay if needed.
                 if let relay, !relay.isConnected, !relay.isConnecting {
-                    print("[Ion] networkMonitor: path satisfied, relay NOT connected -- reconnecting")
-                    Task { @MainActor in
-                        await relay.connect()
-                    }
-                } else {
-                    print("[Ion] networkMonitor: path satisfied, relay connected=\(self.relay?.isConnected ?? false) connecting=\(self.relay?.isConnecting ?? false)")
+                    Task { @MainActor in await relay.connect() }
                 }
-                // Restart Bonjour to re-discover LAN hosts.
-                self.bonjour.startBrowsing()
+                // Restart Bonjour only when recovering from a real outage:
+                // - Skip the first callback (fires immediately on monitor.start(),
+                //   resetting browsers we just started in start()).
+                // - Skip when LAN is already connected (path changes as TCP
+                //   establishes would clear discoveredHosts and fake a disconnect).
+                if !isFirstUpdate && self.state != .lanPreferred {
+                    self.bonjour.startBrowsing()
+                }
             } else {
-                // Network lost.
                 self.updateState()
             }
         }

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -299,6 +299,11 @@ final class TransportManager {
                         let authed = await self.startLANWithAuth(host: host.host, port: host.port)
                         if authed {
                             didRestartBrowser = false
+                            do {
+                                try await self.send(.sync)
+                            } catch {
+                                print("[Ion] bonjour auth ok but sync failed: \(error)")
+                            }
                         } else {
                             self.currentLANHost = nil
                         }

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -117,7 +117,7 @@ final class TransportManager {
     func start() async {
         guard !isStopped else { return }
 
-        bonjour.startBrowsing()
+        await MainActor.run { self.bonjour.startBrowsing() }
         startBonjourObservation()
 
         if let relay {
@@ -155,7 +155,6 @@ final class TransportManager {
             startLANListener()
             startLANStateObservation()
             startNetworkMonitor()
-            bonjour.startBrowsing()
             startBonjourObservation()
             setState(.lanPreferred)
         } else {
@@ -267,7 +266,7 @@ final class TransportManager {
             while !Task.isCancelled {
                 guard let self else { break }
 
-                let hosts = self.bonjour.discoveredHosts
+                let hosts = await MainActor.run { self.bonjour.discoveredHosts }
                 let countChanged = hosts.count != lastKnownCount
                 if countChanged {
                     lastKnownCount = hosts.count
@@ -290,7 +289,7 @@ final class TransportManager {
                 if needsConnect, hosts.first(where: { $0.kind == .ionDirect }) == nil, !didRestartBrowser {
                     didRestartBrowser = true
                     lastKnownCount = 0
-                    self.bonjour.startBrowsing()
+                    await MainActor.run { self.bonjour.startBrowsing() }
                 }
 
                 if countChanged || needsConnect {

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import CryptoKit
 import Network
 import Observation
+import os
 
 // MARK: - TransportState
 
@@ -58,8 +59,7 @@ final class TransportManager {
     /// Set by `stop()` to prevent a deferred `start()` Task from
     /// resurrecting a transport that was already torn down.
     private(set) var isStopped = false
-    var seq: UInt64 = 0
-    let seqLock = NSLock()
+    let _seqLock = OSAllocatedUnfairLock(initialState: UInt64(0))
     var lastReceivedSeq: UInt64 = 0
     let eventContinuation: AsyncStream<RemoteEvent>.Continuation
     var relayListenTask: Task<Void, Never>?
@@ -151,7 +151,7 @@ final class TransportManager {
             )
             // Reset dedup for fresh connection
             lastReceivedSeq = 0
-            seq = 0
+            _seqLock.withLock { state in state = 0 }
             startLANListener()
             startLANStateObservation()
             startNetworkMonitor()

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -20,7 +20,10 @@ extension SessionViewModel {
                 await self.eventBatcher.enqueue(event)
             }
 
-            // Stream ended -- flush any remaining events then wipe state
+            // Stream ended naturally -- flush remaining events and wipe state.
+            // Skip if cancelled (disconnect/reconnect): connect() may have already
+            // advanced connectionState to .connecting and we must not clobber it.
+            guard !Task.isCancelled else { return }
             let remaining = await self.eventBatcher.drain()
             await MainActor.run {
                 for event in remaining {

--- a/ios/commands/install.command
+++ b/ios/commands/install.command
@@ -12,10 +12,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-TEAM_ID="P6UU9VHF7D"
+TEAM_ID="837B5TTFJK"
 SCHEME="IonRemote"
 PROJECT="IonRemote.xcodeproj"
-BUNDLE_ID="com.sprague.ion.mobile"
+BUNDLE_ID="com.geektechlive.ion.mobile"
 CONFIGURATION="Debug"
 DEVICE_ID=""
 

--- a/ios/commands/install.command
+++ b/ios/commands/install.command
@@ -12,10 +12,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-TEAM_ID="837B5TTFJK"
+TEAM_ID="P6UU9VHF7D"
 SCHEME="IonRemote"
 PROJECT="IonRemote.xcodeproj"
-BUNDLE_ID="com.geektechlive.ion.mobile"
+BUNDLE_ID="com.sprague.ion.mobile"
 CONFIGURATION="Debug"
 DEVICE_ID=""
 


### PR DESCRIPTION
## Summary

A batch of iOS transport and lifecycle fixes found while running Ion Remote in production. Each addresses a distinct failure mode.

---

### 1. BonjourBrowser main actor crash (`TransportManager.swift`)

All IonRemote crashes (SIGABRT/SIGSEGV in `BonjourBrowser.stopBrowsing()`) were concurrent dictionary mutations from background `Task`s and the main-queue `NWPathMonitor` handler. `NWBrowser` callbacks already fire on `.main`; callers must dispatch there too.

- `start()`: wrap `bonjour.startBrowsing()` in `await MainActor.run`
- `startBonjourObservation()`: dispatch both `discoveredHosts` read and `startBrowsing()` call to main actor
- Remove redundant `bonjour.startBrowsing()` from `startLANWithAuth()` (browser already running)

---

### 2. Path monitor triggers spurious Bonjour restart (`TransportManager.swift`)

`NWPathMonitor` fires immediately on `monitor.start()` with the current path. That first callback called `bonjour.startBrowsing()` which clears `discoveredHosts`, making the Bonjour poll loop treat a live connection as a disappearance. Fix:

- `isFirstUpdate` flag: skip the immediate initial callback
- Guard `state != .lanPreferred`: skip restart when already connected via LAN (TCP establishment also fires a path change)

---

### 3. Bonjour LAN auth: send sync + 8-second timeout (`TransportManager.swift`, `TransportManager+Send.swift`)

Two fixes for the Bonjour-initiated LAN auth path:

- **Sync after auth**: `startBonjourObservation()` now sends `.sync` after a successful LAN auth handshake, so the desktop emits a snapshot and `connectionState` advances past `.connecting`. Previously only the relay path sent sync; the Bonjour path didn't.
- **Auth timeout**: `performLANAuth()` races the auth exchange against an 8-second timeout via `withTaskGroup`. The timeout branch calls `lan.disconnect()` to close the `AsyncStream` and unblock the waiting task.

---

### 4. Auth timeout cancel guard (`TransportManager+Send.swift`)

When `performLANAuth()` succeeds before the 8-second timeout fires, `group.cancelAll()` cancels the timeout task. `try? await Task.sleep` swallows `CancellationError`, so `lan.disconnect()` would still fire on a live connection. Fix: add `guard !Task.isCancelled` before calling `lan.disconnect()`.

---

### 5. Cancelled task cleanup (`TransportManager+Receive.swift`, `SessionViewModel+EventHandlers.swift`)

After `reconnect()`, the old receive loop and event handler `Task`s are cancelled. Before cancellation propagates, deferred cleanup code was emitting `peerDisconnected` and wipe-state calls, racing with the new connection's setup and causing a connect/disconnect loop. Fix: guard with `!Task.isCancelled` before any cleanup side effect.

---

### 6. `LANClient.isConnected` set on first message (`LANClient.swift`)

`connect()` set `isConnected = true` immediately on `wsTask.resume()`, before any data arrived. The previous guard `guard lan.isConnected else { return false }` in `startLANWithAuth()` always saw `true` but the stream hadn't started yet. After removing that premature guard, `isConnected` now becomes `true` on the first successfully received message, which is the correct invariant.

---

### 7. `OSAllocatedUnfairLock` for sequence counter (`TransportManager.swift`, `TransportManager+Send.swift`)

Replace `var seq: UInt64 = 0` + `NSLock seqLock` with `OSAllocatedUnfairLock(initialState: UInt64(0))`. `NSLock` is not `Sendable`-safe; `OSAllocatedUnfairLock` is the Swift 6-recommended primitive for protecting a single value across concurrent access.

---

### 8. Reconnect after screen lock (`IonRemoteApp.swift`)

`scenePhase` only reaches `.inactive` (not `.background`) on screen lock. The previous `.active` guard checked `connectionState == .disconnected`, so if a reconnect was already in progress when the screen locked, returning from lock left the app stuck at `.connecting` forever. Fix: when returning from `.inactive` (screen lock path), reconnect on any non-`.connected` state.

Also adds a `didGoToBackground` flag to distinguish screen lock from app switch. On app-switch return, reconnect only if fully `.disconnected` — the background task's `disconnect() → reconnect()` sequence is already in flight.

---

### 9. Escape hatch for stuck `.connecting` state (`IonRemoteApp.swift`)

Changes `.task(id:)` from `id: connectionState == .disconnected` (bool) to `id: connectionState` (full enum), enabling per-state handling. Adds a `.connecting/.reconnecting` case that retries every 15 seconds, guarded by `!Task.isCancelled`. Handles the edge case where `reconnect()` transitions `.connecting → .disconnected → .connecting` synchronously so SwiftUI batches the change and `.task(id:)` never restarts between states.

---

## Testing

- LAN connection: auth succeeds, desktop emits snapshot, app shows tabs
- Auth timeout: if Ion isn't running, timeout fires after 8s, retry loop kicks in
- Screen lock: app reconnects reliably on unlock without getting stuck at `.connecting`
- App switch: no premature disconnect/reconnect when returning from background

🤖 Generated with [Claude Code](https://claude.com/claude-code)