### PR TITLE
Engine, ios, and relay fixes

### DIFF
--- a/engine/internal/backend/runloop.go
+++ b/engine/internal/backend/runloop.go
@@ -135,7 +135,14 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 
 		// Fire turn_start hook
 		if hooks.OnTurnStart != nil {
-			hooks.OnTurnStart(run.requestID, turn)
+			if _, err := runHookCtx(ctx, func() struct{} {
+				hooks.OnTurnStart(run.requestID, turn)
+				return struct{}{}
+			}); err != nil {
+				utils.Warn("ApiBackend", fmt.Sprintf("turn_start hook cancelled: runID=%s turn=%d", run.requestID, turn))
+				b.emitExit(run.requestID, intPtr(0), strPtr("cancelled"), conv.ID)
+				return
+			}
 		}
 
 		// Check budget
@@ -300,7 +307,14 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 
 		// Fire turn_end hook
 		if hooks.OnTurnEnd != nil {
-			hooks.OnTurnEnd(run.requestID, turn)
+			if _, err := runHookCtx(ctx, func() struct{} {
+				hooks.OnTurnEnd(run.requestID, turn)
+				return struct{}{}
+			}); err != nil {
+				utils.Warn("ApiBackend", fmt.Sprintf("turn_end hook cancelled: runID=%s turn=%d", run.requestID, turn))
+				b.emitExit(run.requestID, intPtr(0), strPtr("cancelled"), conv.ID)
+				return
+			}
 		}
 
 		// Handle stop reason

--- a/engine/internal/tools/bash_operations.go
+++ b/engine/internal/tools/bash_operations.go
@@ -61,6 +61,12 @@ func (l *LocalBashOperations) Exec(ctx context.Context, command, cwd string, opt
 	// entire subprocess tree, not just the direct shell child.
 	configureProcGroup(cmd)
 
+	// WaitDelay bounds how long cmd.Wait() lingers after Cancel fires.
+	// Without it, Wait() blocks until all I/O pipes close -- an orphaned
+	// grandchild (daemon, setsid, changed PGID) that inherited stdout/stderr
+	// can hold pipes open indefinitely, wedging the goroutine forever.
+	cmd.WaitDelay = 5 * time.Second
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/engine/internal/tools/notebook.go
+++ b/engine/internal/tools/notebook.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/dsswift/ion/engine/internal/types"
 )
@@ -204,8 +205,10 @@ func executeNotebook(ctx context.Context, input map[string]any, cwd string) (*ty
 		}
 
 		code := strings.Join(cell.Source, "")
-		cmd := exec.Command("python3", "-c", code)
+		cmd := exec.CommandContext(ctx, "python3", "-c", code)
 		cmd.Dir = cwd
+		configureProcGroup(cmd)
+		cmd.WaitDelay = 5 * time.Second
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			return &types.ToolResult{

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		A1B2C3D4E5F60001000204AA /* SessionViewModel+Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000205AA /* SessionViewModel+Commands.swift */; };
 		A1B2C3D4E5F60001000206AA /* SessionViewModel+EventHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000207AA /* SessionViewModel+EventHandlers.swift */; };
 		A1B2C3D4E5F60001000208AA /* SessionViewModel+EngineEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000209AA /* SessionViewModel+EngineEvents.swift */; };
+		A1B2C3D4E5F60001000902AA /* SessionViewModel+Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000903AA /* SessionViewModel+Snapshot.swift */; };
 		A1B2C3D4E5F60001000220AA /* TransportManager+Send.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000221AA /* TransportManager+Send.swift */; };
 		A1B2C3D4E5F60001000222AA /* TransportManager+Receive.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000223AA /* TransportManager+Receive.swift */; };
 		A1B2C3D4E5F60001000230AA /* NormalizedEvent+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000231AA /* NormalizedEvent+Lifecycle.swift */; };
@@ -152,6 +153,7 @@
 		A1B2C3D4E5F60001000205AA /* SessionViewModel+Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionViewModel+Commands.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000207AA /* SessionViewModel+EventHandlers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionViewModel+EventHandlers.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000209AA /* SessionViewModel+EngineEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionViewModel+EngineEvents.swift"; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001000903AA /* SessionViewModel+Snapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionViewModel+Snapshot.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000221AA /* TransportManager+Send.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransportManager+Send.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000223AA /* TransportManager+Receive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TransportManager+Receive.swift"; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000231AA /* NormalizedEvent+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NormalizedEvent+Lifecycle.swift"; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 				A1B2C3D4E5F60001000205AA /* SessionViewModel+Commands.swift */,
 				A1B2C3D4E5F60001000207AA /* SessionViewModel+EventHandlers.swift */,
 				A1B2C3D4E5F60001000209AA /* SessionViewModel+EngineEvents.swift */,
+				A1B2C3D4E5F60001000903AA /* SessionViewModel+Snapshot.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -507,6 +510,7 @@
 				A1B2C3D4E5F60001000204AA /* SessionViewModel+Commands.swift in Sources */,
 				A1B2C3D4E5F60001000206AA /* SessionViewModel+EventHandlers.swift in Sources */,
 				A1B2C3D4E5F60001000208AA /* SessionViewModel+EngineEvents.swift in Sources */,
+				A1B2C3D4E5F60001000902AA /* SessionViewModel+Snapshot.swift in Sources */,
 				A1B2C3D4E5F60001000220AA /* TransportManager+Send.swift in Sources */,
 				A1B2C3D4E5F60001000222AA /* TransportManager+Receive.swift in Sources */,
 				A1B2C3D4E5F60001000230AA /* NormalizedEvent+Lifecycle.swift in Sources */,

--- a/ios/IonRemote/App/IonRemoteApp.swift
+++ b/ios/IonRemote/App/IonRemoteApp.swift
@@ -52,9 +52,12 @@ struct ContentView: View {
         Group {
             if viewModel.pairedDevices.isEmpty || viewModel.connectionState == .authFailed {
                 PairingView()
-            } else if viewModel.connectionState == .disconnected || viewModel.connectionState == .connecting || viewModel.connectionState == .reconnecting {
+            } else if viewModel.connectionState == .disconnected || viewModel.connectionState == .connecting {
                 disconnectedView
             } else {
+                // .connected and .reconnecting both show the tab list.
+                // During .reconnecting the transport stays alive and will
+                // auto-recover; the signal-quality bars give visual feedback.
                 TabListView()
             }
         }
@@ -98,15 +101,14 @@ struct ContentView: View {
                           viewModel.connectionState == .disconnected else { break }
                     viewModel.reconnect()
                 }
-            case .connecting, .reconnecting:
+            case .connecting:
                 // Break out of a stuck handshake after 15 seconds and keep retrying.
                 // Loop because reconnect() may batch .connecting→.disconnected→.connecting
                 // in a single SwiftUI update so .task(id:) wouldn't restart.
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .seconds(15))
                     guard !Task.isCancelled,
-                          viewModel.connectionState == .connecting
-                              || viewModel.connectionState == .reconnecting else { return }
+                          viewModel.connectionState == .connecting else { return }
                     viewModel.reconnect()
                 }
             default:

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -38,13 +38,17 @@ extension SessionViewModel {
             while !Task.isCancelled {
                 try? await Task.sleep(for: .milliseconds(16))
                 guard !Task.isCancelled, let self else { break }
-
                 let batch = await self.eventBatcher.drain()
-                if !batch.isEmpty {
-                    await MainActor.run {
-                        for event in batch {
-                            self.handleEvent(event)
-                        }
+                // Sync connectionQuality.transportState so signal bars update promptly.
+                let latestTransport = self.transport?.state ?? .disconnected
+                let needsStateSync = self.connectionQuality.transportState != latestTransport
+                guard !batch.isEmpty || needsStateSync else { continue }
+                await MainActor.run {
+                    for event in batch {
+                        self.handleEvent(event)
+                    }
+                    if needsStateSync {
+                        self.connectionQuality.transportState = latestTransport
                     }
                 }
             }
@@ -67,16 +71,20 @@ extension SessionViewModel {
             if connectionState == .connected {
                 connectionState = .reconnecting
             }
+            connectionQuality.transportState = transport?.state ?? .disconnected
 
         case .heartbeat(let senderTs, let buffered):
             connectionQuality.transportState = transport?.state ?? .disconnected
             connectionQuality.recordHeartbeat(senderTs: senderTs, buffered: buffered)
 
         case .peerDisconnected:
-            // Tear down and let the auto-retry in IonRemoteApp reconnect.
-            // connect() creates a relay-capable transport and starts Bonjour,
-            // so LAN auto-upgrade still works when the desktop comes back.
-            disconnect()
+            // Don't tear down the transport — the relay auto-reconnects and
+            // startRelayStateObservation re-sends sync when the peer returns.
+            if connectionState == .connected || connectionState == .connecting {
+                connectionState = .reconnecting
+                startReconnectSafetyTimer()
+            }
+            connectionQuality.transportState = transport?.state ?? .disconnected
 
         case .snapshot(let snapshotTabs, let recentDirs, let snapshotGroupMode, let snapshotGroups):
             handleSnapshot(snapshotTabs: snapshotTabs, recentDirs: recentDirs, groupMode: snapshotGroupMode, groups: snapshotGroups)
@@ -300,99 +308,6 @@ extension SessionViewModel {
             pairedDevices[0].relayURL = relayUrl
             pairedDevices[0].relayAPIKey = relayApiKey
             savePairedDevices()
-        }
-    }
-
-    @MainActor
-    private func handleSnapshot(snapshotTabs: [RemoteTabState], recentDirs: [String], groupMode: String?, groups: [RemoteTabGroup]?) {
-        if connectionState != .connected {
-            connectionState = .connected
-        }
-        connectionQuality.transportState = transport?.state ?? .disconnected
-        if !recentDirs.isEmpty {
-            recentDirectories = recentDirs
-        }
-        // Update tab group mode and groups from desktop
-        if let mode = groupMode {
-            tabGroupMode = mode
-        }
-        if let grps = groups {
-            tabGroups = grps
-        }
-        // Filter out tabs that iOS requested to close but hasn't received
-        // tab_closed confirmation for yet. Without this, the snapshot
-        // resurrects tabs that the user just swiped away.
-        let filteredTabs = snapshotTabs.filter { !pendingCloseTabIds.contains($0.id) }
-        // Preserve locally-injected permission queue entries that arrived
-        // via permission_request events. Snapshots pull the queue from the
-        // desktop renderer, which may have already auto-allowed tools like
-        // AskUserQuestion/ExitPlanMode (empty queue), while iOS still needs
-        // to show the card until the user taps an answer.
-        var merged = filteredTabs
-        for i in merged.indices {
-            let tabId = merged[i].id
-
-            // Strip ExitPlanMode/AskUserQuestion entries from the snapshot
-            // queue if the user already dismissed the card on this tab.
-            // The 5-second snapshot polling can re-inject stale entries
-            // from the desktop's permissionDenied before it's cleared.
-            if dismissedLiveSpecialTabs.contains(tabId) {
-                merged[i].permissionQueue.removeAll {
-                    $0.toolName == "ExitPlanMode" || $0.toolName == "AskUserQuestion"
-                }
-            }
-
-            if let existing = tabs.first(where: { $0.id == tabId }),
-               !existing.permissionQueue.isEmpty {
-                // Keep existing local queue entries that aren't in the snapshot
-                let snapshotIds = Set(merged[i].permissionQueue.map(\.questionId))
-                let isRunning = merged[i].status == .running
-                let localOnly = existing.permissionQueue.filter { entry in
-                    if snapshotIds.contains(entry.questionId) { return false }
-                    // Don't re-inject stale plan/question cards once a new task is running
-                    if isRunning && (entry.toolName == "ExitPlanMode" || entry.toolName == "AskUserQuestion") {
-                        return false
-                    }
-                    return true
-                }
-                merged[i].permissionQueue.append(contentsOf: localOnly)
-                // Prefer local entry when it has richer data (e.g. planContent from live event)
-                for local in existing.permissionQueue where snapshotIds.contains(local.questionId) {
-                    if local.toolInput?["planContent"]?.value as? String != nil,
-                       let idx = merged[i].permissionQueue.firstIndex(where: { $0.questionId == local.questionId }),
-                       merged[i].permissionQueue[idx].toolInput?["planContent"]?.value as? String == nil {
-                        merged[i].permissionQueue[idx] = local
-                    }
-                }
-            }
-        }
-        // Always prefer locally-tracked lastMessage over snapshot values.
-        // Real-time textChunk/messageAdded events update lastMessage on iOS
-        // faster than the 5-second snapshot poll, so the local value is
-        // always equal or fresher. The snapshot value is only used for
-        // initial population (when no local value exists yet).
-        for i in merged.indices {
-            if let existing = tabs.first(where: { $0.id == merged[i].id }),
-               existing.lastMessage != nil {
-                merged[i].lastMessage = existing.lastMessage
-            }
-        }
-        tabs = merged
-        tabIds = Set(merged.map(\.id))
-        // Populate terminal state from snapshot tab data
-        for tab in merged {
-            if tab.isTerminalOnly == true, let instances = tab.terminalInstances {
-                terminalInstances[tab.id] = instances
-                activeTerminalInstance[tab.id] = tab.activeTerminalInstanceId ?? instances.first?.id
-            }
-            // Populate engine instance state from snapshot tab data
-            if tab.isEngine == true, let instances = tab.engineInstances {
-                engineInstances[tab.id] = instances.map { EngineInstanceInfo(id: $0.id, label: $0.label) }
-                activeEngineInstance[tab.id] = tab.activeEngineInstanceId ?? instances.first?.id
-                ionLog.info("snapshot: engine tab \(tab.id.prefix(8)), instances=\(instances.map(\.id)), active=\(tab.activeEngineInstanceId ?? "nil")")
-                // Pre-load engine conversation history for all engine tabs
-                loadEngineConversation(tabId: tab.id)
-            }
         }
     }
 

--- a/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
@@ -100,6 +100,8 @@ extension SessionViewModel {
 
     /// Disconnect from the current transport and wipe all transient state.
     func disconnect() {
+        reconnectSafetyTask?.cancel()
+        reconnectSafetyTask = nil
         eventTask?.cancel()
         eventTask = nil
         flushTask?.cancel()
@@ -107,6 +109,25 @@ extension SessionViewModel {
         transport?.stop()
         transport = nil
         wipeTransientState()
+    }
+
+    /// Start a safety timer that forces a full reconnect if the app stays
+    /// in `.reconnecting` for too long (e.g. the relay can't reach the peer).
+    func startReconnectSafetyTimer() {
+        reconnectSafetyTask?.cancel()
+        reconnectSafetyTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(30))
+            guard !Task.isCancelled, let self else { return }
+            if self.connectionState == .reconnecting {
+                self.reconnect()
+            }
+        }
+    }
+
+    /// Cancel the reconnect safety timer (called when we reach `.connected`).
+    func cancelReconnectSafetyTimer() {
+        reconnectSafetyTask?.cancel()
+        reconnectSafetyTask = nil
     }
 
     /// Clear all transient state (tabs, messages, etc.) to prevent stale data.

--- a/ios/IonRemote/ViewModels/SessionViewModel+Snapshot.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Snapshot.swift
@@ -1,0 +1,107 @@
+import Foundation
+import os
+
+private let ionLog = Logger(subsystem: "com.sprague.ion.mobile", category: "engine")
+
+// MARK: - Snapshot Handling
+
+extension SessionViewModel {
+
+    @MainActor
+    func handleSnapshot(snapshotTabs: [RemoteTabState], recentDirs: [String], groupMode: String?, groups: [RemoteTabGroup]?) {
+        if connectionState != .connected {
+            connectionState = .connected
+            cancelReconnectSafetyTimer()
+        }
+        connectionQuality.transportState = transport?.state ?? .disconnected
+        if !recentDirs.isEmpty {
+            recentDirectories = recentDirs
+        }
+        // Update tab group mode and groups from desktop
+        if let mode = groupMode {
+            tabGroupMode = mode
+        }
+        if let grps = groups {
+            tabGroups = grps
+        }
+        // Filter out tabs that iOS requested to close but hasn't received
+        // tab_closed confirmation for yet. Without this, the snapshot
+        // resurrects tabs that the user just swiped away.
+        let filteredTabs = snapshotTabs.filter { !pendingCloseTabIds.contains($0.id) }
+        // Preserve locally-injected permission queue entries that arrived
+        // via permission_request events. Snapshots pull the queue from the
+        // desktop renderer, which may have already auto-allowed tools like
+        // AskUserQuestion/ExitPlanMode (empty queue), while iOS still needs
+        // to show the card until the user taps an answer.
+        var merged = filteredTabs
+        for i in merged.indices {
+            let tabId = merged[i].id
+
+            // Strip ExitPlanMode/AskUserQuestion entries from the snapshot
+            // queue if the user already dismissed the card on this tab.
+            // The 5-second snapshot polling can re-inject stale entries
+            // from the desktop's permissionDenied before it's cleared.
+            if dismissedLiveSpecialTabs.contains(tabId) {
+                merged[i].permissionQueue.removeAll {
+                    $0.toolName == "ExitPlanMode" || $0.toolName == "AskUserQuestion"
+                }
+            }
+
+            if let existing = tabs.first(where: { $0.id == tabId }),
+               !existing.permissionQueue.isEmpty {
+                // Keep existing local queue entries that aren't in the snapshot
+                let snapshotIds = Set(merged[i].permissionQueue.map(\.questionId))
+                let isRunning = merged[i].status == .running
+                let localOnly = existing.permissionQueue.filter { entry in
+                    if snapshotIds.contains(entry.questionId) { return false }
+                    // Don't re-inject stale plan/question cards once a new task is running
+                    if isRunning && (entry.toolName == "ExitPlanMode" || entry.toolName == "AskUserQuestion") {
+                        return false
+                    }
+                    return true
+                }
+                merged[i].permissionQueue.append(contentsOf: localOnly)
+                // Prefer local entry when it has richer data (e.g. planContent from live event)
+                for local in existing.permissionQueue where snapshotIds.contains(local.questionId) {
+                    if local.toolInput?["planContent"]?.value as? String != nil,
+                       let idx = merged[i].permissionQueue.firstIndex(where: { $0.questionId == local.questionId }),
+                       merged[i].permissionQueue[idx].toolInput?["planContent"]?.value as? String == nil {
+                        merged[i].permissionQueue[idx] = local
+                    }
+                }
+            }
+        }
+        // Always prefer locally-tracked lastMessage over snapshot values.
+        // Real-time textChunk/messageAdded events update lastMessage on iOS
+        // faster than the 5-second snapshot poll, so the local value is
+        // always equal or fresher. The snapshot value is only used for
+        // initial population (when no local value exists yet).
+        for i in merged.indices {
+            if let existing = tabs.first(where: { $0.id == merged[i].id }),
+               existing.lastMessage != nil {
+                merged[i].lastMessage = existing.lastMessage
+            }
+        }
+        tabs = merged
+        tabIds = Set(merged.map(\.id))
+        // Populate terminal state from snapshot tab data
+        for tab in merged {
+            if tab.isTerminalOnly == true, let instances = tab.terminalInstances {
+                terminalInstances[tab.id] = instances
+                activeTerminalInstance[tab.id] = tab.activeTerminalInstanceId ?? instances.first?.id
+            }
+            // Populate engine instance state from snapshot tab data
+            if tab.isEngine == true, let instances = tab.engineInstances {
+                engineInstances[tab.id] = instances.map { EngineInstanceInfo(id: $0.id, label: $0.label) }
+                activeEngineInstance[tab.id] = tab.activeEngineInstanceId ?? instances.first?.id
+                ionLog.info("snapshot: engine tab \(tab.id.prefix(8)), instances=\(instances.map(\.id)), active=\(tab.activeEngineInstanceId ?? "nil")")
+                // Pre-load engine conversation history for all engine tabs
+                loadEngineConversation(tabId: tab.id)
+            }
+        }
+        // Re-send in-flight conversation loads that may have been dropped.
+        for tabId in loadingConversation {
+            send(.loadConversation(tabId: tabId, before: conversationCursor[tabId]))
+        }
+    }
+}

--- a/ios/IonRemote/ViewModels/SessionViewModel.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel.swift
@@ -219,6 +219,8 @@ final class SessionViewModel {
     var transport: TransportManager?
     var eventTask: Task<Void, Never>?
     var flushTask: Task<Void, Never>?
+    /// Safety timer: if `.reconnecting` lingers too long, force a full reconnect.
+    var reconnectSafetyTask: Task<Void, Never>?
     let eventBatcher = EventBatcher()
     /// Standalone browser for pairing discovery (before a transport exists).
     private(set) var pairingBrowser = BonjourBrowser()

--- a/ios/IonRemote/Views/ConnectionQualityView.swift
+++ b/ios/IonRemote/Views/ConnectionQualityView.swift
@@ -13,7 +13,7 @@ struct ConnectionQualityView: View {
     @State private var showPopover = false
 
     var body: some View {
-        if viewModel.connectionState == .connected {
+        if viewModel.connectionState == .connected || viewModel.connectionState == .reconnecting {
             content
         } else {
             EmptyView()

--- a/ios/commands/install.command
+++ b/ios/commands/install.command
@@ -129,12 +129,15 @@ fi
 
 # ── Choose build strategy ──
 
+# Always resolve the legacy UDID for the install step.  ios-deploy uses
+# usbmuxd which needs the 40-char hex UDID, not the CoreDevice UUID.
+detect_legacy_udid
+
 if $TUNNEL_OK; then
   # CoreDevice tunnel works — build targeting the specific device
   DESTINATION="id=$DEVICE_ID"
 else
   # Tunnel broken — build for generic iOS and install separately
-  detect_legacy_udid
   if [[ -z "$LEGACY_UDID" ]] && ! command -v ios-deploy &>/dev/null; then
     echo
     echo "✗ CoreDevice tunnel is unavailable and no fallback install tool found."

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -122,9 +122,19 @@ func (h *Hub) HandleWebSocket(w http.ResponseWriter, r *http.Request, channelID,
 		return
 	}
 
+	// Enable compression only for the desktop ("ion") role.  Apple's
+	// URLSessionWebSocketTask offers permessage-deflate in the handshake
+	// but its inflate implementation is broken for context-takeover mode,
+	// causing immediate "Protocol error" disconnects on every received
+	// frame.  Disabling compression for mobile avoids this.
+	compressionMode := websocket.CompressionDisabled
+	if role == "ion" {
+		compressionMode = websocket.CompressionContextTakeover
+	}
+
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true,
-		CompressionMode:    websocket.CompressionContextTakeover,
+		CompressionMode:    compressionMode,
 	})
 	if err != nil {
 		log.Printf("accept error: %v", err)


### PR DESCRIPTION
- **fix(ios): keep transport alive on peer disconnect**
- **fix(ios): resolve legacy udid before ios-deploy install**
- **fix(engine): prevent tool goroutines from wedging indefinitely**
- **fix(relay): disable websocket compression for mobile role**
