### PR TITLE
Availability fixes and improvements

### DIFF
--- a/desktop/src/renderer/stores/slices/engine-event-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-slice.ts
@@ -281,6 +281,21 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
           })
           break
         }
+        case 'engine_events_dropped': {
+          set((state) => {
+            const notifications = new Map(state.engineNotifications)
+            const keyNotifications = [...(notifications.get(key) || [])]
+            keyNotifications.push({
+              id: nextMsgId(),
+              message: `Connection fell behind — ${event.count} events dropped. State may be stale.`,
+              level: 'warning',
+              timestamp: Date.now(),
+            })
+            notifications.set(key, keyNotifications)
+            return { engineNotifications: notifications }
+          })
+          break
+        }
       }
     },
   }

--- a/desktop/src/shared/types-engine.ts
+++ b/desktop/src/shared/types-engine.ts
@@ -78,4 +78,5 @@ export type EngineEvent =
   | { type: 'engine_tool_stalled'; toolId: string; toolName: string; toolElapsed: number }
   | { type: 'engine_extension_died'; extensionName: string; exitCode: number | null; signal: string | null }
   | { type: 'engine_extension_respawned'; extensionName: string; attemptNumber: number }
+  | { type: 'engine_events_dropped'; count: number }
   | { type: 'engine_extension_dead_permanent'; extensionName: string; attemptNumber: number }

--- a/docs/architecture/relay.md
+++ b/docs/architecture/relay.md
@@ -80,7 +80,7 @@ Every WebSocket upgrade request must include a valid Bearer token. The relay com
 
 ### Origin rejection
 
-The relay rejects WebSocket upgrades with an `Origin` header that does not match expected patterns. This prevents browser-based cross-origin attacks.
+The relay rejects WebSocket upgrades that include an `Origin` header. Native clients (engine, iOS) do not send this header; browsers do. This prevents browser-based cross-origin attacks.
 
 ### End-to-end encryption
 
@@ -100,4 +100,4 @@ mDNS is best-effort. If it fails to start (common in containers without host net
 
 When all three APNs environment variables are configured (`APNS_KEY_PATH`, `APNS_KEY_ID`, `APNS_TEAM_ID`), the relay can send push notifications to wake the iOS app when a message arrives and the mobile peer is disconnected.
 
-This is a background push (content-available), not a user-visible notification. It wakes the app so it can reconnect to the relay and receive the pending message.
+This is a user-visible alert notification (with title, body, and sound) that also sets `content-available` to wake the app in the background.

--- a/docs/architecture/relay.md
+++ b/docs/architecture/relay.md
@@ -36,6 +36,7 @@ Key behaviors:
 - Second peer joins the existing channel
 - If a peer reconnects, it replaces the previous connection for that role
 - Messages are forwarded synchronously (no buffering or queuing)
+- Messages are forwarded with `permessage-deflate` compression when the client supports it
 
 ## Protocol
 
@@ -54,6 +55,8 @@ The relay validates the Bearer token against `RELAY_API_KEY` before upgrading to
 
 Once connected, all WebSocket frames from one peer are forwarded to the other peer on the same channel. The relay treats every frame as opaque bytes. It does not parse, validate, or transform the content.
 
+The relay offers `permessage-deflate` compression during the WebSocket handshake. Both the engine client and iOS client negotiate compression automatically.
+
 ### Health
 
 ```
@@ -62,6 +65,12 @@ GET /healthz
 ```
 
 No authentication required.
+
+## Keepalive
+
+The relay sends WebSocket ping frames every 30 seconds (configurable via `RELAY_PING_INTERVAL_S`) to detect dead connections. If no pong arrives within 10 seconds (configurable via `RELAY_PING_TIMEOUT_S`), the connection is closed.
+
+All relay timeouts (write, ping interval, ping timeout, max message size) are configurable via environment variables. See [Relay Deployment](../deployment/relay.md) for the full list.
 
 ## Security
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -81,7 +81,7 @@ ion prompt "text" [--model M] [--max-turns N] [--max-budget USD] [--output FORMA
 | `--extension` | No | -- | Path to extension directory |
 | `--no-extensions` | No | false | Skip all extensions for this prompt |
 | `--attach` | No | false | Stream output until idle (non-ephemeral sessions) |
-| `--timeout` | No | -- | Wall-clock deadline for the prompt (e.g. `60s`, `5m`, `2h`). For ephemeral prompts, the engine aborts the in-progress run before cleanup. For keyed sessions with `--attach`, the CLI disconnects but the engine session continues. Exit code 124. |
+| `--timeout` | No | -- | Wall-clock deadline (e.g. `60s`, `5m`, `2h`). Applies to `text` and `stream-json` output modes. For ephemeral prompts, the engine aborts the in-progress run before cleanup. For keyed sessions, the CLI disconnects but the engine session continues. Exit code 124. Not applicable to `json` output (returns immediately). |
 
 #### Output formats
 
@@ -89,7 +89,7 @@ ion prompt "text" [--model M] [--max-turns N] [--max-budget USD] [--output FORMA
 
 **`json`**: Returns the raw command response as indented JSON. Does not stream.
 
-**`stream-json`**: Streams all engine events as NDJSON to stdout. Includes text deltas, tool use, status changes, and errors. Does not exit automatically; connect to watch the full event stream.
+**`stream-json`**: Streams all engine events as NDJSON to stdout. Includes text deltas, tool use, status changes, and errors. Continues until the connection closes or `--timeout` fires (exit 124).
 
 #### Examples
 
@@ -180,6 +180,54 @@ Returns the shutdown acknowledgment as JSON, then the daemon exits.
 
 ---
 
+### `ion health`
+
+Probe daemon liveness.
+
+```bash
+ion health
+```
+
+Returns a JSON health report with version, uptime, and session count. Exits 0 if the daemon is healthy, 1 if it's down or unhealthy.
+
+```bash
+# Use in scripts or monitoring
+ion health && echo "Engine is running"
+
+# Pretty-print the health report
+ion health | jq .
+```
+
+---
+
+### `ion upgrade`
+
+Upgrade the engine to the latest release.
+
+```bash
+ion upgrade
+```
+
+Downloads the latest release from GitHub, verifies the SHA-256 checksum, and atomically replaces the running binary. Development builds (`version = "dev"`) cannot be upgraded — install a release build first.
+
+```bash
+# Check and upgrade
+ion upgrade
+# Checking for updates...
+# Update available: 0.1.0 → 0.2.0
+# Downloading ion-darwin-arm64...
+# Checksum verified.
+# Upgraded: 0.1.0 → 0.2.0
+```
+
+If already on the latest version:
+
+```
+Already up to date: 0.2.0
+```
+
+---
+
 ### `ion record`
 
 Record session events to an NDJSON file.
@@ -238,13 +286,13 @@ These flags are recognized by `ion prompt`. Other commands accept subsets as doc
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--model` | string | config default (`claude-sonnet-4-6`) | LLM model identifier |
-| `--max-turns` | int | 50 | Maximum agent loop iterations |
+| `--max-turns` | int | 50 (server default) | Maximum agent loop iterations. Applied server-side; if not specified, the engine uses its built-in default of 50. |
 | `--max-budget` | float | unlimited | Maximum spend in USD |
 | `--output` | string | `text` | Output format (`text`, `json`, `stream-json`) |
 | `--key` | string | -- | Session key |
 | `--extension` | string | -- | Extension directory path (supports `~` expansion) |
 | `--no-extensions` | bool | false | Skip all extensions |
-| `--timeout` | duration | -- | Wall-clock deadline for `ion prompt` (e.g. `60s`, `5m`). Exit 124 on timeout. |
+| `--timeout` | duration | -- | Wall-clock deadline for `ion prompt` (e.g. `60s`, `5m`). Applies to `text` and `stream-json` modes. Exit 124 on timeout. |
 | `--attach` | bool | false | Stream output until idle (keyed sessions) |
 
 ## Daemon auto-start

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -81,7 +81,7 @@ ion prompt "text" [--model M] [--max-turns N] [--max-budget USD] [--output FORMA
 | `--extension` | No | -- | Path to extension directory |
 | `--no-extensions` | No | false | Skip all extensions for this prompt |
 | `--attach` | No | false | Stream output until idle (non-ephemeral sessions) |
-| `--timeout` | No | -- | Wall-clock deadline for the prompt (e.g. `60s`, `5m`, `2h`). When exceeded, the engine aborts the run and the CLI exits with code 124. |
+| `--timeout` | No | -- | Wall-clock deadline for the prompt (e.g. `60s`, `5m`, `2h`). For ephemeral prompts, the engine aborts the in-progress run before cleanup. For keyed sessions with `--attach`, the CLI disconnects but the engine session continues. Exit code 124. |
 
 #### Output formats
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -68,7 +68,7 @@ ion start --profile backend --dir . --key api-session --extension ~/.ion/extensi
 Send a prompt to the engine. If no daemon is running, one is auto-started. If no `--key` is provided, an ephemeral session is created, used, and cleaned up.
 
 ```bash
-ion prompt "text" [--model M] [--max-turns N] [--max-budget USD] [--output FORMAT] [--key KEY] [--extension PATH] [--no-extensions]
+ion prompt "text" [--model M] [--max-turns N] [--max-budget USD] [--output FORMAT] [--key KEY] [--extension PATH] [--no-extensions] [--attach] [--timeout DURATION]
 ```
 
 | Flag | Required | Default | Description |
@@ -80,6 +80,8 @@ ion prompt "text" [--model M] [--max-turns N] [--max-budget USD] [--output FORMA
 | `--key` | No | (ephemeral) | Target session key |
 | `--extension` | No | -- | Path to extension directory |
 | `--no-extensions` | No | false | Skip all extensions for this prompt |
+| `--attach` | No | false | Stream output until idle (non-ephemeral sessions) |
+| `--timeout` | No | -- | Wall-clock deadline for the prompt (e.g. `60s`, `5m`, `2h`). When exceeded, the engine aborts the run and the CLI exits with code 124. |
 
 #### Output formats
 
@@ -106,6 +108,9 @@ ion prompt "hello" --output stream-json
 
 # Skip extensions
 ion prompt "hello" --no-extensions
+
+# CI/scripting: fail if not done in 5 minutes
+ion prompt "run the test suite" --timeout 5m
 ```
 
 ---
@@ -239,6 +244,8 @@ These flags are recognized by `ion prompt`. Other commands accept subsets as doc
 | `--key` | string | -- | Session key |
 | `--extension` | string | -- | Extension directory path (supports `~` expansion) |
 | `--no-extensions` | bool | false | Skip all extensions |
+| `--timeout` | duration | -- | Wall-clock deadline for `ion prompt` (e.g. `60s`, `5m`). Exit 124 on timeout. |
+| `--attach` | bool | false | Stream output until idle (keyed sessions) |
 
 ## Daemon auto-start
 
@@ -266,3 +273,4 @@ This makes `ion prompt` fully self-contained for one-shot use. For persistent se
 |------|---------|
 | 0 | Success |
 | 1 | Error (connection failed, invalid arguments, engine error) |
+| 124 | Timeout (prompt exceeded `--timeout` deadline) |

--- a/docs/configuration/engine-json.md
+++ b/docs/configuration/engine-json.md
@@ -300,20 +300,20 @@ Tune every internal timeout and retry limit. All duration fields are in millisec
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `toolDefaultMs` | int | `300000` (5 min) | Per-tool execution timeout. Applies to built-in tools unless a tool-specific timeout overrides it. |
-| `toolStallMs` | int | `30000` (30 s) | Stall detection threshold. If a tool produces no output for this long, the engine logs a warning. |
-| `bashDefaultMs` | int | `120000` (2 min) | Default timeout for `Bash` tool commands. Overridable per-call via the tool's `timeout` parameter. |
-| `mcpCallMs` | int | `60000` (60 s) | MCP tool call timeout. How long the engine waits for an MCP server to return a tool result. |
-| `mcpMetadataMs` | int | `30000` (30 s) | MCP metadata operation timeout (`initialize`, `listTools`, `listResources`, `readResource`). |
-| `mcpWriteMs` | int | `30000` (30 s) | MCP WebSocket write timeout. How long a write to an MCP server's WebSocket can block. |
-| `webFetchMs` | int | `30000` (30 s) | HTTP request timeout for the `WebFetch` tool. |
-| `globMs` | int | `60000` (60 s) | Filesystem walk timeout for the `Glob` tool. |
-| `sshDefaultMs` | int | `120000` (2 min) | Default timeout for SSH operations. |
-| `extensionRpcMs` | int | `30000` (30 s) | How long the engine waits for an extension to respond to an RPC call (init, hook, tool, command). |
-| `hookDefaultMs` | int | `30000` (30 s) | Default timeout for external hook execution. |
-| `elicitationMs` | int | `300000` (5 min) | How long the engine waits for user input during an elicitation dialog. |
-| `relayWriteMs` | int | `10000` (10 s) | Write timeout when forwarding messages to the relay server. |
-| `broadcastWriteMs` | int | `5000` (5 s) | Write timeout for broadcasting events to connected socket clients. |
+| `toolDefaultMs` | int64 | `300000` (5 min) | Per-tool execution timeout. Applies to built-in tools unless a tool-specific timeout overrides it. |
+| `toolStallMs` | int64 | `30000` (30 s) | Stall detection threshold. If a tool produces no output for this long, the engine logs a warning. |
+| `bashDefaultMs` | int64 | `120000` (2 min) | Default timeout for `Bash` tool commands. Overridable per-call via the tool's `timeout` parameter. |
+| `mcpCallMs` | int64 | `60000` (60 s) | MCP tool call timeout. How long the engine waits for an MCP server to return a tool result. |
+| `mcpMetadataMs` | int64 | `30000` (30 s) | MCP metadata operation timeout (`initialize`, `listTools`, `listResources`, `readResource`). |
+| `mcpWriteMs` | int64 | `30000` (30 s) | MCP WebSocket write timeout. How long a write to an MCP server's WebSocket can block. |
+| `webFetchMs` | int64 | `30000` (30 s) | HTTP request timeout for the `WebFetch` tool. |
+| `globMs` | int64 | `60000` (60 s) | Filesystem walk timeout for the `Glob` tool. |
+| `sshDefaultMs` | int64 | `120000` (2 min) | Default timeout for SSH operations. |
+| `extensionRpcMs` | int64 | `30000` (30 s) | How long the engine waits for an extension to respond to an RPC call (init, hook, tool, command). |
+| `hookDefaultMs` | int64 | `30000` (30 s) | Default timeout for external hook execution. |
+| `elicitationMs` | int64 | `300000` (5 min) | How long the engine waits for user input during an elicitation dialog. |
+| `relayWriteMs` | int64 | `10000` (10 s) | Write timeout when forwarding messages to the relay server. |
+| `broadcastWriteMs` | int64 | `5000` (5 s) | Write timeout for broadcasting events to connected socket clients. |
 | `truncationRetries` | int | `3` | Maximum consecutive retries when the LLM response is truncated (hits `max_tokens`). |
 
 These follow the same merge semantics as other config fields: higher-priority layers override lower ones. Zero means "use the compiled default."

--- a/docs/configuration/engine-json.md
+++ b/docs/configuration/engine-json.md
@@ -294,6 +294,41 @@ WebSocket relay connection for mobile remote access.
 | `apiKey` | string | `""` | Bearer token for relay authentication. |
 | `channelId` | string | `""` | 32-character hex channel identifier. |
 
+## timeouts
+
+Tune every internal timeout and retry limit. All duration fields are in milliseconds. Omit a field (or set to `0`) to use the compiled default. See [Limits](limits.md) for turn and budget limits; this section covers operational timeouts.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `toolDefaultMs` | int | `300000` (5 min) | Per-tool execution timeout. Applies to built-in tools unless a tool-specific timeout overrides it. |
+| `toolStallMs` | int | `30000` (30 s) | Stall detection threshold. If a tool produces no output for this long, the engine logs a warning. |
+| `bashDefaultMs` | int | `120000` (2 min) | Default timeout for `Bash` tool commands. Overridable per-call via the tool's `timeout` parameter. |
+| `mcpCallMs` | int | `60000` (60 s) | MCP tool call timeout. How long the engine waits for an MCP server to return a tool result. |
+| `mcpMetadataMs` | int | `30000` (30 s) | MCP metadata operation timeout (`initialize`, `listTools`, `listResources`, `readResource`). |
+| `mcpWriteMs` | int | `30000` (30 s) | MCP WebSocket write timeout. How long a write to an MCP server's WebSocket can block. |
+| `webFetchMs` | int | `30000` (30 s) | HTTP request timeout for the `WebFetch` tool. |
+| `globMs` | int | `60000` (60 s) | Filesystem walk timeout for the `Glob` tool. |
+| `sshDefaultMs` | int | `120000` (2 min) | Default timeout for SSH operations. |
+| `extensionRpcMs` | int | `30000` (30 s) | How long the engine waits for an extension to respond to an RPC call (init, hook, tool, command). |
+| `hookDefaultMs` | int | `30000` (30 s) | Default timeout for external hook execution. |
+| `elicitationMs` | int | `300000` (5 min) | How long the engine waits for user input during an elicitation dialog. |
+| `relayWriteMs` | int | `10000` (10 s) | Write timeout when forwarding messages to the relay server. |
+| `broadcastWriteMs` | int | `5000` (5 s) | Write timeout for broadcasting events to connected socket clients. |
+| `truncationRetries` | int | `3` | Maximum consecutive retries when the LLM response is truncated (hits `max_tokens`). |
+
+These follow the same merge semantics as other config fields: higher-priority layers override lower ones. Zero means "use the compiled default."
+
+```json
+{
+  "timeouts": {
+    "toolDefaultMs": 300000,
+    "mcpCallMs": 120000,
+    "bashDefaultMs": 300000,
+    "extensionRpcMs": 60000
+  }
+}
+```
+
 ## featureFlags
 
 Feature flag source configuration.
@@ -360,6 +395,10 @@ A multi-provider configuration mixing a local Ollama model with a hosted OpenAI 
   },
   "security": {
     "redactSecrets": true
+  },
+  "timeouts": {
+    "mcpCallMs": 120000,
+    "extensionRpcMs": 60000
   },
   "telemetry": {
     "enabled": false

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -90,3 +90,21 @@ MCP servers configured with `type: "stdio"` can receive custom environment varia
 ```
 
 These variables are only visible to the MCP server subprocess and do not affect the engine process.
+
+## Relay server
+
+The relay server (a separate Go binary, not part of the engine) reads its configuration from environment variables. These are documented here for convenience; the relay is deployed independently.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RELAY_API_KEY` | -- (required) | Hex secret for Bearer authentication. Generate with `openssl rand -hex 32`. |
+| `RELAY_PORT` | `8443` | Listen port. |
+| `RELAY_WRITE_TIMEOUT_MS` | `10000` | Write timeout in milliseconds when forwarding messages to a peer. |
+| `RELAY_PING_INTERVAL_S` | `30` | Interval in seconds between WebSocket keepalive pings. |
+| `RELAY_PING_TIMEOUT_S` | `10` | Maximum seconds to wait for a pong response before closing the connection. |
+| `RELAY_MAX_MESSAGE_SIZE` | `1048576` (1 MB) | Maximum WebSocket message size in bytes. |
+| `APNS_KEY_PATH` | -- | Path to APNs `.p8` key file for iOS push notifications. |
+| `APNS_KEY_ID` | -- | APNs key ID from Apple Developer portal. |
+| `APNS_TEAM_ID` | -- | Apple Developer team ID. |
+
+See [Relay Deployment](../deployment/relay.md) for full deployment instructions.

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -106,5 +106,6 @@ The relay server (a separate Go binary, not part of the engine) reads its config
 | `APNS_KEY_PATH` | -- | Path to APNs `.p8` key file for iOS push notifications. |
 | `APNS_KEY_ID` | -- | APNs key ID from Apple Developer portal. |
 | `APNS_TEAM_ID` | -- | Apple Developer team ID. |
+| `APNS_PRODUCTION` | -- | Set to `1` to use Apple's production APNs endpoint. Default uses the sandbox endpoint. |
 
 See [Relay Deployment](../deployment/relay.md) for full deployment instructions.

--- a/docs/configuration/limits.md
+++ b/docs/configuration/limits.md
@@ -19,7 +19,7 @@ Resource limits control how long an agent session can run and how much it can sp
 | `disableTurnLimitWarning` | bool | unset (`false`) | -- | When `true`, the turn-limit wind-down message is not injected. |
 | `disableMaxTokenContinue` | bool | unset (`false`) | -- | When `true`, the max-tokens continue prompt is not injected. |
 
-The engine ships unopinionated. There is no built-in default cap on turns, budget, or idle timeout. Harness engineers and operators set them via `engine.json`, CLI flags, or per-call options.
+The engine ships unopinionated. There is no built-in default cap on turns or budget. Harness engineers and operators set them via `engine.json`, CLI flags, or per-call options. For operational timeouts (tool execution, MCP calls, extension RPC, etc.), see the [`timeouts`](engine-json.md#timeouts) section.
 
 ## Configuration
 
@@ -131,3 +131,11 @@ Enterprise policy can enforce limit values that lower layers cannot weaken. If t
 | Large refactors | `maxTurns: 200`, `maxBudgetUsd: 50.0` |
 | Background agents | `maxTurns: 500`, `maxBudgetUsd: 100.0` |
 | Unbounded (engine default) | omit both fields |
+
+## Timeouts
+
+Resource limits (turns, budget) control *how much* work a session does. Timeouts control *how long* individual operations take. The two are independent.
+
+Tool execution timeouts, MCP call timeouts, extension RPC timeouts, and other operational timeouts are configured via the `timeouts` block in `engine.json`. See [engine.json Reference — timeouts](engine-json.md#timeouts) for the full field reference.
+
+For CLI prompts, the `--timeout` flag sets a wall-clock deadline for the entire prompt execution. See [CLI Reference](../cli/reference.md#ion-prompt) for details.

--- a/docs/deployment/relay.md
+++ b/docs/deployment/relay.md
@@ -52,6 +52,10 @@ All configuration is through environment variables.
 | `APNS_KEY_PATH` | No | -- | Path to APNs `.p8` key file. |
 | `APNS_KEY_ID` | No | -- | APNs key ID from Apple Developer portal. |
 | `APNS_TEAM_ID` | No | -- | Apple Developer team ID. |
+| `RELAY_WRITE_TIMEOUT_MS` | No | `10000` | Write timeout in milliseconds when forwarding messages to a peer. |
+| `RELAY_PING_INTERVAL_S` | No | `30` | Interval in seconds between WebSocket keepalive pings. |
+| `RELAY_PING_TIMEOUT_S` | No | `10` | Maximum seconds to wait for a pong response before closing the connection. |
+| `RELAY_MAX_MESSAGE_SIZE` | No | `1048576` (1 MB) | Maximum WebSocket message size in bytes. Messages exceeding this limit cause the connection to close. |
 
 APNs is optional. When all three `APNS_*` variables are set, the relay sends push notifications to wake the iOS app when a message arrives on a channel where the mobile peer is disconnected.
 
@@ -149,6 +153,18 @@ spec:
 ```
 
 Use cert-manager or your own TLS provisioning to populate the `relay-tls` secret. The relay itself does not terminate TLS -- that is handled by the ingress controller.
+
+## Keepalive
+
+The relay sends WebSocket ping frames at a configurable interval (default 30 seconds) to detect dead connections. If a pong response is not received within the timeout (default 10 seconds), the connection is closed and the peer is removed from the channel.
+
+This is important for public internet deployments where NAT gateways, load balancers, and mobile network switches can silently drop idle TCP connections. The defaults are suitable for most deployments; adjust `RELAY_PING_INTERVAL_S` and `RELAY_PING_TIMEOUT_S` if your network has specific requirements.
+
+## Compression
+
+The relay offers `permessage-deflate` WebSocket compression. Clients that support it (the Ion Engine client and iOS `URLSessionWebSocketTask` both do) negotiate compression automatically during the WebSocket handshake. Clients that do not support compression receive uncompressed frames — no configuration needed.
+
+Compression reduces bandwidth for the repetitive JSON structures in streaming events, which is beneficial for public internet deployments.
 
 ## Protocol reference
 

--- a/docs/extensions/json-rpc-protocol.md
+++ b/docs/extensions/json-rpc-protocol.md
@@ -374,7 +374,8 @@ Dispatch a tool call from extension code through the same registry the LLM uses 
   "method": "ext/call_tool",
   "params": {
     "name": "Read",
-    "input": { "file_path": "/Users/you/project/README.md" }
+    "input": { "file_path": "/Users/you/project/README.md" },
+    "timeout": 120000
   }
 }
 ```
@@ -393,6 +394,8 @@ Dispatch a tool call from extension code through the same registry the LLM uses 
 ```
 
 `name` is required. `input` may be omitted or null and is treated as an empty object.
+
+`timeout` is optional. When set (in milliseconds), it overrides the default MCP/tool call timeout for this single invocation. Use this for long-running tools where you know the call will exceed the default timeout. Omit or set to `0` to use the default.
 
 The result mirrors what an LLM-issued tool call would receive. Permission `deny` decisions resolve with `{ content, isError: true }` describing the rule that fired. `ask` decisions auto-deny with the same shape -- extension calls cannot block on user elicitation, so the harness must configure an explicit allow rule for the specific tool to permit it from extension code.
 
@@ -479,4 +482,16 @@ Use standard JSON-RPC 2.0 error codes:
 
 ## Timeout
 
-The engine waits up to 30 seconds for each RPC response. If the extension does not respond within this window, the call fails with a timeout error and the engine continues without the extension's result.
+The engine waits up to 30 seconds by default for each RPC response. If the extension does not respond within this window, the call fails with a timeout error and the engine continues without the extension's result.
+
+This timeout is configurable via the `extensionRpcMs` field in `engine.json`:
+
+```json
+{
+  "timeouts": {
+    "extensionRpcMs": 60000
+  }
+}
+```
+
+See [engine.json Reference](../configuration/engine-json.md#timeouts) for all configurable timeouts.

--- a/docs/extensions/sdk-raw.md
+++ b/docs/extensions/sdk-raw.md
@@ -238,7 +238,7 @@ Your extension needs to handle both incoming requests (from engine) and incoming
 
 1. **Flush stdout after every write.** Buffered output will cause the engine to hang waiting for responses.
 2. **Handle unknown hooks gracefully.** The engine sends all 55 hooks to subprocess extensions. Return null for hooks you don't care about.
-3. **Respect the 30-second timeout.** The engine drops calls that don't respond within 30 seconds.
+3. **Respect the RPC timeout.** The engine drops calls that don't respond within the configured timeout (default: 30 seconds, configurable via `timeouts.extensionRpcMs` in `engine.json`).
 4. **Never write non-JSON to stdout.** Debug output goes to stderr.
 5. **Parse the `_ctx` field** from hook and tool params if you need session context (cwd, model, config).
 6. **Use unique IDs for outgoing requests.** Start from a high number (e.g., 100000) to avoid collisions with engine-assigned IDs.

--- a/engine/cmd/ion/cmd_prompt.go
+++ b/engine/cmd/ion/cmd_prompt.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func cmdPrompt(positional []string, flags map[string]string, listFlags map[string][]string) {
@@ -15,6 +16,17 @@ func cmdPrompt(positional []string, flags map[string]string, listFlags map[strin
 	if text == "" {
 		fmt.Fprintln(os.Stderr, "Error: prompt text required")
 		os.Exit(1)
+	}
+
+	// Parse --timeout flag (duration string like 60s, 5m, 2h).
+	var timeout time.Duration
+	if t := flags["timeout"]; t != "" {
+		d, err := time.ParseDuration(t)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: invalid --timeout value %q: %s\n", t, err)
+			os.Exit(1)
+		}
+		timeout = d
 	}
 
 	sock := socketPath()
@@ -128,7 +140,14 @@ func cmdPrompt(positional []string, flags map[string]string, listFlags map[strin
 			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
 			os.Exit(1)
 		}
-		streamUntilIdle(sock, key)
+		timedOut := streamUntilIdle(sock, key, timeout)
+		if timedOut {
+			// Send abort so the engine doesn't keep running.
+			_, _ = connectAndSend(sock, map[string]interface{}{
+				"cmd": "abort",
+				"key": key,
+			})
+		}
 		_, _ = connectAndSend(sock, map[string]interface{}{
 			"cmd": "stop_session",
 			"key": key,
@@ -137,6 +156,9 @@ func cmdPrompt(positional []string, flags map[string]string, listFlags map[strin
 			_, _ = connectAndSend(sock, map[string]interface{}{
 				"cmd": "shutdown",
 			})
+		}
+		if timedOut {
+			os.Exit(124)
 		}
 		return
 	}
@@ -173,7 +195,11 @@ func cmdPrompt(positional []string, flags map[string]string, listFlags map[strin
 	}
 	if ok, _ := result["ok"].(bool); ok {
 		if flags["attach"] == "true" {
-			streamUntilIdle(sock, key)
+			timedOut := streamUntilIdle(sock, key, timeout)
+			if timedOut {
+				fmt.Fprintf(os.Stderr, "\nTimeout: prompt exceeded %s deadline\n", timeout)
+				os.Exit(124)
+			}
 		} else {
 			fmt.Println("Prompt sent. Use `ion attach` to stream output.")
 		}

--- a/engine/cmd/ion/cmd_prompt.go
+++ b/engine/cmd/ion/cmd_prompt.go
@@ -173,7 +173,25 @@ func cmdPrompt(positional []string, flags map[string]string, listFlags map[strin
 			fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
 			os.Exit(1)
 		}
-		attachStream(sock, key)
+		timedOut := attachStream(sock, key, timeout)
+		if timedOut {
+			if ephemeral {
+				_, _ = connectAndSend(sock, map[string]interface{}{
+					"cmd": "abort",
+					"key": key,
+				})
+				_, _ = connectAndSend(sock, map[string]interface{}{
+					"cmd": "stop_session",
+					"key": key,
+				})
+				if serverStarted {
+					_, _ = connectAndSend(sock, map[string]interface{}{
+						"cmd": "shutdown",
+					})
+				}
+			}
+			os.Exit(124)
+		}
 		return
 	}
 

--- a/engine/cmd/ion/cmd_serve.go
+++ b/engine/cmd/ion/cmd_serve.go
@@ -13,8 +13,10 @@ import (
 	"github.com/dsswift/ion/engine/internal/auth"
 	"github.com/dsswift/ion/engine/internal/backend"
 	"github.com/dsswift/ion/engine/internal/config"
+	"github.com/dsswift/ion/engine/internal/extension"
 	"github.com/dsswift/ion/engine/internal/featureflags"
 	"github.com/dsswift/ion/engine/internal/filelock"
+	"github.com/dsswift/ion/engine/internal/mcp"
 	"github.com/dsswift/ion/engine/internal/modelconfig"
 	"github.com/dsswift/ion/engine/internal/network"
 	"github.com/dsswift/ion/engine/internal/protocol"
@@ -74,6 +76,14 @@ func cmdServe() {
 
 	resolver := auth.NewResolver(cfg.Auth)
 
+	// Wire configurable timeouts into MCP and extension subsystems.
+	if cfg.Timeouts != nil {
+		mcp.SetDefaultCallTimeout(cfg.Timeouts.McpCall())
+		mcp.SetDefaultMetadataTimeout(cfg.Timeouts.McpMetadata())
+		mcp.SetDefaultWriteTimeout(cfg.Timeouts.McpWrite())
+		extension.ConfiguredDefaultTimeout = cfg.Timeouts.HookDefault()
+	}
+
 	for name, pcfg := range cfg.Providers {
 		if pcfg.APIKey != "" {
 			resolver.SetProgrammatic(name, pcfg.APIKey)
@@ -127,6 +137,9 @@ func cmdServe() {
 	var relay *transport.RelayTransport
 	if cfg.Relay != nil && cfg.Relay.URL != "" && cfg.Relay.ChannelID != "" {
 		relay = transport.NewRelayTransport(cfg.Relay.URL, cfg.Relay.APIKey, cfg.Relay.ChannelID)
+		if cfg.Timeouts != nil {
+			relay.SetWriteTimeout(cfg.Timeouts.RelayWrite())
+		}
 
 		relay.OnMessage = func(data []byte) {
 			line := strings.TrimSpace(string(data))

--- a/engine/cmd/ion/cmd_session.go
+++ b/engine/cmd/ion/cmd_session.go
@@ -50,7 +50,7 @@ func cmdStart(flags map[string]string, listFlags map[string][]string) {
 }
 
 func cmdAttach(flags map[string]string) {
-	attachStream(socketPath(), flags["key"])
+	attachStream(socketPath(), flags["key"], 0)
 }
 
 func cmdStatus() {

--- a/engine/cmd/ion/ipc.go
+++ b/engine/cmd/ion/ipc.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 )
 
 // connectAndSend connects to the engine socket, sends a command, waits for response.
@@ -59,14 +60,22 @@ func attachStream(sock string, key string) {
 }
 
 // streamUntilIdle connects to the engine socket and streams text deltas to
-// stdout until the session emits engine_status with state=idle.
-func streamUntilIdle(sock, key string) {
+// stdout until the session emits engine_status with state=idle. When deadline
+// is non-zero, the stream is bounded by that wall-clock timeout — returns true
+// if the deadline fired (caller should abort and exit 124). A zero deadline
+// means "no limit".
+func streamUntilIdle(sock, key string, deadline time.Duration) (timedOut bool) {
 	conn, err := net.Dial(dialNetwork(), sock)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error connecting to stream: %s\n", err)
-		return
+		return false
 	}
 	defer func() { _ = conn.Close() }()
+
+	// Set a read deadline so the scanner unblocks when the timeout fires.
+	if deadline > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(deadline))
+	}
 
 	scanner := bufio.NewScanner(conn)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
@@ -97,14 +106,22 @@ func streamUntilIdle(sock, key string) {
 			if fields != nil {
 				if state, _ := fields["state"].(string); state == "idle" {
 					fmt.Println()
-					return
+					return false
 				}
 			}
 		case "engine_error":
 			if errMsg, ok := event["message"].(string); ok {
 				fmt.Fprintf(os.Stderr, "\nError: %s\n", errMsg)
-				return
+				return false
 			}
 		}
 	}
+	// Scanner exited — check if it was a timeout.
+	if scanErr := scanner.Err(); scanErr != nil && deadline > 0 {
+		if netErr, ok := scanErr.(net.Error); ok && netErr.Timeout() {
+			fmt.Fprintf(os.Stderr, "\nTimeout: prompt exceeded %s deadline\n", deadline)
+			return true
+		}
+	}
+	return false
 }

--- a/engine/cmd/ion/ipc.go
+++ b/engine/cmd/ion/ipc.go
@@ -41,14 +41,21 @@ func connectAndSend(sock string, msg map[string]interface{}) (map[string]interfa
 	return nil, fmt.Errorf("connection closed before receiving response")
 }
 
-// attachStream connects to engine and streams all events to stdout.
-func attachStream(sock string, key string) {
+// attachStream connects to engine and streams all events to stdout. When
+// deadline is non-zero, the stream is bounded by that wall-clock timeout —
+// returns true if the deadline fired (caller should exit 124). A zero deadline
+// means "no limit".
+func attachStream(sock string, key string, deadline time.Duration) (timedOut bool) {
 	conn, err := net.Dial(dialNetwork(), sock)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Connection error: %s\n", err)
 		os.Exit(1)
 	}
 	defer func() { _ = conn.Close() }()
+
+	if deadline > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(deadline))
+	}
 
 	scanner := bufio.NewScanner(conn)
 	for scanner.Scan() {
@@ -57,6 +64,13 @@ func attachStream(sock string, key string) {
 			fmt.Println(line)
 		}
 	}
+	if scanErr := scanner.Err(); scanErr != nil && deadline > 0 {
+		if netErr, ok := scanErr.(net.Error); ok && netErr.Timeout() {
+			fmt.Fprintf(os.Stderr, "\nTimeout: stream exceeded %s deadline\n", deadline)
+			return true
+		}
+	}
+	return false
 }
 
 // streamUntilIdle connects to the engine socket and streams text deltas to

--- a/engine/cmd/ion/main.go
+++ b/engine/cmd/ion/main.go
@@ -54,6 +54,7 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "    --no-extensions        Skip extensions for this prompt")
 	fmt.Fprintln(os.Stderr, "    --extension FILE       Load extension (can be repeated)")
 	fmt.Fprintln(os.Stderr, "    --attach               Stream output until idle (keyed sessions)")
+	fmt.Fprintln(os.Stderr, "    --timeout DURATION      Wall-clock deadline (e.g. 60s, 5m, 2h); exit 124 on timeout")
 	fmt.Fprintln(os.Stderr, "  attach                   Stream events (NDJSON)")
 	fmt.Fprintln(os.Stderr, "  status                   List sessions")
 	fmt.Fprintln(os.Stderr, "  stop --key               Stop session")

--- a/engine/go.mod
+++ b/engine/go.mod
@@ -11,4 +11,4 @@ require (
 	golang.org/x/text v0.36.0
 )
 
-require nhooyr.io/websocket v1.8.17
+require github.com/coder/websocket v1.8.14

--- a/engine/go.sum
+++ b/engine/go.sum
@@ -1,8 +1,8 @@
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
-nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
-nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/engine/internal/backend/backend.go
+++ b/engine/internal/backend/backend.go
@@ -114,4 +114,5 @@ type RunConfig struct {
 	McpToolRouter func(name string, input map[string]interface{}) (content string, isErr bool, err error)
 	AgentSpawner  tools.AgentSpawner
 	Telemetry     TelemetryCollector
+	Timeouts      *types.TimeoutsConfig
 }

--- a/engine/internal/backend/runloop.go
+++ b/engine/internal/backend/runloop.go
@@ -85,6 +85,7 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 
 	// Track consecutive prompt_too_long compaction failures to prevent infinite loops
 	promptTooLongRetries := 0
+	truncationRetries := 0
 
 	// Agent loop: turn increments at the top of each iteration (before
 	// turn_start fires), so the first turn has turn=1. This matches the
@@ -233,16 +234,28 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 			return
 		}
 
-		// Stream succeeded -- reset compaction retry counter
-		promptTooLongRetries = 0
-
 		// Stream truncated (no stop reason) -- emit reset so desktop discards
-		// partial text, then retry the turn.
+		// partial text, then retry the turn (capped at 3 consecutive).
 		if stopReason == "" {
-			utils.Warn("ApiBackend", fmt.Sprintf("stream truncated (no stop reason): runID=%s turn=%d, retrying", run.requestID, turn))
+			truncationRetries++
+			if truncationRetries > 3 {
+				utils.Error("ApiBackend", fmt.Sprintf("stream truncated %d consecutive times, giving up: runID=%s", truncationRetries, run.requestID))
+				b.emit(run, types.NormalizedEvent{Data: &types.ErrorEvent{
+					ErrorMessage: fmt.Sprintf("Stream truncated %d consecutive times. The provider may be experiencing issues.", truncationRetries),
+					IsError:      true,
+					ErrorCode:    "stream_truncated",
+				}})
+				b.emitExit(run.requestID, intPtr(1), nil, conv.ID)
+				return
+			}
+			utils.Warn("ApiBackend", fmt.Sprintf("stream truncated (no stop reason): runID=%s turn=%d attempt=%d/3, retrying", run.requestID, turn, truncationRetries))
 			b.emit(run, types.NormalizedEvent{Data: &types.StreamResetEvent{}})
 			continue
 		}
+
+		// Stream succeeded with a valid stop reason -- reset retry counters.
+		promptTooLongRetries = 0
+		truncationRetries = 0
 
 		// Track usage and cost
 		if turnUsage != nil {

--- a/engine/internal/backend/runloop.go
+++ b/engine/internal/backend/runloop.go
@@ -238,7 +238,11 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 		// partial text, then retry the turn (capped at 3 consecutive).
 		if stopReason == "" {
 			truncationRetries++
-			if truncationRetries > 3 {
+			maxTruncation := 3
+			if run.cfg != nil && run.cfg.Timeouts != nil {
+				maxTruncation = run.cfg.Timeouts.TruncationRetryLimit()
+			}
+			if truncationRetries > maxTruncation {
 				utils.Error("ApiBackend", fmt.Sprintf("stream truncated %d consecutive times, giving up: runID=%s", truncationRetries, run.requestID))
 				b.emit(run, types.NormalizedEvent{Data: &types.ErrorEvent{
 					ErrorMessage: fmt.Sprintf("Stream truncated %d consecutive times. The provider may be experiencing issues.", truncationRetries),

--- a/engine/internal/backend/runloop_tools.go
+++ b/engine/internal/backend/runloop_tools.go
@@ -269,6 +269,9 @@ func (b *ApiBackend) executeTools(
 			// Capture the threshold locally so the goroutine doesn't race
 			// with tests that reassign the package-level var.
 			stallThreshold := toolStallThreshold
+			if run.cfg != nil && run.cfg.Timeouts != nil {
+				stallThreshold = run.cfg.Timeouts.ToolStall()
+			}
 			toolDone := make(chan struct{})
 			go func() {
 				ticker := time.NewTicker(stallThreshold)
@@ -290,12 +293,21 @@ func (b *ApiBackend) executeTools(
 			}()
 
 			// Route to built-in, extension, or MCP tool (Step 5).
-			// Each tool call is bounded by defaultToolTimeout. A tool that
-			// observes ctx will cancel cleanly; a tool that ignores ctx will
+			// Each tool call is bounded by the configured tool timeout. A tool
+			// that observes ctx will cancel cleanly; a tool that ignores ctx will
 			// be left running but its result is dropped, and executeTools
 			// returns once errgroup's children all return.
-			toolCtx, toolCancel := context.WithTimeout(gCtx, defaultToolTimeout)
+			toolTimeout := defaultToolTimeout
+			if run.cfg != nil && run.cfg.Timeouts != nil {
+				toolTimeout = run.cfg.Timeouts.ToolDefault()
+			}
+			toolCtx, toolCancel := context.WithTimeout(gCtx, toolTimeout)
 			defer toolCancel()
+
+			// Inject timeouts config into context for individual tools to read.
+			if run.cfg != nil && run.cfg.Timeouts != nil {
+				toolCtx = types.WithTimeouts(toolCtx, run.cfg.Timeouts)
+			}
 
 			var toolResult *types.ToolResult
 			var err error
@@ -338,7 +350,7 @@ func (b *ApiBackend) executeTools(
 			if err != nil && toolCtx.Err() == context.DeadlineExceeded {
 				err = nil
 				toolResult = &types.ToolResult{
-					Content: fmt.Sprintf("Error: tool %q exceeded %s deadline. Narrow the request or split it into smaller calls.", block.Name, defaultToolTimeout),
+					Content: fmt.Sprintf("Error: tool %q exceeded %s deadline. Narrow the request or split it into smaller calls.", block.Name, toolTimeout),
 					IsError: true,
 				}
 			}

--- a/engine/internal/config/merge.go
+++ b/engine/internal/config/merge.go
@@ -244,6 +244,11 @@ func mergeInto(dst, src *types.EngineRuntimeConfig) {
 	if src.LogLevel != "" {
 		dst.LogLevel = src.LogLevel
 	}
+
+	// Timeouts: merge non-zero fields
+	if src.Timeouts != nil {
+		dst.Timeouts = types.MergeTimeouts(dst.Timeouts, src.Timeouts)
+	}
 }
 
 func contains(slice []string, item string) bool {

--- a/engine/internal/extension/external_hooks.go
+++ b/engine/internal/extension/external_hooks.go
@@ -20,6 +20,10 @@ const (
 	DefaultTimeout = 30 * time.Second
 )
 
+// ConfiguredDefaultTimeout overrides DefaultTimeout when set from TimeoutsConfig
+// at startup. A zero value means "use DefaultTimeout".
+var ConfiguredDefaultTimeout time.Duration
+
 // ExternalHookConfig defines a shell command triggered by an engine event.
 type ExternalHookConfig struct {
 	Command []string      `json:"command"`
@@ -66,6 +70,15 @@ func (m *ExternalHookManager) parseConfig(config map[string]interface{}) {
 	}
 }
 
+// effectiveDefaultTimeout returns ConfiguredDefaultTimeout when set,
+// otherwise DefaultTimeout.
+func effectiveDefaultTimeout() time.Duration {
+	if ConfiguredDefaultTimeout > 0 {
+		return ConfiguredDefaultTimeout
+	}
+	return DefaultTimeout
+}
+
 // parseHookEntry parses a single hook entry. Supports two formats:
 //   - Array format: ["cmd", "arg1", "arg2"] (fire-and-forget, default timeout)
 //   - Object format: {"command": ["cmd","arg"], "await": true, "timeout": 5000}
@@ -80,7 +93,7 @@ func (m *ExternalHookManager) parseHookEntry(entry interface{}) *ExternalHookCon
 		return &ExternalHookConfig{
 			Command: cmd,
 			Await:   false,
-			Timeout: DefaultTimeout,
+			Timeout: effectiveDefaultTimeout(),
 		}
 
 	case map[string]interface{}:
@@ -101,7 +114,7 @@ func (m *ExternalHookManager) parseHookEntry(entry interface{}) *ExternalHookCon
 		cfg := ExternalHookConfig{
 			Command: cmd,
 			Await:   false,
-			Timeout: DefaultTimeout,
+			Timeout: effectiveDefaultTimeout(),
 		}
 
 		if await, ok := v["await"].(bool); ok {

--- a/engine/internal/extension/host.go
+++ b/engine/internal/extension/host.go
@@ -12,7 +12,8 @@ import (
 	"github.com/dsswift/ion/engine/internal/types"
 )
 
-const rpcCallTimeout = 30 * time.Second
+// defaultRPCTimeout is the compiled default for extension RPC calls.
+const defaultRPCTimeout = 30 * time.Second
 
 // Host manages extension subprocess lifecycle. It supports both in-process
 // extensions (Go functions registered directly on the SDK) and subprocess
@@ -24,6 +25,10 @@ type Host struct {
 	stdin   io.WriteCloser
 	stdout  *bufio.Scanner
 	cmd     *exec.Cmd
+
+	// rpcTimeout is the per-call timeout for extension RPC requests.
+	// Defaults to defaultRPCTimeout (30s), overridable via SetRPCTimeout.
+	rpcTimeout time.Duration
 
 	// writeMu serialises all writes to h.stdin so concurrent goroutines
 	// (send, sendResponse, sendNotification) cannot interleave NDJSON
@@ -118,8 +123,9 @@ func (h *Host) SetPersistentEmit(fn func(types.EngineEvent)) {
 // NewHost creates a new extension host with an empty SDK.
 func NewHost() *Host {
 	h := &Host{
-		sdk:     NewSDK(),
-		pending: make(map[int64]chan *jsonrpcResponse),
+		sdk:        NewSDK(),
+		pending:    make(map[int64]chan *jsonrpcResponse),
+		rpcTimeout: defaultRPCTimeout,
 	}
 	// Start IDs at 1 (0 is reserved/unused).
 	h.nextID.Store(1)
@@ -132,6 +138,11 @@ func NewHost() *Host {
 // SDK returns the underlying hook registry for direct registration.
 func (h *Host) SDK() *SDK {
 	return h.sdk
+}
+
+// SetRPCTimeout overrides the per-call timeout for extension RPC requests.
+func (h *Host) SetRPCTimeout(d time.Duration) {
+	h.rpcTimeout = d
 }
 
 // Name returns the extension's name as reported by the init handshake.

--- a/engine/internal/extension/host_io.go
+++ b/engine/internal/extension/host_io.go
@@ -77,7 +77,7 @@ func (h *Host) send(msg rpcRequest) error {
 
 // call sends a JSON-RPC request and waits for the matching response.
 func (h *Host) call(method string, params interface{}) (json.RawMessage, error) {
-	return h.callWithTimeout(method, params, rpcCallTimeout)
+	return h.callWithTimeout(method, params, h.rpcTimeout)
 }
 
 func (h *Host) callWithTimeout(method string, params interface{}, timeout time.Duration) (json.RawMessage, error) {

--- a/engine/internal/extension/host_rpc.go
+++ b/engine/internal/extension/host_rpc.go
@@ -358,8 +358,9 @@ func (h *Host) handleExtRequest(method string, id int64, raw []byte) {
 	case "ext/call_tool":
 		var req struct {
 			Params struct {
-				Name  string                 `json:"name"`
-				Input map[string]interface{} `json:"input"`
+				Name    string                 `json:"name"`
+				Input   map[string]interface{} `json:"input"`
+				Timeout *float64               `json:"timeout,omitempty"` // optional ms
 			} `json:"params"`
 		}
 		if err := json.Unmarshal(raw, &req); err != nil {
@@ -370,12 +371,28 @@ func (h *Host) handleExtRequest(method string, id int64, raw []byte) {
 			h.sendResponse(id, nil, &jsonrpcError{Code: -32602, Message: "tool name required"})
 			return
 		}
-		if ctx == nil || ctx.CallTool == nil {
-			h.sendResponse(id, nil, &jsonrpcError{Code: -32000, Message: "callTool not available outside an active session"})
+		if ctx == nil || ctx.CallToolWithContext == nil {
+			// Fall back to legacy CallTool if the new API isn't wired.
+			if ctx == nil || ctx.CallTool == nil {
+				h.sendResponse(id, nil, &jsonrpcError{Code: -32000, Message: "callTool not available outside an active session"})
+				return
+			}
+			go func() {
+				content, isError, err := ctx.CallTool(req.Params.Name, req.Params.Input)
+				if err != nil {
+					h.sendResponse(id, nil, &jsonrpcError{Code: -32000, Message: err.Error()})
+					return
+				}
+				data, _ := json.Marshal(struct {
+					Content string `json:"content"`
+					IsError bool   `json:"isError,omitempty"`
+				}{Content: content, IsError: isError})
+				h.sendResponse(id, json.RawMessage(data), nil)
+			}()
 			return
 		}
 		go func() {
-			content, isError, err := ctx.CallTool(req.Params.Name, req.Params.Input)
+			content, isError, err := ctx.CallToolWithContext(req.Params.Name, req.Params.Input, req.Params.Timeout)
 			if err != nil {
 				h.sendResponse(id, nil, &jsonrpcError{Code: -32000, Message: err.Error()})
 				return

--- a/engine/internal/extension/sdk_types.go
+++ b/engine/internal/extension/sdk_types.go
@@ -79,6 +79,12 @@ type Context struct {
 	// engine still fire.
 	CallTool func(toolName string, input map[string]interface{}) (string, bool, error)
 
+	// CallToolWithContext is like CallTool but accepts an optional timeout in
+	// milliseconds. When timeoutMs is non-nil, the tool call is bounded by
+	// that deadline. This is wired by the ext/call_tool RPC handler when the
+	// extension provides a timeout parameter.
+	CallToolWithContext func(toolName string, input map[string]interface{}, timeoutMs *float64) (string, bool, error)
+
 	// SendPrompt queues a fresh prompt on this session's agent loop. The
 	// call returns once the engine has accepted (or rejected) the prompt;
 	// it does NOT wait for the LLM to finish. `model` is an optional

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -4,6 +4,7 @@ package mcp
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -73,7 +74,9 @@ func ListMcpResources(serverName string) ([]McpResource, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("MCP server %q not connected", serverName)
 	}
-	return conn.ListResources()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return conn.ListResources(ctx)
 }
 
 // ReadMcpResource reads a resource from a connected MCP server by name and URI.
@@ -82,7 +85,9 @@ func ReadMcpResource(serverName, uri string) (*McpResourceContent, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("MCP server %q not connected", serverName)
 	}
-	return conn.ReadResource(uri)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return conn.ReadResource(ctx, uri)
 }
 
 const mcpCallTimeout = 60 * time.Second
@@ -197,7 +202,9 @@ func Connect(name string, config types.McpServerConfig) (*Connection, error) {
 }
 
 func (c *Connection) initialize() error {
-	resp, err := c.call("initialize", map[string]any{
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.call(ctx, "initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
 		"capabilities":    map[string]any{},
 		"clientInfo": map[string]any{
@@ -220,7 +227,9 @@ func (c *Connection) initialize() error {
 }
 
 func (c *Connection) listTools() ([]ToolDef, error) {
-	resp, err := c.call("tools/list", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.call(ctx, "tools/list", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +243,7 @@ func (c *Connection) listTools() ([]ToolDef, error) {
 	return result.Tools, nil
 }
 
-func (c *Connection) call(method string, params any) (json.RawMessage, error) {
+func (c *Connection) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -295,14 +304,19 @@ func (c *Connection) call(method string, params any) (json.RawMessage, error) {
 	select {
 	case r := <-ch:
 		return r.data, r.err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("mcp call %s: %w", method, ctx.Err())
 	case <-time.After(timeout):
+		// Note: the goroutine running Receive() may leak if the transport
+		// truly hangs, but this is strictly better than the caller also
+		// hanging indefinitely (the previous behavior).
 		return nil, fmt.Errorf("mcp call %s: timeout after %s", method, timeout)
 	}
 }
 
 // CallTool invokes a tool on the MCP server and returns the text result.
-func (c *Connection) CallTool(toolName string, params map[string]interface{}) (string, error) {
-	resp, err := c.call("tools/call", map[string]any{
+func (c *Connection) CallTool(ctx context.Context, toolName string, params map[string]interface{}) (string, error) {
+	resp, err := c.call(ctx, "tools/call", map[string]any{
 		"name":      toolName,
 		"arguments": params,
 	})
@@ -346,8 +360,8 @@ func (c *Connection) Tools() []ToolDef {
 }
 
 // ListResources returns resources available on the MCP server.
-func (c *Connection) ListResources() ([]McpResource, error) {
-	resp, err := c.call("resources/list", nil)
+func (c *Connection) ListResources(ctx context.Context) ([]McpResource, error) {
+	resp, err := c.call(ctx, "resources/list", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +376,8 @@ func (c *Connection) ListResources() ([]McpResource, error) {
 }
 
 // ReadResource reads a specific resource by URI from the MCP server.
-func (c *Connection) ReadResource(uri string) (*McpResourceContent, error) {
-	resp, err := c.call("resources/read", map[string]any{
+func (c *Connection) ReadResource(ctx context.Context, uri string) (*McpResourceContent, error) {
+	resp, err := c.call(ctx, "resources/read", map[string]any{
 		"uri": uri,
 	})
 	if err != nil {

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/dsswift/ion/engine/internal/types"
 )
@@ -84,13 +85,16 @@ func ReadMcpResource(serverName, uri string) (*McpResourceContent, error) {
 	return conn.ReadResource(uri)
 }
 
+const mcpCallTimeout = 60 * time.Second
+
 // Connection is an active MCP server connection.
 type Connection struct {
-	name      string
-	tools     []ToolDef
-	transport mcpTransport
-	nextID    atomic.Int64
-	mu        sync.Mutex
+	name        string
+	tools       []ToolDef
+	transport   mcpTransport
+	nextID      atomic.Int64
+	mu          sync.Mutex
+	callTimeout time.Duration
 }
 
 // mcpTransport abstracts stdio vs SSE communication.
@@ -168,6 +172,9 @@ func Connect(name string, config types.McpServerConfig) (*Connection, error) {
 		name:      name,
 		transport: transport,
 	}
+	if config.TimeoutSeconds > 0 {
+		conn.callTimeout = time.Duration(config.TimeoutSeconds) * time.Second
+	}
 
 	// Initialize the connection.
 	if err := conn.initialize(); err != nil {
@@ -231,6 +238,11 @@ func (c *Connection) call(method string, params any) (json.RawMessage, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	timeout := c.callTimeout
+	if timeout == 0 {
+		timeout = mcpCallTimeout
+	}
+
 	id := c.nextID.Add(1)
 	req := jsonRPCRequest{
 		JSONRPC: "2.0",
@@ -248,26 +260,43 @@ func (c *Connection) call(method string, params any) (json.RawMessage, error) {
 		return nil, fmt.Errorf("send: %w", err)
 	}
 
-	// Read responses until we get one matching our ID.
-	for {
-		respData, err := c.transport.Receive()
-		if err != nil {
-			return nil, fmt.Errorf("receive: %w", err)
-		}
+	// Read responses in a goroutine so we can enforce a timeout.
+	type callResult struct {
+		data json.RawMessage
+		err  error
+	}
+	ch := make(chan callResult, 1)
+	go func() {
+		for {
+			respData, err := c.transport.Receive()
+			if err != nil {
+				ch <- callResult{nil, fmt.Errorf("receive: %w", err)}
+				return
+			}
 
-		var resp jsonRPCResponse
-		if err := json.Unmarshal(respData, &resp); err != nil {
-			continue // Skip non-response messages (notifications).
-		}
+			var resp jsonRPCResponse
+			if err := json.Unmarshal(respData, &resp); err != nil {
+				continue // Skip non-response messages (notifications).
+			}
 
-		if resp.ID != id {
-			continue // Skip responses for other requests.
-		}
+			if resp.ID != id {
+				continue // Skip responses for other requests.
+			}
 
-		if resp.Error != nil {
-			return nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+			if resp.Error != nil {
+				ch <- callResult{nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)}
+				return
+			}
+			ch <- callResult{resp.Result, nil}
+			return
 		}
-		return resp.Result, nil
+	}()
+
+	select {
+	case r := <-ch:
+		return r.data, r.err
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("mcp call %s: timeout after %s", method, timeout)
 	}
 }
 

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -74,7 +74,7 @@ func ListMcpResources(serverName string) ([]McpResource, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("MCP server %q not connected", serverName)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultMetadataTimeout)
 	defer cancel()
 	return conn.ListResources(ctx)
 }
@@ -85,12 +85,26 @@ func ReadMcpResource(serverName, uri string) (*McpResourceContent, error) {
 	if conn == nil {
 		return nil, fmt.Errorf("MCP server %q not connected", serverName)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultMetadataTimeout)
 	defer cancel()
 	return conn.ReadResource(ctx, uri)
 }
 
-const mcpCallTimeout = 60 * time.Second
+const mcpCallTimeoutDefault = 60 * time.Second
+
+// DefaultCallTimeout is the fallback MCP tool call timeout when no per-server
+// override is configured. Set at startup from TimeoutsConfig.McpCall().
+var DefaultCallTimeout = mcpCallTimeoutDefault
+
+// DefaultMetadataTimeout is the timeout for MCP metadata operations
+// (initialize, listTools, listResources, readResource).
+var DefaultMetadataTimeout = 30 * time.Second
+
+// SetDefaultCallTimeout overrides the default MCP tool call timeout.
+func SetDefaultCallTimeout(d time.Duration) { DefaultCallTimeout = d }
+
+// SetDefaultMetadataTimeout overrides the default MCP metadata timeout.
+func SetDefaultMetadataTimeout(d time.Duration) { DefaultMetadataTimeout = d }
 
 // Connection is an active MCP server connection.
 type Connection struct {
@@ -202,7 +216,7 @@ func Connect(name string, config types.McpServerConfig) (*Connection, error) {
 }
 
 func (c *Connection) initialize() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultMetadataTimeout)
 	defer cancel()
 	resp, err := c.call(ctx, "initialize", map[string]any{
 		"protocolVersion": "2024-11-05",
@@ -227,7 +241,7 @@ func (c *Connection) initialize() error {
 }
 
 func (c *Connection) listTools() ([]ToolDef, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultMetadataTimeout)
 	defer cancel()
 	resp, err := c.call(ctx, "tools/list", nil)
 	if err != nil {
@@ -249,7 +263,7 @@ func (c *Connection) call(ctx context.Context, method string, params any) (json.
 
 	timeout := c.callTimeout
 	if timeout == 0 {
-		timeout = mcpCallTimeout
+		timeout = DefaultCallTimeout
 	}
 
 	id := c.nextID.Add(1)

--- a/engine/internal/mcp/mcp_test.go
+++ b/engine/internal/mcp/mcp_test.go
@@ -2,7 +2,10 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -369,5 +372,86 @@ func TestConnectionRegistry(t *testing.T) {
 	unregisterConnection("reg-test")
 	if getConnection("reg-test") != nil {
 		t.Error("expected nil after unregister")
+	}
+}
+
+// slowTransport blocks on Receive until closed.
+type slowTransport struct {
+	sent   []json.RawMessage
+	done   chan struct{}
+	closed bool
+}
+
+func (s *slowTransport) Send(msg json.RawMessage) error {
+	s.sent = append(s.sent, msg)
+	return nil
+}
+
+func (s *slowTransport) Receive() (json.RawMessage, error) {
+	<-s.done // Block until closed.
+	return nil, io.EOF
+}
+
+func (s *slowTransport) Close() error {
+	if !s.closed {
+		s.closed = true
+		close(s.done)
+	}
+	return nil
+}
+
+func TestCall_Timeout(t *testing.T) {
+	st := &slowTransport{done: make(chan struct{})}
+	defer st.Close()
+
+	conn := &Connection{
+		name:        "timeout-test",
+		transport:   st,
+		callTimeout: 100 * time.Millisecond,
+	}
+
+	_, err := conn.call("tools/list", nil)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected timeout in error, got: %s", err)
+	}
+}
+
+// errorTransport returns an error from Receive.
+type errorTransport struct {
+	sent    []json.RawMessage
+	recvErr error
+}
+
+func (e *errorTransport) Send(msg json.RawMessage) error {
+	e.sent = append(e.sent, msg)
+	return nil
+}
+
+func (e *errorTransport) Receive() (json.RawMessage, error) {
+	return nil, e.recvErr
+}
+
+func (e *errorTransport) Close() error {
+	return nil
+}
+
+func TestCall_ReceiveError(t *testing.T) {
+	et := &errorTransport{recvErr: fmt.Errorf("connection reset")}
+
+	conn := &Connection{
+		name:        "error-test",
+		transport:   et,
+		callTimeout: 5 * time.Second,
+	}
+
+	_, err := conn.call("tools/list", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection reset") {
+		t.Errorf("expected 'connection reset' in error, got: %s", err)
 	}
 }

--- a/engine/internal/mcp/mcp_test.go
+++ b/engine/internal/mcp/mcp_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -410,7 +411,7 @@ func TestCall_Timeout(t *testing.T) {
 		callTimeout: 100 * time.Millisecond,
 	}
 
-	_, err := conn.call("tools/list", nil)
+	_, err := conn.call(context.Background(), "tools/list", nil)
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
@@ -447,7 +448,7 @@ func TestCall_ReceiveError(t *testing.T) {
 		callTimeout: 5 * time.Second,
 	}
 
-	_, err := conn.call("tools/list", nil)
+	_, err := conn.call(context.Background(), "tools/list", nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/engine/internal/mcp/ws.go
+++ b/engine/internal/mcp/ws.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/coder/websocket"
 )
@@ -46,7 +47,9 @@ func newWSTransport(url string, headers map[string]string) (*wsTransport, error)
 func (t *wsTransport) Send(msg json.RawMessage) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.conn.Write(context.Background(), websocket.MessageText, msg)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return t.conn.Write(ctx, websocket.MessageText, msg)
 }
 
 func (t *wsTransport) Receive() (json.RawMessage, error) {

--- a/engine/internal/mcp/ws.go
+++ b/engine/internal/mcp/ws.go
@@ -44,10 +44,16 @@ func newWSTransport(url string, headers map[string]string) (*wsTransport, error)
 	}, nil
 }
 
+// DefaultWriteTimeout is the MCP WebSocket write timeout.
+var DefaultWriteTimeout = 30 * time.Second
+
+// SetDefaultWriteTimeout overrides the default MCP WebSocket write timeout.
+func SetDefaultWriteTimeout(d time.Duration) { DefaultWriteTimeout = d }
+
 func (t *wsTransport) Send(msg json.RawMessage) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultWriteTimeout)
 	defer cancel()
 	return t.conn.Write(ctx, websocket.MessageText, msg)
 }

--- a/engine/internal/mcp/ws.go
+++ b/engine/internal/mcp/ws.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sync"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 )
 
 // wsTransport implements mcpTransport over a WebSocket connection.

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -620,6 +620,15 @@ func (s *Server) broadcast(line string) {
 	for _, cw := range clients {
 		select {
 		case cw.queue <- payload:
+			// If events were previously dropped, notify the client now that the queue has room.
+			if n := atomic.LoadInt64(&cw.dropped); n > 0 {
+				select {
+				case cw.queue <- eventsDroppedLine(n):
+					atomic.StoreInt64(&cw.dropped, 0)
+				default:
+					// Queue full again — notification will be retried on the next successful send.
+				}
+			}
 		default:
 			n := atomic.AddInt64(&cw.dropped, 1)
 			if n == 1 || n%256 == 0 {
@@ -631,6 +640,13 @@ func (s *Server) broadcast(line string) {
 	for _, lh := range listeners {
 		select {
 		case lh.queue <- line:
+			if n := atomic.LoadInt64(&lh.dropped); n > 0 {
+				select {
+				case lh.queue <- string(eventsDroppedLine(n)):
+					atomic.StoreInt64(&lh.dropped, 0)
+				default:
+				}
+			}
 		default:
 			n := atomic.AddInt64(&lh.dropped, 1)
 			if n == 1 || n%256 == 0 {
@@ -638,6 +654,11 @@ func (s *Server) broadcast(line string) {
 			}
 		}
 	}
+}
+
+// eventsDroppedLine returns a JSON line notifying the client that events were dropped.
+func eventsDroppedLine(count int64) []byte {
+	return []byte(fmt.Sprintf("{\"type\":\"engine_events_dropped\",\"count\":%d}\n", count))
 }
 
 // writeToClient routes a single line to the given conn through its queue, so

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -319,6 +319,13 @@ func (s *Server) drainListener(lh *listenerHandle) {
 
 func (s *Server) handleClient(conn net.Conn) {
 	defer s.evictClient(conn)
+	defer func() {
+		if r := recover(); r != nil {
+			buf := make([]byte, 4096)
+			n := runtime.Stack(buf, false)
+			utils.Error("Server", fmt.Sprintf("panic in handleClient: %v\n%s", r, buf[:n]))
+		}
+	}()
 
 	scanner := bufio.NewScanner(conn)
 	// Allow large messages (1MB)
@@ -348,6 +355,15 @@ func (s *Server) handleClient(conn net.Conn) {
 }
 
 func (s *Server) dispatch(conn net.Conn, cmd *protocol.ClientCommand) {
+	defer func() {
+		if r := recover(); r != nil {
+			buf := make([]byte, 4096)
+			n := runtime.Stack(buf, false)
+			utils.Error("Server", fmt.Sprintf("panic in dispatch cmd=%s key=%s: %v\n%s", cmd.Cmd, cmd.Key, r, buf[:n]))
+			s.sendResult(conn, cmd, fmt.Errorf("internal error"), nil)
+		}
+	}()
+
 	utils.Debug("Server", fmt.Sprintf("dispatch: cmd=%s key=%s requestID=%s", cmd.Cmd, cmd.Key, cmd.RequestID))
 	switch cmd.Cmd {
 	case "start_session":
@@ -498,6 +514,14 @@ func (s *Server) dispatch(conn net.Conn, cmd *protocol.ClientCommand) {
 		// Run in a goroutine to avoid blocking the client's read loop
 		// while the LLM call is in flight.
 		go func(c net.Conn, command *protocol.ClientCommand) {
+			defer func() {
+				if r := recover(); r != nil {
+					buf := make([]byte, 4096)
+					n := runtime.Stack(buf, false)
+					utils.Error("Server", fmt.Sprintf("panic in generate_title: %v\n%s", r, buf[:n]))
+					s.sendResult(c, command, fmt.Errorf("internal error"), nil)
+				}
+			}()
 			title, err := titling.GenerateTitle(context.Background(), command.Text)
 			if err != nil {
 				s.sendResult(c, command, err, nil)

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -39,8 +39,9 @@ func DefaultSocketPath() string {
 const broadcastQueueSize = 256
 
 // broadcastWriteDeadline is how long a single per-client write may take before
-// the drainer treats the connection as dead and evicts it.
-const broadcastWriteDeadline = 5 * time.Second
+// the drainer treats the connection as dead and evicts it. Configurable via
+// TimeoutsConfig.BroadcastWrite().
+var broadcastWriteDeadline = 5 * time.Second
 
 // clientWriter owns a connected client's outbound queue. A drain goroutine
 // reads from queue and writes to conn under a per-write deadline. Slow or
@@ -83,6 +84,9 @@ type Server struct {
 func (s *Server) SetConfig(cfg *types.EngineRuntimeConfig) {
 	s.config = cfg
 	s.manager.SetConfig(cfg)
+	if cfg != nil && cfg.Timeouts != nil {
+		broadcastWriteDeadline = cfg.Timeouts.BroadcastWrite()
+	}
 }
 
 // SetVersion stores the engine binary version for the health command.

--- a/engine/internal/server/server_test.go
+++ b/engine/internal/server/server_test.go
@@ -732,6 +732,180 @@ func TestStopNonExistentSession(t *testing.T) {
 	}
 }
 
+// ─── Panic recovery tests ───
+
+// registerPipeClient creates a net.Pipe, registers the server-side end in
+// srv.clients (so writeToClient can route results through the queue), starts
+// the drain goroutine, and returns the client-side end for reading.
+func registerPipeClient(t *testing.T, srv *Server) (serverConn, clientConn net.Conn) {
+	t.Helper()
+	serverConn, clientConn = net.Pipe()
+	cw := &clientWriter{
+		conn:  serverConn,
+		queue: make(chan []byte, broadcastQueueSize),
+		done:  make(chan struct{}),
+	}
+	srv.mu.Lock()
+	srv.clients[serverConn] = cw
+	srv.mu.Unlock()
+	go srv.drainClient(cw)
+	t.Cleanup(func() {
+		srv.evictClient(serverConn)
+		clientConn.Close()
+	})
+	return serverConn, clientConn
+}
+
+// TestDispatchPanicRecovery verifies that a panic in dispatch() is recovered and
+// returns a structured error result to the client, and the connection remains
+// functional for subsequent commands.
+func TestDispatchPanicRecovery(t *testing.T) {
+	mb := newMockBackend()
+	srv := newShortPathTestServer(t, mb)
+
+	serverConn, clientConn := registerPipeClient(t, srv)
+
+	// dispatch() dereferences *cmd.Config, which panics on nil. The recovery
+	// guard should catch it and send an error result.
+	cmd := &protocol.ClientCommand{
+		Cmd:       "start_session",
+		Key:       "panic-test",
+		RequestID: "req-panic",
+		Config:    nil, // will cause nil-pointer dereference
+	}
+	srv.dispatch(serverConn, cmd)
+
+	// Read the error result sent by the recovery guard.
+	lines := readLines(t, clientConn, 3, 2*time.Second)
+	r := findResult(t, lines)
+	if r == nil {
+		t.Fatalf("expected error result from panic recovery; lines=%v", lines)
+	}
+	if r.OK {
+		t.Error("expected ok=false from panic recovery, got true")
+	}
+	if r.RequestID != "req-panic" {
+		t.Errorf("expected requestId=req-panic, got %q", r.RequestID)
+	}
+	if r.Error != "internal error" {
+		t.Errorf("expected error='internal error', got %q", r.Error)
+	}
+
+	// Verify the server is still functional via a real socket client.
+	conn := dialServer(t, srv)
+	defer conn.Close()
+	sendJSON(t, conn, map[string]interface{}{
+		"cmd":       "list_sessions",
+		"requestId": "req-after-panic",
+	})
+	afterLines := readLines(t, conn, 3, 2*time.Second)
+	rAfter := findResult(t, afterLines)
+	if rAfter == nil {
+		t.Fatalf("server unresponsive after panic; lines=%v", afterLines)
+	}
+	if !rAfter.OK {
+		t.Errorf("list_sessions after panic failed: %s", rAfter.Error)
+	}
+}
+
+// TestDispatchPanicRecoveryRelayPath verifies that a panic via the relay path
+// (DispatchCommand with conn=nil) is recovered without a secondary panic from
+// sendResult writing to a nil conn.
+func TestDispatchPanicRecoveryRelayPath(t *testing.T) {
+	mb := newMockBackend()
+	srv := newShortPathTestServer(t, mb)
+
+	// DispatchCommand calls dispatch(nil, cmd). The nil-config causes a panic
+	// in dispatch(). The recovery guard calls sendResult(nil, ...) which must
+	// not panic itself (writeToClient has a nil-conn guard).
+	cmd := &protocol.ClientCommand{
+		Cmd:       "start_session",
+		Key:       "relay-panic",
+		RequestID: "req-relay-panic",
+		Config:    nil,
+	}
+	// This must not panic. If recovery or the nil-conn path is broken,
+	// the test process crashes.
+	srv.DispatchCommand(cmd)
+
+	// Verify the server is still functional: a new client can connect and
+	// execute commands.
+	conn := dialServer(t, srv)
+	defer conn.Close()
+
+	sendJSON(t, conn, map[string]interface{}{
+		"cmd":       "list_sessions",
+		"requestId": "req-after-relay-panic",
+	})
+	lines := readLines(t, conn, 3, 2*time.Second)
+	r := findResult(t, lines)
+	if r == nil {
+		t.Fatalf("server unresponsive after relay panic; lines=%v", lines)
+	}
+	if !r.OK {
+		t.Errorf("list_sessions after relay panic failed: %s", r.Error)
+	}
+}
+
+// TestDispatchPanicRecoveryServerSurvives verifies that a panic in one client's
+// dispatch does not affect other connected clients (daemon stability).
+func TestDispatchPanicRecoveryServerSurvives(t *testing.T) {
+	mb := newMockBackend()
+	srv := newShortPathTestServer(t, mb)
+
+	// Pipe client: will trigger a panic via direct dispatch call.
+	serverConn, clientConn := registerPipeClient(t, srv)
+
+	// Socket client: connected before the panic, should remain functional.
+	conn2 := dialServer(t, srv)
+	defer conn2.Close()
+
+	// Trigger a panic on the pipe client's dispatch path.
+	cmd := &protocol.ClientCommand{
+		Cmd:       "start_session",
+		Key:       "panic-victim",
+		RequestID: "req-victim",
+		Config:    nil,
+	}
+	srv.dispatch(serverConn, cmd)
+
+	// Drain the error result from the pipe client.
+	readLines(t, clientConn, 3, 1*time.Second)
+
+	// Socket client should be completely unaffected.
+	startSession(t, conn2, "survivor", "req-survivor")
+
+	// Verify via list_sessions that the survivor session exists.
+	sendJSON(t, conn2, map[string]interface{}{
+		"cmd":       "list_sessions",
+		"requestId": "req-list-survive",
+	})
+	lines := readLines(t, conn2, 5, 2*time.Second)
+	r := findResult(t, lines)
+	if r == nil {
+		t.Fatalf("conn2 unresponsive after panic; lines=%v", lines)
+	}
+	if !r.OK {
+		t.Errorf("list_sessions failed: %s", r.Error)
+	}
+
+	dataJSON, _ := json.Marshal(r.Data)
+	var sessions []protocol.SessionInfo
+	if err := json.Unmarshal(dataJSON, &sessions); err != nil {
+		t.Fatalf("unmarshal sessions: %v", err)
+	}
+	var found bool
+	for _, s := range sessions {
+		if s.Key == "survivor" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("survivor session not found after panic on another client")
+	}
+}
+
 // TestDuplicateStartSession verifies that starting a session with a key that
 // already exists returns success (idempotent) with existed=true.
 func TestDuplicateStartSession(t *testing.T) {

--- a/engine/internal/session/dialog_elicit.go
+++ b/engine/internal/session/dialog_elicit.go
@@ -70,7 +70,10 @@ func (m *Manager) elicit(s *engineSession, key string, info extension.Elicitatio
 		}
 	}()
 
-	const timeout = 5 * time.Minute
+	timeout := 5 * time.Minute
+	if m.config != nil && m.config.Timeouts != nil {
+		timeout = m.config.Timeouts.Elicitation()
+	}
 	select {
 	case reply := <-ch:
 		// Mirror the response back through the elicitation_result hook so

--- a/engine/internal/session/extcontext/dispatch_agent.go
+++ b/engine/internal/session/extcontext/dispatch_agent.go
@@ -38,6 +38,9 @@ func BuildDispatchAgentFunc(sa SessionAccessor) func(extension.DispatchAgentOpts
 		var childExtHost *extension.Host
 		if opts.ExtensionDir != "" {
 			childExtHost = extension.NewHost()
+			if cfg := sa.EngineConfig(); cfg != nil && cfg.Timeouts != nil {
+				childExtHost.SetRPCTimeout(cfg.Timeouts.ExtensionRpc())
+			}
 			extCfg := &extension.ExtensionConfig{
 				ExtensionDir:     opts.ExtensionDir,
 				Model:            model,

--- a/engine/internal/session/extcontext/extcontext.go
+++ b/engine/internal/session/extcontext/extcontext.go
@@ -3,6 +3,9 @@
 package extcontext
 
 import (
+	"context"
+	"time"
+
 	"github.com/dsswift/ion/engine/internal/backend"
 	"github.com/dsswift/ion/engine/internal/extension"
 	"github.com/dsswift/ion/engine/internal/mcp"
@@ -84,7 +87,16 @@ func NewExtContext(sa SessionAccessor) *extension.Context {
 			return sa.Elicit(info)
 		},
 		CallTool: func(toolName string, input map[string]interface{}) (string, bool, error) {
-			return CallToolFromExtension(sa, toolName, input)
+			return CallToolFromExtension(context.Background(), sa, toolName, input)
+		},
+		CallToolWithContext: func(toolName string, input map[string]interface{}, timeoutMs *float64) (string, bool, error) {
+			callCtx := context.Background()
+			if timeoutMs != nil && *timeoutMs > 0 {
+				var cancel context.CancelFunc
+				callCtx, cancel = context.WithTimeout(callCtx, time.Duration(*timeoutMs)*time.Millisecond)
+				defer cancel()
+			}
+			return CallToolFromExtension(callCtx, sa, toolName, input)
 		},
 		SendPrompt: func(text string, model string) error {
 			return sa.SendPrompt(text, model)

--- a/engine/internal/session/extcontext/tool_dispatch.go
+++ b/engine/internal/session/extcontext/tool_dispatch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dsswift/ion/engine/internal/tools"
 )
@@ -73,7 +74,9 @@ func CallToolFromExtension(sa SessionAccessor, toolName string, input map[string
 		innerName := parts[2]
 		for _, conn := range mcpConns {
 			if conn.Name() == serverName {
-				content, err := conn.CallTool(innerName, input)
+				callCtx, callCancel := context.WithTimeout(context.Background(), 60*time.Second)
+				content, err := conn.CallTool(callCtx, innerName, input)
+				callCancel()
 				if err != nil {
 					return "", true, err
 				}

--- a/engine/internal/session/extcontext/tool_dispatch.go
+++ b/engine/internal/session/extcontext/tool_dispatch.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
+	"github.com/dsswift/ion/engine/internal/mcp"
 	"github.com/dsswift/ion/engine/internal/tools"
 )
 
@@ -23,7 +23,7 @@ import (
 // tool names so the SDK can surface a Promise rejection on what is almost
 // always a programming error. Tool-internal failures resolve as
 // (errorMessage, true, nil).
-func CallToolFromExtension(sa SessionAccessor, toolName string, input map[string]interface{}) (string, bool, error) {
+func CallToolFromExtension(ctx context.Context, sa SessionAccessor, toolName string, input map[string]interface{}) (string, bool, error) {
 	if input == nil {
 		input = map[string]interface{}{}
 	}
@@ -53,7 +53,7 @@ func CallToolFromExtension(sa SessionAccessor, toolName string, input map[string
 
 	// 1. Built-in tools (Read, Write, Edit, Bash, Grep, Glob, Agent, etc).
 	if tools.GetTool(toolName) != nil {
-		toolResult, err := tools.ExecuteTool(context.Background(), toolName, input, cwd)
+		toolResult, err := tools.ExecuteTool(ctx, toolName, input, cwd)
 		if err != nil {
 			return "", true, err
 		}
@@ -74,7 +74,7 @@ func CallToolFromExtension(sa SessionAccessor, toolName string, input map[string
 		innerName := parts[2]
 		for _, conn := range mcpConns {
 			if conn.Name() == serverName {
-				callCtx, callCancel := context.WithTimeout(context.Background(), 60*time.Second)
+				callCtx, callCancel := context.WithTimeout(ctx, mcp.DefaultCallTimeout)
 				content, err := conn.CallTool(callCtx, innerName, input)
 				callCancel()
 				if err != nil {

--- a/engine/internal/session/prompt_extensions.go
+++ b/engine/internal/session/prompt_extensions.go
@@ -23,6 +23,9 @@ func (m *Manager) lateLoadExtensions(s *engineSession, key string, overrides *Pr
 	group := extension.NewExtensionGroup()
 	for _, extPath := range overrides.Extensions {
 		host := extension.NewHost()
+		if m.config != nil && m.config.Timeouts != nil {
+			host.SetRPCTimeout(m.config.Timeouts.ExtensionRpc())
+		}
 		if m.config != nil && m.config.Enterprise != nil && len(m.config.Enterprise.RequiredHooks) > 0 {
 			hooks := make([]struct{ Event, Handler string }, len(m.config.Enterprise.RequiredHooks))
 			for i, h := range m.config.Enterprise.RequiredHooks {

--- a/engine/internal/session/prompt_runconfig.go
+++ b/engine/internal/session/prompt_runconfig.go
@@ -1,8 +1,10 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dsswift/ion/engine/internal/backend"
 	ionconfig "github.com/dsswift/ion/engine/internal/config"
@@ -196,7 +198,9 @@ func (m *Manager) wireExternalTools(s *engineSession, key string, extGroup *exte
 			toolName := parts[2]
 			for _, conn := range mcpConns {
 				if conn.Name() == serverName {
-					content, err := conn.CallTool(toolName, input)
+					callCtx, callCancel := context.WithTimeout(context.Background(), 60*time.Second)
+					content, err := conn.CallTool(callCtx, toolName, input)
+					callCancel()
 					if err != nil {
 						return "", true, err
 					}

--- a/engine/internal/session/prompt_runconfig.go
+++ b/engine/internal/session/prompt_runconfig.go
@@ -33,6 +33,12 @@ func (m *Manager) buildRunConfig(
 ) *backend.RunConfig {
 	runCfg := &backend.RunConfig{}
 
+	// Thread timeouts config into the run so tool execution and the run loop
+	// can read configured values.
+	if m.config != nil && m.config.Timeouts != nil {
+		runCfg.Timeouts = m.config.Timeouts
+	}
+
 	if permEng != nil {
 		runCfg.PermEngine = permEng
 	}
@@ -198,7 +204,8 @@ func (m *Manager) wireExternalTools(s *engineSession, key string, extGroup *exte
 			toolName := parts[2]
 			for _, conn := range mcpConns {
 				if conn.Name() == serverName {
-					callCtx, callCancel := context.WithTimeout(context.Background(), 60*time.Second)
+					mcpTimeout := m.mcpCallTimeout()
+					callCtx, callCancel := context.WithTimeout(context.Background(), mcpTimeout)
 					content, err := conn.CallTool(callCtx, toolName, input)
 					callCancel()
 					if err != nil {
@@ -253,4 +260,12 @@ func (m *Manager) wireExternalTools(s *engineSession, key string, extGroup *exte
 		}
 		return "", true, fmt.Errorf("external tool %q not found", name)
 	}
+}
+
+// mcpCallTimeout returns the configured MCP call timeout or the default (60s).
+func (m *Manager) mcpCallTimeout() time.Duration {
+	if m.config != nil && m.config.Timeouts != nil {
+		return m.config.Timeouts.McpCall()
+	}
+	return 60 * time.Second
 }

--- a/engine/internal/session/start_session.go
+++ b/engine/internal/session/start_session.go
@@ -268,6 +268,9 @@ func (m *Manager) loadAndWireExtensions(s *engineSession, key string, config typ
 			EventMessage: fmt.Sprintf("Loading extension: %s", filepath.Base(filepath.Dir(extPath))),
 		})
 		host := extension.NewHost()
+		if m.config != nil && m.config.Timeouts != nil {
+			host.SetRPCTimeout(m.config.Timeouts.ExtensionRpc())
+		}
 
 		// Enterprise required hooks prepended before extension loads
 		if m.config != nil && m.config.Enterprise != nil && len(m.config.Enterprise.RequiredHooks) > 0 {

--- a/engine/internal/tools/bash.go
+++ b/engine/internal/tools/bash.go
@@ -32,7 +32,11 @@ func executeBash(ctx context.Context, input map[string]any, cwd string) (*types.
 		return &types.ToolResult{Content: "Error: command is required", IsError: true}, nil
 	}
 
-	timeoutMs := intFromInput(input, "timeout", 120000)
+	defaultMs := int64(120000)
+	if t := types.TimeoutsFrom(ctx); t != nil && t.BashDefaultMs != 0 {
+		defaultMs = t.BashDefaultMs
+	}
+	timeoutMs := intFromInput(input, "timeout", int(defaultMs))
 	timeout := time.Duration(timeoutMs) * time.Millisecond
 
 	ops := GetBashOperations()

--- a/engine/internal/tools/glob.go
+++ b/engine/internal/tools/glob.go
@@ -64,7 +64,11 @@ func executeGlob(ctx context.Context, input map[string]any, cwd string) (*types.
 	}
 
 	// Bound the walk by wall clock, regardless of caller ctx.
-	walkCtx, cancel := context.WithTimeout(ctx, globTimeout)
+	walkTimeout := globTimeout
+	if t := types.TimeoutsFrom(ctx); t != nil && t.GlobMs != 0 {
+		walkTimeout = t.Glob()
+	}
+	walkCtx, cancel := context.WithTimeout(ctx, walkTimeout)
 	defer cancel()
 
 	matches, truncated, err := globWithRipgrep(walkCtx, searchDir, pattern)
@@ -76,7 +80,7 @@ func executeGlob(ctx context.Context, input map[string]any, cwd string) (*types.
 		// timeout/cancel rather than crashing the run loop.
 		if errors.Is(err, context.DeadlineExceeded) {
 			return &types.ToolResult{
-				Content: fmt.Sprintf("Error: Glob exceeded %s deadline (pattern=%q under %q). Narrow the pattern or path.", globTimeout, pattern, searchDir),
+				Content: fmt.Sprintf("Error: Glob exceeded %s deadline (pattern=%q under %q). Narrow the pattern or path.", walkTimeout, pattern, searchDir),
 				IsError: true,
 			}, nil
 		}

--- a/engine/internal/tools/ssh_operations.go
+++ b/engine/internal/tools/ssh_operations.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/dsswift/ion/engine/internal/types"
 )
 
 // SSHConfig holds connection parameters for SSH-based bash execution.
@@ -26,6 +28,9 @@ func (s *SSHBashOperations) Exec(ctx context.Context, command, cwd string, opts 
 	timeout := opts.Timeout
 	if timeout == 0 {
 		timeout = 120 * time.Second
+		if t := types.TimeoutsFrom(ctx); t != nil && t.SshDefaultMs != 0 {
+			timeout = t.SshDefault()
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/engine/internal/tools/web_fetch.go
+++ b/engine/internal/tools/web_fetch.go
@@ -131,7 +131,11 @@ func executeWebFetch(ctx context.Context, input map[string]any, _ string) (*type
 	}
 
 	// Build request.
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	fetchTimeout := 30 * time.Second
+	if t := types.TimeoutsFrom(ctx); t != nil && t.WebFetchMs != 0 {
+		fetchTimeout = t.WebFetch()
+	}
+	ctx, cancel := context.WithTimeout(ctx, fetchTimeout)
 	defer cancel()
 
 	var bodyReader io.Reader
@@ -156,7 +160,7 @@ func executeWebFetch(ctx context.Context, input map[string]any, _ string) (*type
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		if ctx.Err() != nil {
-			return &types.ToolResult{Content: "Request timed out after 30s", IsError: true}, nil
+			return &types.ToolResult{Content: fmt.Sprintf("Request timed out after %s", fetchTimeout), IsError: true}, nil
 		}
 		return &types.ToolResult{Content: fmt.Sprintf("Fetch error: %s", err), IsError: true}, nil
 	}

--- a/engine/internal/transport/relay.go
+++ b/engine/internal/transport/relay.go
@@ -82,10 +82,8 @@ func (r *RelayTransport) connectLoop(handler func(conn Conn)) {
 
 			r.mu.Lock()
 			r.attempt++
-			if r.attempt > 100 {
-				r.mu.Unlock()
-				utils.Log("Relay", "max reconnection attempts reached")
-				return
+			if r.attempt > 0 && r.attempt%50 == 0 {
+				utils.Warn("Relay", fmt.Sprintf("still trying to reconnect (attempt %d)", r.attempt))
 			}
 			r.mu.Unlock()
 			continue

--- a/engine/internal/transport/relay.go
+++ b/engine/internal/transport/relay.go
@@ -130,12 +130,15 @@ func (r *RelayTransport) dial() error {
 		HTTPHeader: http.Header{
 			"Authorization": []string{"Bearer " + r.apiKey},
 		},
+		CompressionMode: websocket.CompressionContextTakeover,
 	}
 
 	conn, _, err := websocket.Dial(context.Background(), dialURL, opts)
 	if err != nil {
 		return fmt.Errorf("websocket dial: %w", err)
 	}
+
+	conn.SetReadLimit(1024 * 1024) // 1MB, matching relay server limit
 
 	r.mu.Lock()
 	r.conn = conn
@@ -207,7 +210,9 @@ func (r *RelayTransport) Broadcast(data []byte) {
 		return
 	}
 
-	err := conn.Write(context.Background(), websocket.MessageText, data)
+	writeCtx, writeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer writeCancel()
+	err := conn.Write(writeCtx, websocket.MessageText, data)
 	if err != nil {
 		utils.Log("Relay", fmt.Sprintf("broadcast write error: %v", err))
 	}

--- a/engine/internal/transport/relay.go
+++ b/engine/internal/transport/relay.go
@@ -30,6 +30,9 @@ type RelayTransport struct {
 	apiKey    string
 	channelID string
 
+	// writeTimeout is the timeout for relay broadcast writes (default 10s).
+	writeTimeout time.Duration
+
 	// OnMessage is called for each non-control WebSocket message received
 	// from the relay (i.e. commands forwarded from the mobile peer).
 	// Must be set before calling Listen.
@@ -45,11 +48,17 @@ type RelayTransport struct {
 // NewRelayTransport creates a relay transport targeting the given WebSocket URL.
 func NewRelayTransport(url, apiKey, channelID string) *RelayTransport {
 	return &RelayTransport{
-		url:       url,
-		apiKey:    apiKey,
-		channelID: channelID,
-		done:      make(chan struct{}),
+		url:          url,
+		apiKey:       apiKey,
+		channelID:    channelID,
+		writeTimeout: 10 * time.Second,
+		done:         make(chan struct{}),
 	}
+}
+
+// SetWriteTimeout overrides the relay broadcast write timeout.
+func (r *RelayTransport) SetWriteTimeout(d time.Duration) {
+	r.writeTimeout = d
 }
 
 // Listen starts the WebSocket connection loop with reconnection.
@@ -208,7 +217,7 @@ func (r *RelayTransport) Broadcast(data []byte) {
 		return
 	}
 
-	writeCtx, writeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	writeCtx, writeCancel := context.WithTimeout(context.Background(), r.writeTimeout)
 	defer writeCancel()
 	err := conn.Write(writeCtx, websocket.MessageText, data)
 	if err != nil {

--- a/engine/internal/transport/relay.go
+++ b/engine/internal/transport/relay.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 
 	"github.com/dsswift/ion/engine/internal/utils"
 )

--- a/engine/internal/types/config.go
+++ b/engine/internal/types/config.go
@@ -113,13 +113,14 @@ type LimitsConfig struct {
 
 // McpServerConfig defines an MCP server connection.
 type McpServerConfig struct {
-	Type    string            `json:"type"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	URL     string            `json:"url,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
-	OAuth   *McpOAuthConfig   `json:"oauth,omitempty"`
+	Type           string            `json:"type"`
+	Command        string            `json:"command,omitempty"`
+	Args           []string          `json:"args,omitempty"`
+	URL            string            `json:"url,omitempty"`
+	Env            map[string]string `json:"env,omitempty"`
+	Headers        map[string]string `json:"headers,omitempty"`
+	OAuth          *McpOAuthConfig   `json:"oauth,omitempty"`
+	TimeoutSeconds int               `json:"timeoutSeconds,omitempty"`
 }
 
 // McpOAuthConfig holds OAuth 2.0 settings for an MCP server.

--- a/engine/internal/types/config.go
+++ b/engine/internal/types/config.go
@@ -74,6 +74,7 @@ type EngineRuntimeConfig struct {
 	Enterprise   *EnterpriseConfig             `json:"enterprise,omitempty"`
 	FeatureFlags *FeatureFlagsConfig           `json:"featureFlags,omitempty"`
 	Relay        *RelayConfig                  `json:"relay,omitempty"`
+	Timeouts     *TimeoutsConfig               `json:"timeouts,omitempty"`
 	LogLevel     string                        `json:"logLevel,omitempty"` // "debug", "info", "warn", "error"
 }
 

--- a/engine/internal/types/timeouts.go
+++ b/engine/internal/types/timeouts.go
@@ -1,0 +1,179 @@
+package types
+
+import (
+	"context"
+	"time"
+)
+
+// TimeoutsConfig allows harness engineers to override the engine's default
+// timeouts and retry limits via ion.json. Every field uses milliseconds
+// (except TruncationRetries) and a zero value means "use the compiled default".
+// The struct is nil-safe: all accessors accept a nil receiver and return the
+// hardcoded default.
+type TimeoutsConfig struct {
+	ToolDefaultMs     int64 `json:"toolDefaultMs,omitempty"`     // default: 300000 (5min)
+	ToolStallMs       int64 `json:"toolStallMs,omitempty"`       // default: 30000
+	BashDefaultMs     int64 `json:"bashDefaultMs,omitempty"`     // default: 120000
+	McpCallMs         int64 `json:"mcpCallMs,omitempty"`         // default: 60000
+	McpMetadataMs     int64 `json:"mcpMetadataMs,omitempty"`     // default: 30000
+	McpWriteMs        int64 `json:"mcpWriteMs,omitempty"`        // default: 30000
+	WebFetchMs        int64 `json:"webFetchMs,omitempty"`        // default: 30000
+	GlobMs            int64 `json:"globMs,omitempty"`            // default: 60000
+	SshDefaultMs      int64 `json:"sshDefaultMs,omitempty"`      // default: 120000
+	ExtensionRpcMs    int64 `json:"extensionRpcMs,omitempty"`    // default: 30000
+	HookDefaultMs     int64 `json:"hookDefaultMs,omitempty"`     // default: 30000
+	ElicitationMs     int64 `json:"elicitationMs,omitempty"`     // default: 300000 (5min)
+	RelayWriteMs      int64 `json:"relayWriteMs,omitempty"`      // default: 10000
+	BroadcastWriteMs  int64 `json:"broadcastWriteMs,omitempty"`  // default: 5000
+	TruncationRetries int   `json:"truncationRetries,omitempty"` // default: 3
+}
+
+func (t *TimeoutsConfig) durationOr(val int64, defaultMs int64) time.Duration {
+	if t == nil || val == 0 {
+		return time.Duration(defaultMs) * time.Millisecond
+	}
+	return time.Duration(val) * time.Millisecond
+}
+
+func (t *TimeoutsConfig) intOr(val int, defaultVal int) int {
+	if t == nil || val == 0 {
+		return defaultVal
+	}
+	return val
+}
+
+// ToolDefault returns the per-tool execution timeout (default 5min).
+func (t *TimeoutsConfig) ToolDefault() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.ToolDefaultMs }), 300000) }
+
+// ToolStall returns the stall detection threshold (default 30s).
+func (t *TimeoutsConfig) ToolStall() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.ToolStallMs }), 30000) }
+
+// BashDefault returns the default bash command timeout (default 120s).
+func (t *TimeoutsConfig) BashDefault() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.BashDefaultMs }), 120000) }
+
+// McpCall returns the MCP tool call timeout (default 60s).
+func (t *TimeoutsConfig) McpCall() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.McpCallMs }), 60000) }
+
+// McpMetadata returns the MCP metadata operation timeout (default 30s).
+func (t *TimeoutsConfig) McpMetadata() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.McpMetadataMs }), 30000) }
+
+// McpWrite returns the MCP WebSocket write timeout (default 30s).
+func (t *TimeoutsConfig) McpWrite() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.McpWriteMs }), 30000) }
+
+// WebFetch returns the web fetch request timeout (default 30s).
+func (t *TimeoutsConfig) WebFetch() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.WebFetchMs }), 30000) }
+
+// Glob returns the glob walk timeout (default 60s).
+func (t *TimeoutsConfig) Glob() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.GlobMs }), 60000) }
+
+// SshDefault returns the SSH command timeout (default 120s).
+func (t *TimeoutsConfig) SshDefault() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.SshDefaultMs }), 120000) }
+
+// ExtensionRpc returns the extension RPC call timeout (default 30s).
+func (t *TimeoutsConfig) ExtensionRpc() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.ExtensionRpcMs }), 30000) }
+
+// HookDefault returns the default external hook execution timeout (default 30s).
+func (t *TimeoutsConfig) HookDefault() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.HookDefaultMs }), 30000) }
+
+// Elicitation returns the elicitation wait timeout (default 5min).
+func (t *TimeoutsConfig) Elicitation() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.ElicitationMs }), 300000) }
+
+// RelayWrite returns the relay forward write timeout (default 10s).
+func (t *TimeoutsConfig) RelayWrite() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.RelayWriteMs }), 10000) }
+
+// BroadcastWrite returns the server broadcast write timeout (default 5s).
+func (t *TimeoutsConfig) BroadcastWrite() time.Duration { return t.durationOr(t.field(func(c *TimeoutsConfig) int64 { return c.BroadcastWriteMs }), 5000) }
+
+// TruncationRetryLimit returns the max consecutive truncation retries (default 3).
+func (t *TimeoutsConfig) TruncationRetryLimit() int { return t.intOr(t.intField(func(c *TimeoutsConfig) int { return c.TruncationRetries }), 3) }
+
+// field extracts a field value, returning 0 for nil receiver.
+func (t *TimeoutsConfig) field(fn func(*TimeoutsConfig) int64) int64 {
+	if t == nil {
+		return 0
+	}
+	return fn(t)
+}
+
+// intField extracts an int field value, returning 0 for nil receiver.
+func (t *TimeoutsConfig) intField(fn func(*TimeoutsConfig) int) int {
+	if t == nil {
+		return 0
+	}
+	return fn(t)
+}
+
+// --- Context threading ---
+
+type timeoutsKey struct{}
+
+// WithTimeouts stores a TimeoutsConfig in the context for tool functions
+// to read without changing the Execute signature.
+func WithTimeouts(ctx context.Context, t *TimeoutsConfig) context.Context {
+	return context.WithValue(ctx, timeoutsKey{}, t)
+}
+
+// TimeoutsFrom retrieves a TimeoutsConfig from the context. Returns nil if
+// none is set (callers should use the typed accessors which are nil-safe).
+func TimeoutsFrom(ctx context.Context) *TimeoutsConfig {
+	t, _ := ctx.Value(timeoutsKey{}).(*TimeoutsConfig)
+	return t
+}
+
+// MergeTimeouts copies non-zero fields from src into dst. Both pointers
+// may be nil; returns the merged result (or nil if both are nil).
+func MergeTimeouts(dst, src *TimeoutsConfig) *TimeoutsConfig {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		dup := *src
+		return &dup
+	}
+	if src.ToolDefaultMs != 0 {
+		dst.ToolDefaultMs = src.ToolDefaultMs
+	}
+	if src.ToolStallMs != 0 {
+		dst.ToolStallMs = src.ToolStallMs
+	}
+	if src.BashDefaultMs != 0 {
+		dst.BashDefaultMs = src.BashDefaultMs
+	}
+	if src.McpCallMs != 0 {
+		dst.McpCallMs = src.McpCallMs
+	}
+	if src.McpMetadataMs != 0 {
+		dst.McpMetadataMs = src.McpMetadataMs
+	}
+	if src.McpWriteMs != 0 {
+		dst.McpWriteMs = src.McpWriteMs
+	}
+	if src.WebFetchMs != 0 {
+		dst.WebFetchMs = src.WebFetchMs
+	}
+	if src.GlobMs != 0 {
+		dst.GlobMs = src.GlobMs
+	}
+	if src.SshDefaultMs != 0 {
+		dst.SshDefaultMs = src.SshDefaultMs
+	}
+	if src.ExtensionRpcMs != 0 {
+		dst.ExtensionRpcMs = src.ExtensionRpcMs
+	}
+	if src.HookDefaultMs != 0 {
+		dst.HookDefaultMs = src.HookDefaultMs
+	}
+	if src.ElicitationMs != 0 {
+		dst.ElicitationMs = src.ElicitationMs
+	}
+	if src.RelayWriteMs != 0 {
+		dst.RelayWriteMs = src.RelayWriteMs
+	}
+	if src.BroadcastWriteMs != 0 {
+		dst.BroadcastWriteMs = src.BroadcastWriteMs
+	}
+	if src.TruncationRetries != 0 {
+		dst.TruncationRetries = src.TruncationRetries
+	}
+	return dst
+}

--- a/relay/go.mod
+++ b/relay/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.26.3
 
 require (
+	github.com/coder/websocket v1.8.14
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/gorilla/websocket v1.5.3
 	golang.org/x/net v0.53.0
 )
 

--- a/relay/go.sum
+++ b/relay/go.sum
@@ -1,7 +1,7 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=

--- a/relay/main.go
+++ b/relay/main.go
@@ -61,7 +61,7 @@ func main() {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"status":"ok"}`))
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
 	mux.HandleFunc("GET /v1/channel/{channelId}", func(w http.ResponseWriter, r *http.Request) {

--- a/relay/main.go
+++ b/relay/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 )
@@ -42,6 +43,29 @@ func main() {
 	cfg := loadConfig()
 
 	hub := NewHub()
+
+	// Apply optional env var overrides for relay timeouts.
+	if v := os.Getenv("RELAY_WRITE_TIMEOUT_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
+			hub.WriteTimeout = time.Duration(ms) * time.Millisecond
+		}
+	}
+	if v := os.Getenv("RELAY_PING_INTERVAL_S"); v != "" {
+		if s, err := strconv.Atoi(v); err == nil && s > 0 {
+			hub.PingInterval = time.Duration(s) * time.Second
+		}
+	}
+	if v := os.Getenv("RELAY_PING_TIMEOUT_S"); v != "" {
+		if s, err := strconv.Atoi(v); err == nil && s > 0 {
+			hub.PingTimeout = time.Duration(s) * time.Second
+		}
+	}
+	if v := os.Getenv("RELAY_MAX_MESSAGE_SIZE"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			hub.MaxMessageSize = n
+		}
+	}
+
 	auth := NewAuthMiddleware(cfg.APIKey)
 
 	var pusher *APNsPusher

--- a/relay/mdns.go
+++ b/relay/mdns.go
@@ -16,8 +16,8 @@ type MDNSHandle struct {
 
 func (h *MDNSHandle) Shutdown() {
 	if h.cmd != nil && h.cmd.Process != nil {
-		h.cmd.Process.Kill()
-		h.cmd.Wait()
+		_ = h.cmd.Process.Kill()
+		_ = h.cmd.Wait()
 	}
 }
 

--- a/relay/push.go
+++ b/relay/push.go
@@ -187,7 +187,7 @@ func (p *APNsPusher) sendAsync(deviceToken, title, body string) {
 		log.Printf("APNs send error: %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -1,47 +1,21 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 )
-
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  64 * 1024,
-	WriteBufferSize: 256 * 1024,
-	// Reject connections with an Origin header. Native apps (Ion desktop,
-	// iOS) don't send Origin; browsers do. This prevents browser-based
-	// cross-site WebSocket hijacking attacks against the relay.
-	CheckOrigin: func(r *http.Request) bool {
-		return r.Header.Get("Origin") == ""
-	},
-}
-
-// SafeConn wraps a websocket.Conn with a write mutex.
-// gorilla/websocket requires that at most one goroutine calls write methods
-// concurrently. SafeConn serializes all writes through SafeWrite.
-type SafeConn struct {
-	*websocket.Conn
-	writeMu sync.Mutex
-}
-
-// SafeWrite sends a WebSocket message while holding the write mutex.
-func (sc *SafeConn) SafeWrite(msgType int, data []byte, deadline time.Duration) error {
-	sc.writeMu.Lock()
-	defer sc.writeMu.Unlock()
-	sc.Conn.SetWriteDeadline(time.Now().Add(deadline))
-	return sc.Conn.WriteMessage(msgType, data)
-}
 
 // Channel holds the two sides of a relay channel.
 type Channel struct {
 	mu     sync.Mutex
-	ion    *SafeConn
-	mobile *SafeConn
+	ion    *websocket.Conn
+	mobile *websocket.Conn
 
 	// APNs device token for push notifications (set by mobile on connect).
 	apnsToken string
@@ -91,14 +65,21 @@ func (h *Hub) CloseAll() {
 	for _, ch := range h.channels {
 		ch.mu.Lock()
 		if ch.ion != nil {
-			ch.ion.Close()
+			_ = ch.ion.CloseNow()
 		}
 		if ch.mobile != nil {
-			ch.mobile.Close()
+			_ = ch.mobile.CloseNow()
 		}
 		ch.mu.Unlock()
 	}
 	h.channels = make(map[string]*Channel)
+}
+
+// ChannelCount returns the number of active channels (used by tests).
+func (h *Hub) ChannelCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.channels)
 }
 
 // controlMessage is a relay-originated control frame.
@@ -106,9 +87,13 @@ type controlMessage struct {
 	Type string `json:"type"`
 }
 
-func sendControl(conn *SafeConn, msgType string) {
+func sendControl(conn *websocket.Conn, msgType string) {
 	msg, _ := json.Marshal(controlMessage{Type: msgType})
-	conn.SafeWrite(websocket.TextMessage, msg, 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := conn.Write(ctx, websocket.MessageText, msg); err != nil {
+		log.Printf("sendControl(%s) error: %v", msgType, err)
+	}
 }
 
 // relayMessage wraps a forwarded payload to check for push flags.
@@ -119,13 +104,24 @@ type relayMessage struct {
 }
 
 func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID, role string, pusher *APNsPusher) {
-	rawConn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		log.Printf("upgrade error: %v", err)
+	// Reject connections with an Origin header. Native apps (Ion desktop,
+	// iOS) don't send Origin; browsers do. This prevents browser-based
+	// cross-site WebSocket hijacking attacks against the relay.
+	if r.Header.Get("Origin") != "" {
+		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
 	}
 
-	conn := &SafeConn{Conn: rawConn}
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		log.Printf("accept error: %v", err)
+		return
+	}
+
+	// Allow messages up to 1MB (default is 32KB).
+	conn.SetReadLimit(1024 * 1024)
 
 	ch := h.getOrCreateChannel(channelID)
 
@@ -135,12 +131,12 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 	switch role {
 	case "ion":
 		if ch.ion != nil {
-			ch.ion.Close()
+			_ = ch.ion.CloseNow()
 		}
 		ch.ion = conn
 	case "mobile":
 		if ch.mobile != nil {
-			ch.mobile.Close()
+			_ = ch.mobile.CloseNow()
 		}
 		ch.mobile = conn
 	}
@@ -162,19 +158,15 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 
 	log.Printf("channel=%s role=%s connected", channelID, role)
 
-	// Set up ping/pong keepalive.
-	conn.SetPongHandler(func(string) error {
-		conn.SetReadDeadline(time.Now().Add(90 * time.Second))
-		return nil
-	})
-	conn.SetReadDeadline(time.Now().Add(90 * time.Second))
-
+	// Start keepalive pings. Essential for public internet deployments where
+	// NAT timeouts, load balancer idle limits, and mobile network switches
+	// can silently kill connections.
 	done := make(chan struct{})
-	go h.ping(conn, done)
+	go ping(conn, done)
 
 	// Read loop: forward messages to the peer.
 	for {
-		msgType, data, err := conn.ReadMessage()
+		msgType, data, err := conn.Read(context.Background())
 		if err != nil {
 			break
 		}
@@ -185,9 +177,11 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 		ch.mu.Unlock()
 
 		if peer != nil {
-			if err := peer.SafeWrite(msgType, data, 10*time.Second); err != nil {
+			writeCtx, writeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := peer.Write(writeCtx, msgType, data); err != nil {
 				log.Printf("channel=%s forward error: %v", channelID, err)
 			}
+			writeCancel()
 		} else if role == "ion" && pusher != nil && apnsToken != "" {
 			// Peer not connected. Check if this message requests a push notification.
 			var msg relayMessage
@@ -227,17 +221,20 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 	log.Printf("channel=%s role=%s disconnected", channelID, role)
 	h.removeIfEmpty(channelID)
 	close(done)
-	_ = conn.Close()
+	_ = conn.CloseNow()
 }
 
-func (ch *Channel) getPeerLocked(myRole string) *SafeConn {
+func (ch *Channel) getPeerLocked(myRole string) *websocket.Conn {
 	if myRole == "ion" {
 		return ch.mobile
 	}
 	return ch.ion
 }
 
-func (h *Hub) ping(conn *SafeConn, done <-chan struct{}) {
+// ping sends WebSocket pings every 30s to detect dead connections.
+// If a pong is not received within 10s, the connection is closed,
+// which causes the read loop to exit.
+func ping(conn *websocket.Conn, done <-chan struct{}) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -245,7 +242,11 @@ func (h *Hub) ping(conn *SafeConn, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			if err := conn.SafeWrite(websocket.PingMessage, nil, 5*time.Second); err != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			err := conn.Ping(ctx)
+			cancel()
+			if err != nil {
+				_ = conn.CloseNow()
 				return
 			}
 		}

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -25,11 +25,21 @@ type Channel struct {
 type Hub struct {
 	mu       sync.RWMutex
 	channels map[string]*Channel
+
+	// Configurable timeouts and limits (set at construction, read-only after).
+	WriteTimeout   time.Duration // forward write deadline (default 10s)
+	PingInterval   time.Duration // keepalive ping interval (default 30s)
+	PingTimeout    time.Duration // pong wait deadline (default 10s)
+	MaxMessageSize int64         // read limit in bytes (default 1MB)
 }
 
 func NewHub() *Hub {
 	return &Hub{
-		channels: make(map[string]*Channel),
+		channels:       make(map[string]*Channel),
+		WriteTimeout:   10 * time.Second,
+		PingInterval:   30 * time.Second,
+		PingTimeout:    10 * time.Second,
+		MaxMessageSize: 1024 * 1024,
 	}
 }
 
@@ -87,9 +97,9 @@ type controlMessage struct {
 	Type string `json:"type"`
 }
 
-func sendControl(conn *websocket.Conn, msgType string) {
+func sendControl(conn *websocket.Conn, msgType string, timeout time.Duration) {
 	msg, _ := json.Marshal(controlMessage{Type: msgType})
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	if err := conn.Write(ctx, websocket.MessageText, msg); err != nil {
 		log.Printf("sendControl(%s) error: %v", msgType, err)
@@ -121,8 +131,8 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 		return
 	}
 
-	// Allow messages up to 1MB (default is 32KB).
-	conn.SetReadLimit(1024 * 1024)
+	// Allow messages up to the configured max (default 1MB).
+	conn.SetReadLimit(h.MaxMessageSize)
 
 	ch := h.getOrCreateChannel(channelID)
 
@@ -152,7 +162,7 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 	// Notify peer that the other side connected.
 	peer := ch.getPeerLocked(role)
 	if peer != nil {
-		sendControl(peer, "relay:peer-reconnected")
+		sendControl(peer, "relay:peer-reconnected", h.WriteTimeout)
 	}
 
 	ch.mu.Unlock()
@@ -163,7 +173,7 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 	// NAT timeouts, load balancer idle limits, and mobile network switches
 	// can silently kill connections.
 	done := make(chan struct{})
-	go ping(conn, done)
+	go ping(conn, done, h.PingInterval, h.PingTimeout)
 
 	// Read loop: forward messages to the peer.
 	for {
@@ -178,7 +188,7 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 		ch.mu.Unlock()
 
 		if peer != nil {
-			writeCtx, writeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			writeCtx, writeCancel := context.WithTimeout(context.Background(), h.WriteTimeout)
 			if err := peer.Write(writeCtx, msgType, data); err != nil {
 				log.Printf("channel=%s forward error: %v", channelID, err)
 			}
@@ -216,7 +226,7 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 	ch.mu.Unlock()
 
 	if peer != nil {
-		sendControl(peer, "relay:peer-disconnected")
+		sendControl(peer, "relay:peer-disconnected", h.WriteTimeout)
 	}
 
 	log.Printf("channel=%s role=%s disconnected", channelID, role)
@@ -232,18 +242,18 @@ func (ch *Channel) getPeerLocked(myRole string) *websocket.Conn {
 	return ch.ion
 }
 
-// ping sends WebSocket pings every 30s to detect dead connections.
-// If a pong is not received within 10s, the connection is closed,
+// ping sends WebSocket pings at the configured interval to detect dead connections.
+// If a pong is not received within pingTimeout, the connection is closed,
 // which causes the read loop to exit.
-func ping(conn *websocket.Conn, done <-chan struct{}) {
-	ticker := time.NewTicker(30 * time.Second)
+func ping(conn *websocket.Conn, done <-chan struct{}, interval, pingTimeout time.Duration) {
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-done:
 			return
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
 			err := conn.Ping(ctx)
 			cancel()
 			if err != nil {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -114,6 +114,7 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
+		CompressionMode:    websocket.CompressionContextTakeover,
 	})
 	if err != nil {
 		log.Printf("accept error: %v", err)
@@ -131,12 +132,12 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 	switch role {
 	case "ion":
 		if ch.ion != nil {
-			_ = ch.ion.CloseNow()
+			_ = ch.ion.Close(websocket.StatusGoingAway, "replaced")
 		}
 		ch.ion = conn
 	case "mobile":
 		if ch.mobile != nil {
-			_ = ch.mobile.CloseNow()
+			_ = ch.mobile.Close(websocket.StatusGoingAway, "replaced")
 		}
 		ch.mobile = conn
 	}

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/coder/websocket"
 )
 
 func startTestRelay(t *testing.T, apiKey string) (*httptest.Server, *Hub) {
@@ -45,14 +48,30 @@ func startTestRelay(t *testing.T, apiKey string) (*httptest.Server, *Hub) {
 func dialWS(t *testing.T, server *httptest.Server, channelID, role, apiKey string) *websocket.Conn {
 	t.Helper()
 	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/channel/" + channelID + "?role=" + role
-	header := http.Header{}
-	header.Set("Authorization", "Bearer "+apiKey)
-	conn, resp, err := websocket.DefaultDialer.Dial(url, header)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer " + apiKey},
+		},
+	})
 	if err != nil {
-		t.Fatalf("dial failed: %v (resp: %v)", err, resp)
+		t.Fatalf("dial failed: %v", err)
 	}
-	t.Cleanup(func() { conn.Close() })
+	t.Cleanup(func() { conn.CloseNow() })
 	return conn
+}
+
+// readExpected reads one message with a timeout. Returns the data or fails the test.
+func readExpected(t *testing.T, conn *websocket.Conn, label string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("%s: read error: %v", label, err)
+	}
+	return data
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -71,10 +90,14 @@ func TestAuthRejectsInvalidKey(t *testing.T) {
 	server, _ := startTestRelay(t, "correct-key")
 
 	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/channel/abc123?role=ion"
-	header := http.Header{}
-	header.Set("Authorization", "Bearer wrong-key")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	_, resp, err := websocket.DefaultDialer.Dial(url, header)
+	_, resp, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer wrong-key"},
+		},
+	})
 	if err == nil {
 		t.Fatal("expected dial to fail with invalid key")
 	}
@@ -87,24 +110,16 @@ func TestAuthRejectsMissingKey(t *testing.T) {
 	server, _ := startTestRelay(t, "correct-key")
 
 	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/channel/abc123?role=ion"
-	_, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, resp, err := websocket.Dial(ctx, url, nil)
 	if err == nil {
 		t.Fatal("expected dial to fail without auth header")
 	}
 	if resp != nil && resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("expected 401, got %d", resp.StatusCode)
 	}
-}
-
-// readExpected reads one message with a timeout. Returns the data or fails the test.
-func readExpected(t *testing.T, conn *websocket.Conn, label string) []byte {
-	t.Helper()
-	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	_, data, err := conn.ReadMessage()
-	if err != nil {
-		t.Fatalf("%s: read error: %v", label, err)
-	}
-	return data
 }
 
 func TestBidirectionalForwarding(t *testing.T) {
@@ -124,14 +139,15 @@ func TestBidirectionalForwarding(t *testing.T) {
 	}
 
 	// Ion -> Mobile
-	ionConn.WriteMessage(websocket.TextMessage, []byte(`{"msg":"hello from ion"}`))
+	ctx := context.Background()
+	ionConn.Write(ctx, websocket.MessageText, []byte(`{"msg":"hello from ion"}`))
 	data := readExpected(t, mobileConn, "mobile")
 	if string(data) != `{"msg":"hello from ion"}` {
 		t.Errorf("mobile got: %s", data)
 	}
 
 	// Mobile -> Ion
-	mobileConn.WriteMessage(websocket.TextMessage, []byte(`{"msg":"hello from mobile"}`))
+	mobileConn.Write(ctx, websocket.MessageText, []byte(`{"msg":"hello from mobile"}`))
 	data = readExpected(t, ionConn, "ion")
 	if string(data) != `{"msg":"hello from mobile"}` {
 		t.Errorf("ion got: %s", data)
@@ -153,7 +169,8 @@ func TestChannelIsolation(t *testing.T) {
 	ion2 := dialWS(t, server, "chan-b", "ion", apiKey)
 
 	// Send from ion1 on chan-a.
-	ion1.WriteMessage(websocket.TextMessage, []byte("for-chan-a"))
+	ctx := context.Background()
+	ion1.Write(ctx, websocket.MessageText, []byte("for-chan-a"))
 
 	// Mobile1 on chan-a should receive it.
 	data := readExpected(t, mobile1, "mobile1")
@@ -162,8 +179,9 @@ func TestChannelIsolation(t *testing.T) {
 	}
 
 	// ion2 on chan-b should NOT receive it (timeout expected).
-	ion2.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
-	_, _, err := ion2.ReadMessage()
+	readCtx, readCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer readCancel()
+	_, _, err := ion2.Read(readCtx)
 	if err == nil {
 		t.Error("ion2 should not have received a message from chan-a")
 	}
@@ -184,7 +202,7 @@ func TestPeerDisconnectNotification(t *testing.T) {
 	}
 
 	// Close mobile.
-	mobileConn.Close()
+	mobileConn.Close(websocket.StatusNormalClosure, "bye")
 
 	// Ion should get peer-disconnected.
 	data := readExpected(t, ionConn, "ion-disconnect")
@@ -197,13 +215,258 @@ func TestInvalidRoleRejected(t *testing.T) {
 	server, _ := startTestRelay(t, "test-key")
 
 	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/channel/abc?role=invalid"
-	header := http.Header{}
-	header.Set("Authorization", "Bearer test-key")
-	_, resp, err := websocket.DefaultDialer.Dial(url, header)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, resp, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer test-key"},
+		},
+	})
 	if err == nil {
 		t.Fatal("expected dial to fail with invalid role")
 	}
 	if resp != nil && resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+// --- New tests for migration coverage ---
+
+func TestOriginRejected(t *testing.T) {
+	server, _ := startTestRelay(t, "test-key")
+
+	url := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/channel/abc?role=ion"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, resp, err := websocket.Dial(ctx, url, &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer test-key"},
+			"Origin":        []string{"http://evil.com"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected dial to fail when Origin header is present")
+	}
+	if resp != nil && resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", resp.StatusCode)
+	}
+}
+
+func TestOriginAbsentAllowed(t *testing.T) {
+	server, _ := startTestRelay(t, "test-key")
+
+	// dialWS does not set Origin (simulating native client).
+	conn := dialWS(t, server, "origin-ok", "ion", "test-key")
+
+	// Verify the connection works by writing and checking no error.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := conn.Write(ctx, websocket.MessageText, []byte(`{"ping":true}`))
+	if err != nil {
+		t.Fatalf("write failed on connection without Origin: %v", err)
+	}
+}
+
+func TestRoleReconnectionReplacesPrevious(t *testing.T) {
+	apiKey := "test-key-reconn"
+	server, _ := startTestRelay(t, apiKey)
+
+	// Connect first ion.
+	ion1 := dialWS(t, server, "chan-reconn", "ion", apiKey)
+
+	// Connect mobile so we can test forwarding.
+	mobile := dialWS(t, server, "chan-reconn", "mobile", apiKey)
+
+	// Consume ion1's peer-reconnected.
+	readExpected(t, ion1, "ion1-ctrl")
+
+	// Connect second ion (same channel). This should close ion1.
+	ion2 := dialWS(t, server, "chan-reconn", "ion", apiKey)
+
+	// ion1 should be closed — read should fail.
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+	_, _, err := ion1.Read(readCtx)
+	if err == nil {
+		t.Error("expected ion1 read to fail after replacement")
+	}
+
+	// Wait briefly for the relay to process all control messages before sending.
+	time.Sleep(200 * time.Millisecond)
+
+	// Send from ion2 to mobile.
+	ctx := context.Background()
+	ion2.Write(ctx, websocket.MessageText, []byte("from-ion2"))
+
+	// Read all pending messages from mobile, looking for "from-ion2".
+	// Mobile may receive control messages (peer-disconnected, peer-reconnected)
+	// before the forwarded message. Read them all.
+	found := false
+	for i := 0; i < 5; i++ {
+		msgCtx, msgCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_, data, readErr := mobile.Read(msgCtx)
+		msgCancel()
+		if readErr != nil {
+			t.Fatalf("mobile read %d failed: %v", i, readErr)
+		}
+		if string(data) == "from-ion2" {
+			found = true
+			break
+		}
+		// Must be a control message; continue.
+		if !strings.Contains(string(data), "relay:") {
+			t.Fatalf("unexpected non-control message: %s", data)
+		}
+	}
+	if !found {
+		t.Error("mobile never received 'from-ion2'")
+	}
+}
+
+func TestChannelCleanupAfterBothDisconnect(t *testing.T) {
+	apiKey := "test-key-cleanup"
+	server, hub := startTestRelay(t, apiKey)
+
+	ion := dialWS(t, server, "chan-cleanup", "ion", apiKey)
+	mobile := dialWS(t, server, "chan-cleanup", "mobile", apiKey)
+
+	// Consume peer-reconnected on ion.
+	readExpected(t, ion, "ion-ctrl")
+
+	if hub.ChannelCount() != 1 {
+		t.Fatalf("expected 1 channel, got %d", hub.ChannelCount())
+	}
+
+	// Close both sides.
+	ion.Close(websocket.StatusNormalClosure, "bye")
+	mobile.Close(websocket.StatusNormalClosure, "bye")
+
+	// Wait for the relay goroutines to process the disconnects.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if hub.ChannelCount() == 0 {
+			return // success
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("expected 0 channels after both disconnect, got %d", hub.ChannelCount())
+}
+
+func TestConcurrentWrites(t *testing.T) {
+	apiKey := "test-key-concurrent"
+	server, _ := startTestRelay(t, apiKey)
+
+	ion := dialWS(t, server, "chan-conc", "ion", apiKey)
+	mobile := dialWS(t, server, "chan-conc", "mobile", apiKey)
+
+	// Consume peer-reconnected on ion.
+	readExpected(t, ion, "ion-ctrl")
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	// Spawn N goroutines each sending a message from ion.
+	for i := range n {
+		go func(idx int) {
+			defer wg.Done()
+			msg := fmt.Sprintf(`{"idx":%d}`, idx)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := ion.Write(ctx, websocket.MessageText, []byte(msg)); err != nil {
+				t.Errorf("concurrent write %d failed: %v", idx, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Read all N messages on mobile.
+	received := 0
+	for received < n {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, _, err := mobile.Read(ctx)
+		cancel()
+		if err != nil {
+			t.Fatalf("mobile read failed after %d messages: %v", received, err)
+		}
+		received++
+	}
+	if received != n {
+		t.Errorf("expected %d messages, got %d", n, received)
+	}
+}
+
+func TestBinaryMessageForwarding(t *testing.T) {
+	apiKey := "test-key-binary"
+	server, _ := startTestRelay(t, apiKey)
+
+	ion := dialWS(t, server, "chan-bin", "ion", apiKey)
+	mobile := dialWS(t, server, "chan-bin", "mobile", apiKey)
+
+	// Consume peer-reconnected on ion.
+	readExpected(t, ion, "ion-ctrl")
+
+	// Send binary data from ion.
+	binaryData := []byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 0xFD}
+	ctx := context.Background()
+	if err := ion.Write(ctx, websocket.MessageBinary, binaryData); err != nil {
+		t.Fatalf("binary write failed: %v", err)
+	}
+
+	// Mobile should receive it as binary.
+	readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	msgType, data, err := mobile.Read(readCtx)
+	if err != nil {
+		t.Fatalf("mobile read failed: %v", err)
+	}
+	if msgType != websocket.MessageBinary {
+		t.Errorf("expected MessageBinary, got %v", msgType)
+	}
+	if string(data) != string(binaryData) {
+		t.Errorf("binary data mismatch: got %v, want %v", data, binaryData)
+	}
+}
+
+func TestLargeMessageForwarding(t *testing.T) {
+	apiKey := "test-key-large"
+	server, _ := startTestRelay(t, apiKey)
+
+	ion := dialWS(t, server, "chan-large", "ion", apiKey)
+	mobile := dialWS(t, server, "chan-large", "mobile", apiKey)
+
+	// Increase client-side read limit to match the server's 1MB limit.
+	mobile.SetReadLimit(1024 * 1024)
+
+	// Consume peer-reconnected on ion.
+	readExpected(t, ion, "ion-ctrl")
+
+	// Send a message larger than gorilla's old 64KB read buffer.
+	largeMsg := make([]byte, 128*1024) // 128KB
+	for i := range largeMsg {
+		largeMsg[i] = byte(i % 256)
+	}
+
+	ctx := context.Background()
+	if err := ion.Write(ctx, websocket.MessageBinary, largeMsg); err != nil {
+		t.Fatalf("large write failed: %v", err)
+	}
+
+	readCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, data, err := mobile.Read(readCtx)
+	if err != nil {
+		t.Fatalf("mobile read failed: %v", err)
+	}
+	if len(data) != len(largeMsg) {
+		t.Errorf("large message size mismatch: got %d, want %d", len(data), len(largeMsg))
+	}
+	// Spot-check a few bytes.
+	for _, idx := range []int{0, 1000, 65535, 65536, len(largeMsg) - 1} {
+		if data[idx] != largeMsg[idx] {
+			t.Errorf("byte mismatch at index %d: got %d, want %d", idx, data[idx], largeMsg[idx])
+		}
 	}
 }

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -54,6 +54,7 @@ func dialWS(t *testing.T, server *httptest.Server, channelID, role, apiKey strin
 		HTTPHeader: http.Header{
 			"Authorization": []string{"Bearer " + apiKey},
 		},
+		CompressionMode: websocket.CompressionContextTakeover,
 	})
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
@@ -468,5 +469,31 @@ func TestLargeMessageForwarding(t *testing.T) {
 		if data[idx] != largeMsg[idx] {
 			t.Errorf("byte mismatch at index %d: got %d, want %d", idx, data[idx], largeMsg[idx])
 		}
+	}
+}
+
+func TestCompressionNegotiation(t *testing.T) {
+	apiKey := "test-key-compress"
+	server, _ := startTestRelay(t, apiKey)
+
+	// dialWS enables CompressionContextTakeover. If negotiation fails or
+	// corrupts data, this test will catch it.
+	ion := dialWS(t, server, "chan-compress", "ion", apiKey)
+	mobile := dialWS(t, server, "chan-compress", "mobile", apiKey)
+
+	// Consume peer-reconnected on ion.
+	readExpected(t, ion, "ion-ctrl")
+
+	// Send a highly compressible message (repetitive JSON keys).
+	msg := `{"event":"streaming","data":"` + strings.Repeat("abcdef1234", 500) + `"}`
+
+	ctx := context.Background()
+	if err := ion.Write(ctx, websocket.MessageText, []byte(msg)); err != nil {
+		t.Fatalf("compressed write failed: %v", err)
+	}
+
+	data := readExpected(t, mobile, "mobile-compressed")
+	if string(data) != msg {
+		t.Errorf("compressed message mismatch: got %d bytes, want %d bytes", len(data), len(msg))
 	}
 }


### PR DESCRIPTION
- **fix(engine): add configurable timeout to mcp calls**
- **feat(engine): emit engine_events_dropped on queue recovery**
- **feat(desktop): handle engine_events_dropped event**
- **chore(relay): migrate from gorilla/websocket to coder/websocket**
- **chore(engine): update websocket import path to coder/websocket**
- **fix(relay): enable compression and graceful close on replacement**
- **fix(engine): add read limit and write timeouts for websocket**
- **fix(engine): add panic recovery to server handlers**
- **fix(engine): add retry caps and context timeouts**
- **feat(engine): add TimeoutsConfig for configurable timeouts**
- **feat(engine): read tool timeouts from config**
- **feat(engine): make mcp and extension timeouts configurable**
- **feat(engine): add timeout option to ext/call_tool rpc**
- **feat(engine): add --timeout flag to ion prompt**
- **feat(relay): make relay timeouts configurable via env vars**
- **docs(docs): document timeouts, relay config, and cli flags**
- **fix(engine): wire extensionRpcMs config to host rpc timeout**
- **fix(docs): correct apns type, origin check, types, and cli timeout**
- **fix(engine): honor --timeout for stream-json output mode**
- **docs(docs): add health, upgrade, and max-turns docs**
