### PR TITLE
Engine and desktop feature and fix pack

### DIFF
--- a/desktop/src/main/engine-bridge.ts
+++ b/desktop/src/main/engine-bridge.ts
@@ -379,6 +379,11 @@ export class EngineBridge extends EventEmitter {
     this._send({ cmd: 'abort', key })
   }
 
+  sendSteer(key: string, message: string): void {
+    log(`sendSteer: key=${key} len=${message.length}`)
+    this._send({ cmd: 'steer_agent', key, agentName: '', message })
+  }
+
   sendAbortAgent(key: string, agentName: string, subtree: boolean): void {
     log(`sendAbortAgent: key=${key} agent=${agentName} subtree=${subtree} connected=${this.connected}`)
     this._send({ cmd: 'abort_agent', key, agentName, subtree })

--- a/desktop/src/main/engine-control-plane-events.ts
+++ b/desktop/src/main/engine-control-plane-events.ts
@@ -220,6 +220,18 @@ function handleStatusEvent(
     ctx.setStatus(tabId, hasExitPlan ? 'completed' : 'idle')
     ctx.checkDrain()
   } else if (event.fields.state === 'running') {
+    if (tab.status !== 'running') {
+      ctx.emit('event', tabId, {
+        type: 'session_init',
+        sessionId: tab.conversationId || '',
+        tools: [],
+        model: event.fields.model || '',
+        mcpServers: [],
+        skills: [],
+        version: '',
+        isWarmup: false,
+      } as NormalizedEvent)
+    }
     ctx.setStatus(tabId, 'running')
   }
 }

--- a/desktop/src/main/engine-control-plane.ts
+++ b/desktop/src/main/engine-control-plane.ts
@@ -224,6 +224,12 @@ export class EngineControlPlane extends EventEmitter {
     return true
   }
 
+  steerSession(tabId: string, message: string): void {
+    if (!this.tabs.has(tabId)) return
+    log(`steerSession: tab=${tabId} len=${message.length}`)
+    this.bridge.sendSteer(tabId, message)
+  }
+
   async retry(tabId: string, requestId: string, options: RunOptions): Promise<void> {
     return this.submitPrompt(tabId, requestId, options)
   }

--- a/desktop/src/main/ipc/git.ts
+++ b/desktop/src/main/ipc/git.ts
@@ -3,6 +3,9 @@ import { unlink } from 'fs/promises'
 import { basename, join } from 'path'
 import { IPC } from '../../shared/types'
 import { runGit } from '../git-runner'
+import { error as _error } from '../logger'
+
+const logError = (msg: string): void => { _error('git-ipc', msg) }
 
 export function registerGitIpc(): void {
   ipcMain.handle(IPC.GIT_IS_REPO, async (_event, directory: string) => {
@@ -292,6 +295,7 @@ export function registerGitIpc(): void {
       await runGit(directory, ['add', '--', ...paths])
       return { ok: true }
     } catch (err: any) {
+      logError(`stage failed: ${err.message}`)
       return { ok: false, error: err.message }
     }
   })
@@ -301,6 +305,7 @@ export function registerGitIpc(): void {
       await runGit(directory, ['restore', '--staged', '--', ...paths])
       return { ok: true }
     } catch (err: any) {
+      logError(`unstage failed: ${err.message}`)
       return { ok: false, error: err.message }
     }
   })
@@ -335,6 +340,7 @@ export function registerGitIpc(): void {
       }
       return { ok: true }
     } catch (err: any) {
+      logError(`discard failed: ${err.message}`)
       return { ok: false, error: err.message }
     }
   })

--- a/desktop/src/main/ipc/session.ts
+++ b/desktop/src/main/ipc/session.ts
@@ -107,6 +107,11 @@ export function registerSessionIpc(): void {
     return sessionPlane.cancel(requestId)
   })
 
+  ipcMain.on(IPC.STEER, (_event, { tabId, message }: { tabId: string; message: string }) => {
+    log(`IPC STEER: tab=${tabId}`)
+    sessionPlane.steerSession(tabId, message)
+  })
+
   ipcMain.handle(IPC.STOP_TAB, (_event, tabId: string) => {
     log(`IPC STOP_TAB: ${tabId}`)
     return sessionPlane.cancelTab(tabId)

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -8,6 +8,7 @@ export interface IonAPI {
   createTab(): Promise<{ tabId: string }>
   prompt(tabId: string, requestId: string, options: RunOptions): Promise<void>
   cancel(requestId: string): Promise<boolean>
+  steer(tabId: string, message: string): void
   stopTab(tabId: string): Promise<boolean>
   retry(tabId: string, requestId: string, options: RunOptions): Promise<void>
   status(): Promise<HealthReport>
@@ -154,6 +155,7 @@ const api: IonAPI = {
   createTab: () => ipcRenderer.invoke(IPC.CREATE_TAB),
   prompt: (tabId, requestId, options) => ipcRenderer.invoke(IPC.PROMPT, { tabId, requestId, options }),
   cancel: (requestId) => ipcRenderer.invoke(IPC.CANCEL, requestId),
+  steer: (tabId, message) => ipcRenderer.send(IPC.STEER, { tabId, message }),
   stopTab: (tabId) => ipcRenderer.invoke(IPC.STOP_TAB, tabId),
   retry: (tabId, requestId, options) => ipcRenderer.invoke(IPC.RETRY, { tabId, requestId, options }),
   status: () => ipcRenderer.invoke(IPC.STATUS),

--- a/desktop/src/renderer/components/GitChangesSection.tsx
+++ b/desktop/src/renderer/components/GitChangesSection.tsx
@@ -28,6 +28,13 @@ export function GitChangesSection({
   const [diffFile, setDiffFile] = useState<{ path: string; staged: boolean } | null>(null)
   const [diffData, setDiffData] = useState<{ diff: string; fileName: string } | null>(null)
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set())
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!error) return
+    const t = setTimeout(() => setError(null), 5_000)
+    return () => clearTimeout(t)
+  }, [error])
 
   const stagedFiles = files.filter((f) => f.staged)
   const unstagedFiles = files.filter((f) => !f.staged)
@@ -65,12 +72,14 @@ export function GitChangesSection({
   }, [])
 
   const handleStage = async (path: string) => {
-    await window.ion.gitStage(directory, [path])
+    const result = await window.ion.gitStage(directory, [path])
+    if (!result.ok) { setError(result.error || 'Failed to stage file'); return }
     onRefresh()
   }
 
   const handleUnstage = async (path: string) => {
-    await window.ion.gitUnstage(directory, [path])
+    const result = await window.ion.gitUnstage(directory, [path])
+    if (!result.ok) { setError(result.error || 'Failed to unstage file'); return }
     onRefresh()
   }
 
@@ -80,15 +89,17 @@ export function GitChangesSection({
   }
   const confirmDiscard = async () => {
     if (!discardConfirm) return
-    await window.ion.gitDiscard(directory, [discardConfirm])
+    const result = await window.ion.gitDiscard(directory, [discardConfirm])
     setDiscardConfirm(null)
+    if (!result.ok) { setError(result.error || 'Failed to discard changes'); return }
     onRefresh()
   }
 
   const handleStageAll = async () => {
     const paths = unstagedFiles.map((f) => f.path)
     if (paths.length > 0) {
-      await window.ion.gitStage(directory, paths)
+      const result = await window.ion.gitStage(directory, paths)
+      if (!result.ok) { setError(result.error || 'Failed to stage files'); return }
       onRefresh()
     }
   }
@@ -96,7 +107,8 @@ export function GitChangesSection({
   const handleUnstageAll = async () => {
     const paths = stagedFiles.map((f) => f.path)
     if (paths.length > 0) {
-      await window.ion.gitUnstage(directory, paths)
+      const result = await window.ion.gitUnstage(directory, paths)
+      if (!result.ok) { setError(result.error || 'Failed to unstage files'); return }
       onRefresh()
     }
   }
@@ -220,6 +232,23 @@ export function GitChangesSection({
           </div>
         )}
       </div>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          className="flex items-center justify-between px-2 py-1.5"
+          style={{ borderTop: `1px solid ${colors.containerBorder}`, background: colors.surfacePrimary, flexShrink: 0 }}
+        >
+          <span className="text-[10px] truncate" style={{ color: '#c47060' }}>{error}</span>
+          <button
+            onClick={() => setError(null)}
+            className="text-[10px] px-1.5 py-0.5 rounded flex-shrink-0"
+            style={{ color: colors.textTertiary }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {/* Discard confirmation */}
       {discardConfirm && (

--- a/desktop/src/renderer/components/GitPanel.tsx
+++ b/desktop/src/renderer/components/GitPanel.tsx
@@ -196,59 +196,73 @@ export function GitPanel() {
               >
                 {gitChangesTreeView ? <ListBullets size={11} /> : <TreeStructure size={11} />}
               </button>
-              <input
-                value={commitMsg}
-                onChange={(e) => setCommitMsg(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) handleCommit() }}
-                placeholder="Commit message..."
-                onClick={(e) => e.stopPropagation()}
-                className="text-[10px] bg-transparent outline-none rounded px-1.5"
-                style={{
-                  color: colors.textPrimary,
-                  border: `1px solid ${colors.containerBorder}`,
-                  height: 20,
-                  flex: '1 1 0',
-                  minWidth: 0,
-                  maxWidth: 160,
-                }}
-              />
-              <button
-                onClick={handleCommit}
-                disabled={!commitMsg.trim() || stagedCount === 0}
-                style={{
-                  background: 'none',
-                  border: 'none',
-                  padding: '0 2px',
-                  cursor: (!commitMsg.trim() || stagedCount === 0) ? 'not-allowed' : 'pointer',
-                  color: (!commitMsg.trim() || stagedCount === 0) ? colors.textMuted : colors.accent,
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
-                title="Commit staged changes"
-              >
-                <Check size={13} weight="bold" />
-              </button>
-              <button
-                onClick={handleQuickCommit}
-                style={{
-                  background: 'none',
-                  border: 'none',
-                  padding: '0 2px',
-                  cursor: 'pointer',
-                  color: colors.textTertiary,
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
-                title={commitCommand ? `Run: ${commitCommand}` : 'Let Ion commit'}
-              >
-                <Robot size={13} />
-              </button>
             </>
           )}
         </div>
         {changesOpen && (
-          <div style={{ height: changesContentHeight, overflow: 'auto' }}>
-            <GitChangesSection directory={directory} files={files} onRefresh={refresh} commitMsg={commitMsg} setCommitMsg={setCommitMsg} treeView={gitChangesTreeView} />
+          <div style={{ height: changesContentHeight, display: 'flex', flexDirection: 'column' }}>
+            {/* Commit input row */}
+            {files.length > 0 && (
+              <div
+                className="flex items-center gap-1 px-2.5"
+                style={{
+                  height: 28,
+                  flexShrink: 0,
+                  borderBottom: `1px solid ${colors.containerBorder}`,
+                  background: colors.surfacePrimary,
+                }}
+              >
+                <input
+                  value={commitMsg}
+                  onChange={(e) => setCommitMsg(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) handleCommit() }}
+                  placeholder="Commit message..."
+                  onClick={(e) => e.stopPropagation()}
+                  className="text-[10px] bg-transparent outline-none rounded px-1.5"
+                  style={{
+                    color: colors.textPrimary,
+                    border: `1px solid ${colors.containerBorder}`,
+                    height: 20,
+                    flex: 1,
+                    minWidth: 0,
+                  }}
+                />
+                <button
+                  onClick={handleCommit}
+                  disabled={!commitMsg.trim() || stagedCount === 0}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    padding: '0 2px',
+                    cursor: (!commitMsg.trim() || stagedCount === 0) ? 'not-allowed' : 'pointer',
+                    color: (!commitMsg.trim() || stagedCount === 0) ? colors.textMuted : colors.accent,
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                  title="Commit staged changes"
+                >
+                  <Check size={13} weight="bold" />
+                </button>
+                <button
+                  onClick={handleQuickCommit}
+                  style={{
+                    background: 'none',
+                    border: 'none',
+                    padding: '0 2px',
+                    cursor: 'pointer',
+                    color: colors.textTertiary,
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                  title={commitCommand ? `Run: ${commitCommand}` : 'Let Ion commit'}
+                >
+                  <Robot size={13} />
+                </button>
+              </div>
+            )}
+            <div style={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+              <GitChangesSection directory={directory} files={files} onRefresh={refresh} commitMsg={commitMsg} setCommitMsg={setCommitMsg} treeView={gitChangesTreeView} />
+            </div>
           </div>
         )}
       </div>

--- a/desktop/src/renderer/hooks/useGitPolling.ts
+++ b/desktop/src/renderer/hooks/useGitPolling.ts
@@ -23,8 +23,8 @@ export const useGitPollingStore = create<GitPollingState>((set, get) => ({
   refresh: () => set((s) => ({ refreshKey: s.refreshKey + 1 })),
   _update: (data) => {
     const prev = get()
-    const sig = data.branch + '\n' + data.files.map((f) => f.status + f.path).join('\n')
-    const prevSig = prev.branch + '\n' + prev.files.map((f) => f.status + f.path).join('\n')
+    const sig = data.branch + '\n' + data.files.map((f) => `${f.staged}:${f.status}:${f.path}`).join('\n')
+    const prevSig = prev.branch + '\n' + prev.files.map((f) => `${f.staged}:${f.status}:${f.path}`).join('\n')
     const changed = sig !== prevSig || data.ahead !== prev.ahead || data.behind !== prev.behind
     if (changed) {
       set({

--- a/desktop/src/renderer/stores/slices/send-slice.ts
+++ b/desktop/src/renderer/stores/slices/send-slice.ts
@@ -125,9 +125,16 @@ export function createSendSlice(set: StoreSet, get: StoreGet): Partial<State> {
               title,
               attachments: [],
               bashResults: [],
-              queuedPrompts: withEffectiveBase.queuedPrompts.length > 0
-                ? [withEffectiveBase.queuedPrompts[0] + '\n\n' + prompt]
-                : [prompt],
+              messages: [
+                ...withEffectiveBase.messages,
+                {
+                  id: nextMsgId(),
+                  role: 'user' as const,
+                  content: prompt,
+                  attachments: msgAttachments.length > 0 ? msgAttachments : undefined,
+                  timestamp: Date.now(),
+                },
+              ],
             }
           }
           return {
@@ -153,6 +160,11 @@ export function createSendSlice(set: StoreSet, get: StoreGet): Partial<State> {
           }
         }),
       }))
+
+      if (isBusy) {
+        window.ion.steer(activeTabId, fullPrompt)
+        return
+      }
 
       const preferredModel = usePreferencesStore.getState().preferredModel
 
@@ -236,7 +248,14 @@ export function createSendSlice(set: StoreSet, get: StoreGet): Partial<State> {
         tabs: s.tabs.map((t) => {
           if (t.id !== tabId) return t
           if (isBusy) {
-            return { ...t, title, queuedPrompts: t.queuedPrompts.length > 0 ? [t.queuedPrompts[0] + '\n\n' + prompt] : [prompt] }
+            return {
+              ...t,
+              title,
+              messages: [
+                ...t.messages,
+                { id: nextMsgId(), role: 'user' as const, content: prompt, timestamp: Date.now(), source: 'remote' as const },
+              ],
+            }
           }
           return {
             ...t,
@@ -253,6 +272,11 @@ export function createSendSlice(set: StoreSet, get: StoreGet): Partial<State> {
           }
         }),
       }))
+
+      if (isBusy) {
+        window.ion.steer(tabId, prompt)
+        return
+      }
 
       let remoteExtensions: string[] | undefined
       if (tab.isEngine && tab.engineProfileId) {

--- a/desktop/src/shared/types-ipc.ts
+++ b/desktop/src/shared/types-ipc.ts
@@ -6,6 +6,7 @@ export const IPC = {
   CREATE_TAB: 'ion:create-tab',
   PROMPT: 'ion:prompt',
   CANCEL: 'ion:cancel',
+  STEER: 'ion:steer',
   STOP_TAB: 'ion:stop-tab',
   RETRY: 'ion:retry',
   STATUS: 'ion:status',

--- a/engine/internal/backend/api_backend_test.go
+++ b/engine/internal/backend/api_backend_test.go
@@ -797,9 +797,10 @@ func TestConcurrentMultipleRuns(t *testing.T) {
 	bMulti.OnNormalized(func(runID string, event types.NormalizedEvent) {
 		mu.Lock()
 		defer mu.Unlock()
-		if runID == "req-ma" {
+		switch runID {
+		case "req-ma":
 			eventsA = append(eventsA, event)
-		} else if runID == "req-mb" {
+		case "req-mb":
 			eventsB = append(eventsB, event)
 		}
 	})
@@ -807,9 +808,10 @@ func TestConcurrentMultipleRuns(t *testing.T) {
 	bMulti.OnExit(func(runID string, code *int, signal *string, sessionID string) {
 		mu.Lock()
 		defer mu.Unlock()
-		if runID == "req-ma" {
+		switch runID {
+		case "req-ma":
 			exitA = code
-		} else if runID == "req-mb" {
+		case "req-mb":
 			exitB = code
 		}
 	})

--- a/engine/internal/backend/cli_backend.go
+++ b/engine/internal/backend/cli_backend.go
@@ -131,14 +131,14 @@ func (b *CliBackend) Cancel(requestID string) bool {
 
 	// Send SIGINT (graceful) on Unix, Kill directly on Windows
 	if runtime.GOOS == "windows" {
-		proc.Kill()
+		_ = proc.Kill()
 		run.cancel()
 		return true
 	}
 
 	if err := proc.Signal(syscall.SIGINT); err != nil {
 		utils.Log("CliBackend", "SIGINT failed, killing: "+err.Error())
-		proc.Kill()
+		_ = proc.Kill()
 		run.cancel()
 		return true
 	}
@@ -155,7 +155,7 @@ func (b *CliBackend) Cancel(requestID string) bool {
 		b.mu.Unlock()
 		if stillActive {
 			utils.Log("CliBackend", "process did not exit after SIGINT, sending SIGKILL: "+requestID)
-			proc.Signal(syscall.SIGKILL)
+			_ = proc.Signal(syscall.SIGKILL)
 			run.cancel()
 		}
 	}()
@@ -361,7 +361,7 @@ func (b *CliBackend) runProcess(ctx context.Context, run *cliRun, opts types.Run
 		},
 	}
 	if data, err := json.Marshal(initMsg); err == nil {
-		stdinPipe.Write(append(data, '\n'))
+		_, _ = stdinPipe.Write(append(data, '\n'))
 	}
 
 	// Capture stderr in ring buffer
@@ -391,7 +391,7 @@ func (b *CliBackend) runProcess(ctx context.Context, run *cliRun, opts types.Run
 		if json.Unmarshal(raw, &peek) == nil && peek.Type == "result" {
 			run.stdinMu.Lock()
 			if run.stdinPipe != nil {
-				run.stdinPipe.Close()
+				_ = run.stdinPipe.Close()
 				run.stdinPipe = nil
 			}
 			run.stdinMu.Unlock()
@@ -482,7 +482,7 @@ func (b *CliBackend) removeRun(requestID string) {
 		// Ensure stdin pipe is closed on cleanup
 		run.stdinMu.Lock()
 		if run.stdinPipe != nil {
-			run.stdinPipe.Close()
+			_ = run.stdinPipe.Close()
 			run.stdinPipe = nil
 		}
 		run.stdinMu.Unlock()

--- a/engine/internal/backend/cli_backend_test.go
+++ b/engine/internal/backend/cli_backend_test.go
@@ -157,7 +157,8 @@ func TestCliRunFieldsPresent(t *testing.T) {
 		t.Error("stdinPipe should be nil by default")
 	}
 
-	// stdinMu should be usable
+	// stdinMu should be usable (lock/unlock without deadlock)
 	run.stdinMu.Lock()
+	_ = run.stdinPipe // access guarded field
 	run.stdinMu.Unlock()
 }

--- a/engine/internal/backend/permission_hook_server.go
+++ b/engine/internal/backend/permission_hook_server.go
@@ -61,7 +61,7 @@ func NewPermissionHookServer(permEng *permissions.Engine) (*PermissionHookServer
 	mux.HandleFunc("/hook/pre-tool-use/", s.handlePreToolUse)
 
 	s.server = &http.Server{Handler: mux}
-	go s.server.Serve(listener)
+	go func() { _ = s.server.Serve(listener) }()
 
 	utils.Log("PermissionHookServer", fmt.Sprintf("listening on port %d", s.Port()))
 
@@ -117,7 +117,7 @@ func (s *PermissionHookServer) SetOnAsk(fn PermissionAskCallback) {
 
 // Close shuts down the hook server.
 func (s *PermissionHookServer) Close() {
-	s.server.Close()
+	_ = s.server.Close()
 }
 
 func (s *PermissionHookServer) handlePreToolUse(w http.ResponseWriter, r *http.Request) {
@@ -237,5 +237,5 @@ func writePermissionResponse(w http.ResponseWriter, decision string) {
 		},
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/engine/internal/backend/runloop_setup.go
+++ b/engine/internal/backend/runloop_setup.go
@@ -64,7 +64,11 @@ func buildSystemPrompt(opts *types.RunOptions, conv *conversation.Conversation, 
 		systemPrompt = opts.SystemPrompt
 	}
 	if opts.AppendSystemPrompt != "" {
-		systemPrompt += "\n\n" + opts.AppendSystemPrompt
+		// When AppendSystemPrompt is set, always rebuild from the explicit
+		// SystemPrompt base (or empty string). This prevents duplication
+		// when conv.System already contains content from a previous run.
+		base := opts.SystemPrompt // explicit override, or ""
+		systemPrompt = base + "\n\n" + opts.AppendSystemPrompt
 	}
 	if opts.PlanMode {
 		// Check extension hook for custom plan mode prompt
@@ -187,10 +191,32 @@ func (b *ApiBackend) buildToolDefs(run *activeRun, opts types.RunOptions, provid
 		toolDefs = filtered
 	}
 
-	// When provider supports server-side web search, swap client WebSearch for server tool
+	// Web search mode resolution: determine whether to use server-side
+	// (Anthropic built-in) or client-side (Brave/Tavily/SearXNG) web search.
 	var serverTools []map[string]any
 	providerID := provider.ID()
-	if providerID == "anthropic" || providerID == "vertex" {
+	supportsServer := providerID == "anthropic" || providerID == "vertex"
+	mode := opts.WebSearchMode
+	if mode == "" {
+		mode = "auto"
+	}
+
+	useServer := false
+	switch mode {
+	case "server":
+		useServer = supportsServer
+	case "client":
+		useServer = false
+	default: // "auto"
+		// Prefer client if a backend key is configured (better reliability:
+		// model gets a follow-up turn to process results). Fall back to
+		// server on Anthropic/Vertex when no client key is available.
+		if supportsServer && !tools.HasSearchBackend() {
+			useServer = true
+		}
+	}
+
+	if useServer {
 		filtered := toolDefs[:0]
 		for _, td := range toolDefs {
 			if td.Name != "WebSearch" {

--- a/engine/internal/backend/runloop_setup_test.go
+++ b/engine/internal/backend/runloop_setup_test.go
@@ -1,0 +1,254 @@
+package backend
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/conversation"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// --- buildSystemPrompt tests ---
+
+func TestBuildSystemPrompt_ResumeWithoutDuplication(t *testing.T) {
+	// Simulate resume: conv.System already has CLAUDE.md from first run,
+	// AppendSystemPrompt delivers CLAUDE.md again. Must appear once.
+	claudeContent := "# Context from /home/user/.claude/CLAUDE.md\nBe helpful."
+	conv := &conversation.Conversation{
+		System: "\n\n" + claudeContent, // left over from first run
+	}
+	opts := &types.RunOptions{
+		AppendSystemPrompt: claudeContent,
+	}
+	result := buildSystemPrompt(opts, conv, RunHooks{}, "req-1")
+	count := strings.Count(result, claudeContent)
+	if count != 1 {
+		t.Errorf("expected CLAUDE.md to appear once, appeared %d times", count)
+	}
+}
+
+func TestBuildSystemPrompt_SystemPromptOverride(t *testing.T) {
+	conv := &conversation.Conversation{
+		System: "old system prompt",
+	}
+	opts := &types.RunOptions{
+		SystemPrompt: "new system prompt",
+	}
+	result := buildSystemPrompt(opts, conv, RunHooks{}, "req-2")
+	if result != "new system prompt" {
+		t.Errorf("expected SystemPrompt override, got %q", result)
+	}
+}
+
+func TestBuildSystemPrompt_PreservedWhenNoAppend(t *testing.T) {
+	conv := &conversation.Conversation{
+		System: "preserved system",
+	}
+	opts := &types.RunOptions{} // no SystemPrompt, no AppendSystemPrompt
+	result := buildSystemPrompt(opts, conv, RunHooks{}, "req-3")
+	if result != "preserved system" {
+		t.Errorf("expected conv.System to be preserved, got %q", result)
+	}
+}
+
+func TestBuildSystemPrompt_FirstPromptClean(t *testing.T) {
+	conv := &conversation.Conversation{} // System is ""
+	claudeContent := "# CLAUDE.md content"
+	opts := &types.RunOptions{
+		AppendSystemPrompt: claudeContent,
+	}
+	result := buildSystemPrompt(opts, conv, RunHooks{}, "req-4")
+	count := strings.Count(result, claudeContent)
+	if count != 1 {
+		t.Errorf("expected content once, appeared %d times", count)
+	}
+	// Should start with "\n\n" since base is ""
+	if !strings.HasPrefix(result, "\n\n") {
+		t.Errorf("expected leading newlines from empty base, got %q", result[:10])
+	}
+}
+
+func TestBuildSystemPrompt_PlanModeWithAppend(t *testing.T) {
+	// Plan mode adds its own suffix; AppendSystemPrompt must still not dup
+	conv := &conversation.Conversation{
+		System: "\n\ncontext content\n\nplan mode prompt",
+	}
+	opts := &types.RunOptions{
+		AppendSystemPrompt: "context content",
+		PlanMode:           true,
+		PlanFilePath:       "/tmp/nonexistent-plan.md",
+	}
+	result := buildSystemPrompt(opts, conv, RunHooks{}, "req-5")
+	count := strings.Count(result, "context content")
+	if count != 1 {
+		t.Errorf("expected 'context content' once in plan mode, appeared %d times", count)
+	}
+}
+
+func TestBuildSystemPrompt_ExplicitBaseWithAppend(t *testing.T) {
+	// When both SystemPrompt and AppendSystemPrompt are set, use SystemPrompt as base
+	conv := &conversation.Conversation{
+		System: "stale conv system",
+	}
+	opts := &types.RunOptions{
+		SystemPrompt:       "fresh base",
+		AppendSystemPrompt: "appended context",
+	}
+	result := buildSystemPrompt(opts, conv, RunHooks{}, "req-6")
+	if !strings.HasPrefix(result, "fresh base\n\nappended context") {
+		t.Errorf("expected fresh base + append, got %q", result)
+	}
+	if strings.Contains(result, "stale conv system") {
+		t.Error("stale conv.System should not appear")
+	}
+}
+
+// --- web search mode resolution tests ---
+
+func TestWebSearchMode_AutoAnthropicNoClientKey(t *testing.T) {
+	// Unset all client search keys
+	for _, k := range []string{"BRAVE_SEARCH_API_KEY", "TAVILY_API_KEY", "SEARXNG_URL"} {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "auto"}
+	provider := &mockLlmProvider{id: "anthropic"}
+
+	_, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) == 0 {
+		t.Error("expected server tools for auto + anthropic + no client key")
+	}
+}
+
+func TestWebSearchMode_AutoAnthropicWithClientKey(t *testing.T) {
+	t.Setenv("BRAVE_SEARCH_API_KEY", "test-key-123")
+
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "auto"}
+	provider := &mockLlmProvider{id: "anthropic"}
+
+	toolDefs, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) != 0 {
+		t.Error("expected no server tools when client key is available")
+	}
+	// Verify WebSearch tool is still present
+	hasWebSearch := false
+	for _, td := range toolDefs {
+		if td.Name == "WebSearch" {
+			hasWebSearch = true
+			break
+		}
+	}
+	if !hasWebSearch {
+		t.Error("expected WebSearch client tool to remain")
+	}
+}
+
+func TestWebSearchMode_AutoOpenAI(t *testing.T) {
+	// Unset all client search keys
+	for _, k := range []string{"BRAVE_SEARCH_API_KEY", "TAVILY_API_KEY", "SEARXNG_URL"} {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "auto"}
+	provider := &mockLlmProvider{id: "openai"}
+
+	_, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) != 0 {
+		t.Error("expected no server tools for OpenAI provider")
+	}
+}
+
+func TestWebSearchMode_ServerAnthropic(t *testing.T) {
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "server"}
+	provider := &mockLlmProvider{id: "anthropic"}
+
+	_, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) == 0 {
+		t.Error("expected server tools for explicit server + anthropic")
+	}
+}
+
+func TestWebSearchMode_ServerOpenAI(t *testing.T) {
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "server"}
+	provider := &mockLlmProvider{id: "openai"}
+
+	_, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) != 0 {
+		t.Error("expected no server tools for server + openai (silent fallback)")
+	}
+}
+
+func TestWebSearchMode_ClientAnthropic(t *testing.T) {
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "client"}
+	provider := &mockLlmProvider{id: "anthropic"}
+
+	toolDefs, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) != 0 {
+		t.Error("expected no server tools for explicit client mode")
+	}
+	hasWebSearch := false
+	for _, td := range toolDefs {
+		if td.Name == "WebSearch" {
+			hasWebSearch = true
+			break
+		}
+	}
+	if !hasWebSearch {
+		t.Error("expected WebSearch client tool to remain in client mode")
+	}
+}
+
+func TestWebSearchMode_ClientOpenAI(t *testing.T) {
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{WebSearchMode: "client"}
+	provider := &mockLlmProvider{id: "openai"}
+
+	toolDefs, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) != 0 {
+		t.Error("expected no server tools for client + openai")
+	}
+	hasWebSearch := false
+	for _, td := range toolDefs {
+		if td.Name == "WebSearch" {
+			hasWebSearch = true
+			break
+		}
+	}
+	if !hasWebSearch {
+		t.Error("expected WebSearch client tool to remain")
+	}
+}
+
+func TestWebSearchMode_DefaultsToAuto(t *testing.T) {
+	// Unset all client search keys to trigger server-side for Anthropic
+	for _, k := range []string{"BRAVE_SEARCH_API_KEY", "TAVILY_API_KEY", "SEARXNG_URL"} {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+
+	b := NewApiBackend()
+	run := &activeRun{requestID: "test"}
+	opts := types.RunOptions{} // WebSearchMode is ""
+	provider := &mockLlmProvider{id: "anthropic"}
+
+	_, serverTools := b.buildToolDefs(run, opts, provider)
+	if len(serverTools) == 0 {
+		t.Error("expected server tools for default (empty) mode + anthropic + no client key")
+	}
+}

--- a/engine/internal/backend/tool_server.go
+++ b/engine/internal/backend/tool_server.go
@@ -29,7 +29,7 @@ type ToolHandler func(input map[string]interface{}) (*types.ToolResult, error)
 func NewToolServer(sessionID string) *ToolServer {
 	home, _ := os.UserHomeDir()
 	sockDir := filepath.Join(home, ".ion", "mcp")
-	os.MkdirAll(sockDir, 0o700)
+	_ = os.MkdirAll(sockDir, 0o700)
 
 	return &ToolServer{
 		tools:    make(map[string]ToolHandler),
@@ -50,7 +50,7 @@ func (ts *ToolServer) Start() error {
 	defer ts.mu.Unlock()
 
 	// Clean up stale socket
-	os.Remove(ts.sockPath)
+	_ = os.Remove(ts.sockPath)
 
 	listener, err := net.Listen("unix", ts.sockPath)
 	if err != nil {
@@ -72,9 +72,9 @@ func (ts *ToolServer) Stop() {
 
 	ts.running = false
 	if ts.listener != nil {
-		ts.listener.Close()
+		_ = ts.listener.Close()
 	}
-	os.Remove(ts.sockPath)
+	_ = os.Remove(ts.sockPath)
 }
 
 // SocketPath returns the path to the Unix socket.
@@ -129,7 +129,7 @@ func (ts *ToolServer) acceptLoop() {
 }
 
 func (ts *ToolServer) handleConnection(conn net.Conn) {
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	decoder := json.NewDecoder(conn)
 	encoder := json.NewEncoder(conn)
@@ -161,7 +161,7 @@ func (ts *ToolServer) handleConnection(conn net.Conn) {
 			}
 			ts.mu.Unlock()
 
-			encoder.Encode(map[string]interface{}{
+			_ = encoder.Encode(map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      req.ID,
 				"result":  map[string]interface{}{"tools": toolList},
@@ -172,14 +172,14 @@ func (ts *ToolServer) handleConnection(conn net.Conn) {
 				Name      string                 `json:"name"`
 				Arguments map[string]interface{} `json:"arguments"`
 			}
-			json.Unmarshal(req.Params, &params)
+			_ = json.Unmarshal(req.Params, &params)
 
 			ts.mu.Lock()
 			handler, exists := ts.tools[params.Name]
 			ts.mu.Unlock()
 
 			if !exists {
-				encoder.Encode(map[string]interface{}{
+				_ = encoder.Encode(map[string]interface{}{
 					"jsonrpc": "2.0",
 					"id":      req.ID,
 					"error":   map[string]interface{}{"code": -32601, "message": "tool not found: " + params.Name},
@@ -189,7 +189,7 @@ func (ts *ToolServer) handleConnection(conn net.Conn) {
 
 			result, err := handler(params.Arguments)
 			if err != nil {
-				encoder.Encode(map[string]interface{}{
+				_ = encoder.Encode(map[string]interface{}{
 					"jsonrpc": "2.0",
 					"id":      req.ID,
 					"result": map[string]interface{}{
@@ -200,7 +200,7 @@ func (ts *ToolServer) handleConnection(conn net.Conn) {
 					},
 				})
 			} else {
-				encoder.Encode(map[string]interface{}{
+				_ = encoder.Encode(map[string]interface{}{
 					"jsonrpc": "2.0",
 					"id":      req.ID,
 					"result": map[string]interface{}{
@@ -213,7 +213,7 @@ func (ts *ToolServer) handleConnection(conn net.Conn) {
 			}
 
 		default:
-			encoder.Encode(map[string]interface{}{
+			_ = encoder.Encode(map[string]interface{}{
 				"jsonrpc": "2.0",
 				"id":      req.ID,
 				"error":   map[string]interface{}{"code": -32601, "message": "method not found"},

--- a/engine/internal/providers/anthropic.go
+++ b/engine/internal/providers/anthropic.go
@@ -195,9 +195,7 @@ func (p *anthropicProvider) buildRequestBody(opts types.LlmStreamOptions) map[st
 			"input_schema": t.InputSchema,
 		})
 	}
-	for _, st := range opts.ServerTools {
-		allTools = append(allTools, st)
-	}
+	allTools = append(allTools, opts.ServerTools...)
 	if len(allTools) > 0 {
 		body["tools"] = allTools
 	}
@@ -220,7 +218,7 @@ func (p *anthropicProvider) buildRequestBody(opts types.LlmStreamOptions) map[st
 func (p *anthropicProvider) formatMessages(messages []types.LlmMessage) []map[string]any {
 	result := make([]map[string]any, 0, len(messages))
 
-	for i, msg := range messages {
+	for _, msg := range messages {
 		blocks := contentBlocks(msg)
 		if blocks == nil {
 			continue
@@ -234,18 +232,30 @@ func (p *anthropicProvider) formatMessages(messages []types.LlmMessage) []map[st
 			}
 		}
 
-		// Cache early user messages (first 2 user messages) for prompt caching
-		if msg.Role == "user" && i < 4 && len(formatted) > 0 {
-			last := formatted[len(formatted)-1]
-			if _, hasCacheCtrl := last["cache_control"]; !hasCacheCtrl {
-				last["cache_control"] = map[string]string{"type": "ephemeral"}
-			}
-		}
-
 		result = append(result, map[string]any{
 			"role":    msg.Role,
 			"content": formatted,
 		})
+	}
+
+	// Apply cache_control to the last N user messages (walking backwards).
+	// Budget: Anthropic allows max 4 cache_control blocks per request;
+	// 1 is used by the system prompt, leaving 3 for messages.
+	const messageCacheBudget = 3
+	remaining := messageCacheBudget
+	for i := len(result) - 1; i >= 0 && remaining > 0; i-- {
+		if result[i]["role"] != "user" {
+			continue
+		}
+		content, ok := result[i]["content"].([]map[string]any)
+		if !ok || len(content) == 0 {
+			continue
+		}
+		last := content[len(content)-1]
+		if _, hasCacheCtrl := last["cache_control"]; !hasCacheCtrl {
+			last["cache_control"] = map[string]string{"type": "ephemeral"}
+		}
+		remaining--
 	}
 
 	return result

--- a/engine/internal/session/prompt_options.go
+++ b/engine/internal/session/prompt_options.go
@@ -73,6 +73,9 @@ func (m *Manager) applyConfigDefaults(opts *types.RunOptions) {
 	if m.config.Limits.DisableMaxTokenContinue != nil && *m.config.Limits.DisableMaxTokenContinue {
 		opts.DisableMaxTokenContinue = true
 	}
+	if m.config.WebSearch != nil && m.config.WebSearch.Mode != "" {
+		opts.WebSearchMode = m.config.WebSearch.Mode
+	}
 }
 
 // resolveModelTier resolves model tier aliases (e.g. "fast" -> configured fast model).

--- a/engine/internal/tools/web_search.go
+++ b/engine/internal/tools/web_search.go
@@ -202,6 +202,12 @@ func resolveSearchBackend() SearchBackend {
 	return nil
 }
 
+// HasSearchBackend reports whether a client-side search backend is configured
+// via environment variables (BRAVE_SEARCH_API_KEY, TAVILY_API_KEY, or SEARXNG_URL).
+func HasSearchBackend() bool {
+	return resolveSearchBackend() != nil
+}
+
 // WebSearchTool returns a ToolDef that searches the web using a pluggable
 // backend (Brave, Tavily, or SearXNG).
 func WebSearchTool() *types.ToolDef {

--- a/engine/internal/types/config.go
+++ b/engine/internal/types/config.go
@@ -75,6 +75,7 @@ type EngineRuntimeConfig struct {
 	FeatureFlags *FeatureFlagsConfig           `json:"featureFlags,omitempty"`
 	Relay        *RelayConfig                  `json:"relay,omitempty"`
 	Timeouts     *TimeoutsConfig               `json:"timeouts,omitempty"`
+	WebSearch    *WebSearchConfig              `json:"webSearch,omitempty"`
 	LogLevel     string                        `json:"logLevel,omitempty"` // "debug", "info", "warn", "error"
 }
 
@@ -291,4 +292,9 @@ type OtelConfig struct {
 	Headers            map[string]string `json:"headers,omitempty"`
 	ServiceName        string            `json:"serviceName,omitempty"`
 	ResourceAttributes map[string]string `json:"resourceAttributes,omitempty"`
+}
+
+// WebSearchConfig controls web search tool behavior.
+type WebSearchConfig struct {
+	Mode string `json:"mode,omitempty"` // "auto", "client", or "server"; default "auto"
 }

--- a/engine/internal/types/types.go
+++ b/engine/internal/types/types.go
@@ -402,6 +402,7 @@ type RunOptions struct {
 	DisableMaxTokenContinue bool         `json:"disableMaxTokenContinue,omitempty"`
 	CapabilityTools         []LlmToolDef `json:"-"` // capability tools injected by session manager
 	CapabilityPrompt        string       `json:"-"` // capability prompt content injected by session manager
+	WebSearchMode           string       `json:"-"` // "auto", "client", or "server", propagated from config
 }
 
 // StoredSessionInfo is metadata for a saved conversation on disk.


### PR DESCRIPTION
- **fix(desktop): emit session_init for queued prompt transitions**
- **feat(desktop): wire steer_agent for mid-run messages**
- **fix(engine): cap cache_control blocks to anthropic limit of 4**
- **fix(desktop): detect staged flag in git polling diff**
- **fix(desktop): move commit input to dedicated row**
- **feat(engine): add web search mode configuration**
- **chore(engine): replace if-else chains with switch statements**
- **chore(engine): ignore return values from cleanup operations**
