### PR TITLE
MCP fix and tests pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ release/
 
 # Go binaries
 engine/bin/
+engine/mcpserver
 desktop/resources/engine/
 
 # Gap analysis working files

--- a/engine/internal/mcp/http.go
+++ b/engine/internal/mcp/http.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"sync/atomic"
 )
 
 // httpTransport implements mcpTransport for StreamableHTTP MCP servers.
@@ -17,6 +18,8 @@ type httpTransport struct {
 	sessionID string
 	mu        sync.Mutex
 	respCh    chan json.RawMessage
+	closed    atomic.Bool
+	closeOnce sync.Once
 }
 
 func newHTTPTransport(baseURL string, headers map[string]string) (*httpTransport, error) {
@@ -72,7 +75,9 @@ func (t *httpTransport) Send(msg json.RawMessage) error {
 	}
 
 	if len(body) > 0 && json.Valid(body) {
-		t.respCh <- json.RawMessage(body)
+		if !t.closed.Load() {
+			t.respCh <- json.RawMessage(body)
+		}
 	}
 
 	return nil
@@ -87,24 +92,28 @@ func (t *httpTransport) Receive() (json.RawMessage, error) {
 }
 
 func (t *httpTransport) Close() error {
-	t.mu.Lock()
-	sid := t.sessionID
-	t.mu.Unlock()
+	t.closeOnce.Do(func() {
+		t.closed.Store(true)
 
-	if sid != "" {
-		req, err := http.NewRequest(http.MethodDelete, t.baseURL, nil)
-		if err == nil {
-			req.Header.Set("Mcp-Session-Id", sid)
-			for k, v := range t.headers {
-				req.Header.Set(k, v)
-			}
-			resp, err := t.client.Do(req)
+		t.mu.Lock()
+		sid := t.sessionID
+		t.mu.Unlock()
+
+		if sid != "" {
+			req, err := http.NewRequest(http.MethodDelete, t.baseURL, nil)
 			if err == nil {
-				resp.Body.Close()
+				req.Header.Set("Mcp-Session-Id", sid)
+				for k, v := range t.headers {
+					req.Header.Set(k, v)
+				}
+				resp, err := t.client.Do(req)
+				if err == nil {
+					_ = resp.Body.Close()
+				}
 			}
 		}
-	}
 
-	close(t.respCh)
+		close(t.respCh)
+	})
 	return nil
 }

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -145,6 +145,14 @@ type jsonRPCError struct {
 	Message string `json:"message"`
 }
 
+// jsonRPCNotification is a JSON-RPC 2.0 notification (no "id" field).
+// Per the spec, notifications MUST NOT include an "id" member.
+type jsonRPCNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
 // Connect establishes a connection to an MCP server.
 func Connect(name string, config types.McpServerConfig) (*Connection, error) {
 	var transport mcpTransport
@@ -233,7 +241,7 @@ func (c *Connection) initialize() error {
 	_ = resp
 
 	// Send initialized notification (no response expected).
-	notif := jsonRPCRequest{
+	notif := jsonRPCNotification{
 		JSONRPC: "2.0",
 		Method:  "notifications/initialized",
 	}

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -526,10 +526,12 @@ func (t *stdioTransport) Close() error {
 // --- SSE transport ---
 
 type sseTransport struct {
-	baseURL string
-	msgCh   chan json.RawMessage
-	client  *http.Client
-	done    chan struct{}
+	baseURL   string
+	msgCh     chan json.RawMessage
+	client    *http.Client
+	done      chan struct{}
+	closeOnce sync.Once
+	wg        sync.WaitGroup
 }
 
 func newSSETransport(config types.McpServerConfig) (*sseTransport, error) {
@@ -544,10 +546,62 @@ func newSSETransport(config types.McpServerConfig) (*sseTransport, error) {
 		done:    make(chan struct{}),
 	}
 
+	// Start SSE event stream reader goroutine.
+	t.wg.Add(1)
+	go t.readEventStream()
+
 	return t, nil
 }
 
+// readEventStream connects to the SSE endpoint and reads events into msgCh.
+func (t *sseTransport) readEventStream() {
+	defer t.wg.Done()
+
+	req, err := http.NewRequest(http.MethodGet, t.baseURL, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		select {
+		case <-t.done:
+			return
+		default:
+		}
+
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		data = strings.TrimSpace(data)
+		if len(data) == 0 || !json.Valid([]byte(data)) {
+			continue
+		}
+
+		select {
+		case t.msgCh <- json.RawMessage(data):
+		case <-t.done:
+			return
+		}
+	}
+}
+
 func (t *sseTransport) Send(msg json.RawMessage) error {
+	select {
+	case <-t.done:
+		return fmt.Errorf("SSE transport closed")
+	default:
+	}
+
 	req, err := http.NewRequest(http.MethodPost, t.baseURL+"/message", strings.NewReader(string(msg)))
 	if err != nil {
 		return err
@@ -558,11 +612,24 @@ func (t *sseTransport) Send(msg json.RawMessage) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("SSE send error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	// Some MCP servers return inline JSON-RPC responses in the POST body
+	// rather than via the event stream. Queue them like stream events.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil // Send succeeded; read failure is non-fatal.
+	}
+	if len(body) > 0 && json.Valid(body) {
+		select {
+		case t.msgCh <- json.RawMessage(body):
+		case <-t.done:
+		}
 	}
 
 	return nil
@@ -577,6 +644,12 @@ func (t *sseTransport) Receive() (json.RawMessage, error) {
 }
 
 func (t *sseTransport) Close() error {
-	close(t.done)
+	t.closeOnce.Do(func() {
+		close(t.done)
+		// Wait for the reader goroutine to exit before closing msgCh
+		// to prevent send-on-closed-channel panic.
+		t.wg.Wait()
+		close(t.msgCh)
+	})
 	return nil
 }

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -115,6 +115,9 @@ type Connection struct {
 	nextID      atomic.Int64
 	mu          sync.Mutex
 	callTimeout time.Duration
+	dead        chan struct{} // closed when connection is marked dead (e.g. timeout)
+	deadOnce    sync.Once
+	deadErr     error // the error that caused the connection to be marked dead
 }
 
 // mcpTransport abstracts stdio vs SSE communication.
@@ -199,6 +202,7 @@ func Connect(name string, config types.McpServerConfig) (*Connection, error) {
 	conn := &Connection{
 		name:      name,
 		transport: transport,
+		dead:      make(chan struct{}),
 	}
 	if config.TimeoutSeconds > 0 {
 		conn.callTimeout = time.Duration(config.TimeoutSeconds) * time.Second
@@ -267,6 +271,13 @@ func (c *Connection) listTools() ([]ToolDef, error) {
 }
 
 func (c *Connection) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	// Fast-fail if the connection was previously marked dead.
+	select {
+	case <-c.dead:
+		return nil, fmt.Errorf("mcp connection %s is dead: %w", c.name, c.deadErr)
+	default:
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -328,13 +339,22 @@ func (c *Connection) call(ctx context.Context, method string, params any) (json.
 	case r := <-ch:
 		return r.data, r.err
 	case <-ctx.Done():
-		return nil, fmt.Errorf("mcp call %s: %w", method, ctx.Err())
+		c.markDead(fmt.Errorf("mcp call %s: %w", method, ctx.Err()))
+		return nil, c.deadErr
 	case <-time.After(timeout):
-		// Note: the goroutine running Receive() may leak if the transport
-		// truly hangs, but this is strictly better than the caller also
-		// hanging indefinitely (the previous behavior).
-		return nil, fmt.Errorf("mcp call %s: timeout after %s", method, timeout)
+		c.markDead(fmt.Errorf("mcp call %s: timeout after %s", method, timeout))
+		return nil, c.deadErr
 	}
+}
+
+// markDead marks the connection as permanently failed. Subsequent calls will
+// fast-fail. The leaked Receive goroutine will be cleaned up when Close() is
+// called on the transport.
+func (c *Connection) markDead(err error) {
+	c.deadOnce.Do(func() {
+		c.deadErr = err
+		close(c.dead)
+	})
 }
 
 // CallTool invokes a tool on the MCP server and returns the text result.

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -375,7 +375,7 @@ func (c *Connection) CallTool(ctx context.Context, toolName string, params map[s
 		IsError bool `json:"isError"`
 	}
 	if err := json.Unmarshal(resp, &result); err != nil {
-		return string(resp), nil
+		return "", fmt.Errorf("unexpected tool response format: %w (raw: %.200s)", err, resp)
 	}
 
 	if result.IsError {

--- a/engine/internal/mcp/mcp.go
+++ b/engine/internal/mcp/mcp.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -435,8 +436,11 @@ func newStdioTransport(config types.McpServerConfig) (*stdioTransport, error) {
 	}
 
 	cmd := exec.Command(config.Command, config.Args...)
-	for k, v := range config.Env {
-		cmd.Env = append(cmd.Env, k+"="+v)
+	if len(config.Env) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range config.Env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
 	}
 
 	stdin, err := cmd.StdinPipe()
@@ -483,8 +487,12 @@ func (t *stdioTransport) Receive() (json.RawMessage, error) {
 }
 
 func (t *stdioTransport) Close() error {
-	t.stdin.Close()
-	return t.cmd.Process.Kill()
+	_ = t.stdin.Close()
+	_ = t.cmd.Process.Kill()
+	// Wait reaps the child process to prevent zombies. The error from Wait is
+	// always non-nil after Kill, so we ignore it.
+	_ = t.cmd.Wait()
+	return nil
 }
 
 // --- SSE transport ---

--- a/engine/internal/mcp/mcp_integration_test.go
+++ b/engine/internal/mcp/mcp_integration_test.go
@@ -1,0 +1,145 @@
+//go:build integration
+
+package mcp
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+var testServerBin string
+
+func TestMain(m *testing.M) {
+	// Compile the test MCP server binary.
+	tmp, err := os.MkdirTemp("", "mcp-test-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	bin := filepath.Join(tmp, "mcpserver")
+	cmd := exec.Command("go", "build", "-o", bin, "./testdata/mcpserver")
+	cmd.Dir = filepath.Join(".")
+	// Use the current module context for building.
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic("build test server: " + err.Error() + "\n" + string(out))
+	}
+	testServerBin = bin
+	os.Exit(m.Run())
+}
+
+func TestStdioConnect_FullLifecycle(t *testing.T) {
+	conn, err := Connect("integ-test", types.McpServerConfig{
+		Command: testServerBin,
+	})
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Verify tool discovery.
+	tools := conn.Tools()
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		toolNames[tool.Name] = true
+	}
+	if !toolNames["echo"] || !toolNames["get_env"] {
+		t.Errorf("unexpected tools: %v", toolNames)
+	}
+
+	// Call echo tool.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	result, err := conn.CallTool(ctx, "echo", map[string]interface{}{"text": "hello world"})
+	if err != nil {
+		t.Fatalf("CallTool echo: %v", err)
+	}
+	if result != "hello world" {
+		t.Errorf("echo result = %q, want %q", result, "hello world")
+	}
+}
+
+func TestStdioConnect_Timeout(t *testing.T) {
+	conn, err := Connect("integ-timeout", types.McpServerConfig{
+		Command:        testServerBin,
+		TimeoutSeconds: 1, // 1s timeout — slow_echo sleeps 5s
+	})
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer conn.Close()
+
+	ctx := context.Background()
+	_, err = conn.CallTool(ctx, "slow_echo", map[string]interface{}{"text": "test"})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected 'timeout' in error, got: %s", err)
+	}
+}
+
+func TestStdioConnect_EnvInheritance(t *testing.T) {
+	conn, err := Connect("integ-env", types.McpServerConfig{
+		Command: testServerBin,
+		Env:     map[string]string{"CUSTOM_TEST_VAR": "custom_value_42"},
+	})
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Verify custom env var is passed.
+	result, err := conn.CallTool(ctx, "get_env", map[string]interface{}{"name": "CUSTOM_TEST_VAR"})
+	if err != nil {
+		t.Fatalf("CallTool get_env CUSTOM_TEST_VAR: %v", err)
+	}
+	if result != "custom_value_42" {
+		t.Errorf("CUSTOM_TEST_VAR = %q, want %q", result, "custom_value_42")
+	}
+
+	// Verify parent PATH is inherited (not wiped).
+	result, err = conn.CallTool(ctx, "get_env", map[string]interface{}{"name": "PATH"})
+	if err != nil {
+		t.Fatalf("CallTool get_env PATH: %v", err)
+	}
+	if result == "" {
+		t.Error("PATH should not be empty — parent env must be inherited")
+	}
+}
+
+func TestStdioConnect_CloseReaps(t *testing.T) {
+	conn, err := Connect("integ-close", types.McpServerConfig{
+		Command: testServerBin,
+	})
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// After close, calls should fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_, err = conn.CallTool(ctx, "echo", map[string]interface{}{"text": "should fail"})
+	if err == nil {
+		t.Error("expected error after close, got nil")
+	}
+}

--- a/engine/internal/mcp/mcp_test.go
+++ b/engine/internal/mcp/mcp_test.go
@@ -409,6 +409,7 @@ func TestCall_Timeout(t *testing.T) {
 		name:        "timeout-test",
 		transport:   st,
 		callTimeout: 100 * time.Millisecond,
+		dead:        make(chan struct{}),
 	}
 
 	_, err := conn.call(context.Background(), "tools/list", nil)
@@ -446,6 +447,7 @@ func TestCall_ReceiveError(t *testing.T) {
 		name:        "error-test",
 		transport:   et,
 		callTimeout: 5 * time.Second,
+		dead:        make(chan struct{}),
 	}
 
 	_, err := conn.call(context.Background(), "tools/list", nil)
@@ -454,5 +456,35 @@ func TestCall_ReceiveError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "connection reset") {
 		t.Errorf("expected 'connection reset' in error, got: %s", err)
+	}
+}
+
+func TestCall_DeadAfterTimeout(t *testing.T) {
+	st := &slowTransport{done: make(chan struct{})}
+	defer st.Close()
+
+	conn := &Connection{
+		name:        "dead-test",
+		transport:   st,
+		callTimeout: 50 * time.Millisecond,
+		dead:        make(chan struct{}),
+	}
+
+	// First call should timeout and mark connection dead.
+	_, err := conn.call(context.Background(), "tools/list", nil)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("expected 'timeout' in error, got: %s", err)
+	}
+
+	// Second call should immediately fail with dead connection error.
+	_, err = conn.call(context.Background(), "tools/list", nil)
+	if err == nil {
+		t.Fatal("expected dead connection error")
+	}
+	if !strings.Contains(err.Error(), "dead") {
+		t.Errorf("expected 'dead' in error, got: %s", err)
 	}
 }

--- a/engine/internal/mcp/oauth.go
+++ b/engine/internal/mcp/oauth.go
@@ -185,13 +185,25 @@ func (s *OAuthStore) load() {
 	s.tokens = tokens
 }
 
+// getOAuthStore returns the package-level singleton OAuthStore instance.
+// Multiple MCP connections share one store to avoid concurrent file I/O.
+var (
+	globalOAuthStore     *OAuthStore
+	globalOAuthStoreOnce sync.Once
+)
+
+func getOAuthStore() *OAuthStore {
+	globalOAuthStoreOnce.Do(func() { globalOAuthStore = NewOAuthStore() })
+	return globalOAuthStore
+}
+
 // resolveOAuthHeaders returns auth headers for a server, refreshing if needed.
 func resolveOAuthHeaders(serverName string, oauthConfig *OAuthConfig) map[string]string {
 	if oauthConfig == nil {
 		return nil
 	}
 
-	store := NewOAuthStore()
+	store := getOAuthStore()
 	token := store.GetToken(serverName)
 
 	// Try refresh if token is expired but refresh token exists.

--- a/engine/internal/mcp/testdata/mcpserver/main.go
+++ b/engine/internal/mcp/testdata/mcpserver/main.go
@@ -1,0 +1,132 @@
+// Package main implements a minimal MCP server for integration testing.
+// It reads JSON-RPC 2.0 lines from stdin and writes responses to stdout.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+type request struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string           `json:"method"`
+	Params  json.RawMessage  `json:"params,omitempty"`
+}
+
+type response struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   interface{} `json:"error,omitempty"`
+}
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var req request
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+
+		// Notifications have no ID — do not respond.
+		if req.ID == nil {
+			continue
+		}
+
+		var id interface{}
+		_ = json.Unmarshal(*req.ID, &id)
+
+		resp := handleMethod(req.Method, req.Params, id)
+		data, _ := json.Marshal(resp)
+		fmt.Fprintf(os.Stdout, "%s\n", data)
+	}
+}
+
+func handleMethod(method string, params json.RawMessage, id interface{}) response {
+	switch method {
+	case "initialize":
+		return response{JSONRPC: "2.0", ID: id, Result: map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": "test-mcpserver", "version": "1.0.0"},
+		}}
+	case "tools/list":
+		return response{JSONRPC: "2.0", ID: id, Result: map[string]interface{}{
+			"tools": []interface{}{
+				map[string]interface{}{
+					"name": "echo", "description": "Echoes input text",
+					"inputSchema": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"text": map[string]interface{}{"type": "string"},
+						},
+						"required": []string{"text"},
+					},
+				},
+				map[string]interface{}{
+					"name": "get_env", "description": "Returns an env var value",
+					"inputSchema": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"name": map[string]interface{}{"type": "string"},
+						},
+						"required": []string{"name"},
+					},
+				},
+			},
+		}}
+	case "tools/call":
+		return handleToolCall(params, id)
+	default:
+		return response{JSONRPC: "2.0", ID: id, Error: map[string]interface{}{
+			"code": -32601, "message": "method not found",
+		}}
+	}
+}
+
+func handleToolCall(params json.RawMessage, id interface{}) response {
+	var p struct {
+		Name      string                 `json:"name"`
+		Arguments map[string]interface{} `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return response{JSONRPC: "2.0", ID: id, Error: map[string]interface{}{
+			"code": -32602, "message": "invalid params",
+		}}
+	}
+
+	switch p.Name {
+	case "echo":
+		text, _ := p.Arguments["text"].(string)
+		return toolResult(id, text, false)
+	case "get_env":
+		name, _ := p.Arguments["name"].(string)
+		return toolResult(id, os.Getenv(name), false)
+	case "slow_echo":
+		time.Sleep(5 * time.Second)
+		text, _ := p.Arguments["text"].(string)
+		return toolResult(id, text, false)
+	default:
+		return toolResult(id, "unknown tool: "+p.Name, true)
+	}
+}
+
+func toolResult(id interface{}, text string, isError bool) response {
+	return response{JSONRPC: "2.0", ID: id, Result: map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": text},
+		},
+		"isError": isError,
+	}}
+}

--- a/engine/internal/mcp/ws.go
+++ b/engine/internal/mcp/ws.go
@@ -14,9 +14,10 @@ import (
 
 // wsTransport implements mcpTransport over a WebSocket connection.
 type wsTransport struct {
-	conn *websocket.Conn
-	mu   sync.Mutex
-	done chan struct{}
+	conn      *websocket.Conn
+	mu        sync.Mutex
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 func newWSTransport(url string, headers map[string]string) (*wsTransport, error) {
@@ -72,6 +73,10 @@ func (t *wsTransport) Receive() (json.RawMessage, error) {
 }
 
 func (t *wsTransport) Close() error {
-	close(t.done)
-	return t.conn.Close(websocket.StatusNormalClosure, "closing")
+	var err error
+	t.closeOnce.Do(func() {
+		close(t.done)
+		err = t.conn.Close(websocket.StatusNormalClosure, "closing")
+	})
+	return err
 }


### PR DESCRIPTION
- **fix(engine): fix mcp stdio env inheritance and process reap**
- **fix(engine): fix mcp notification id violation**
- **fix(engine): mark mcp connection dead on timeout**
- **test(engine): add mcp stdio integration test**
- **fix(engine): add close safety to mcp ws and http transports**
- **fix(engine): fix mcp calltool error masking**
- **fix(engine): singleton oauth store for mcp**
- **fix(engine): implement mcp sse event stream reader**
- **chore(repo): ignore mcp test server binary**
