### PR TITLE
Multi-device pairing and other ios, relay features and fixes

### DIFF
--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		A1B2C3D4E5F60001001000AA /* LayoutCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001001AA /* LayoutCache.swift */; };
 		A1B2C3D4E5F60001001002AA /* PeerStatusPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001003AA /* PeerStatusPoller.swift */; };
 		A1B2C3D4E5F60001001004AA /* DesktopPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */; };
+		A1B2C3D4E5F60001001006AA /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001007AA /* DiagnosticLog.swift */; };
+		A1B2C3D4E5F60001001008AA /* DiagnosticLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001009AA /* DiagnosticLogView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -191,6 +193,8 @@
 		A1B2C3D4E5F60001001001AA /* LayoutCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutCache.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001001003AA /* PeerStatusPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerStatusPoller.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopPickerMenu.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001001007AA /* DiagnosticLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001001009AA /* DiagnosticLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLogView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -331,6 +335,7 @@
 				A1B2C3D4E5F60001000703AA /* ToolGroupView.swift */,
 				A1B2C3D4E5F60001000801AA /* ActivityIndicatorView.swift */,
 				A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */,
+					A1B2C3D4E5F60001001009AA /* DiagnosticLogView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -389,6 +394,7 @@
 				A1B2C3D4E5F600010000F7AA /* MarkdownFormatter.swift */,
 				A1B2C3D4E5F60001000705AA /* ToolGrouping.swift */,
 				A1B2C3D4E5F60001001001AA /* LayoutCache.swift */,
+				A1B2C3D4E5F60001001007AA /* DiagnosticLog.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -564,6 +570,8 @@
 				A1B2C3D4E5F60001001000AA /* LayoutCache.swift in Sources */,
 				A1B2C3D4E5F60001001002AA /* PeerStatusPoller.swift in Sources */,
 				A1B2C3D4E5F60001001004AA /* DesktopPickerMenu.swift in Sources */,
+				A1B2C3D4E5F60001001006AA /* DiagnosticLog.swift in Sources */,
+				A1B2C3D4E5F60001001008AA /* DiagnosticLogView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		A1B2C3D4E5F60001001004AA /* DesktopPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */; };
 		A1B2C3D4E5F60001001006AA /* DiagnosticLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001007AA /* DiagnosticLog.swift */; };
 		A1B2C3D4E5F60001001008AA /* DiagnosticLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001009AA /* DiagnosticLogView.swift */; };
+		A1B2C3D4E5F60001002000AA /* IonTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001002001AA /* IonTheme.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -195,6 +196,7 @@
 		A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopPickerMenu.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001001007AA /* DiagnosticLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLog.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001001009AA /* DiagnosticLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticLogView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001002001AA /* IonTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IonTheme.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -336,6 +338,7 @@
 				A1B2C3D4E5F60001000801AA /* ActivityIndicatorView.swift */,
 				A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */,
 					A1B2C3D4E5F60001001009AA /* DiagnosticLogView.swift */,
+					A1B2C3D4E5F60001002001AA /* IonTheme.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -572,6 +575,7 @@
 				A1B2C3D4E5F60001001004AA /* DesktopPickerMenu.swift in Sources */,
 				A1B2C3D4E5F60001001006AA /* DiagnosticLog.swift in Sources */,
 				A1B2C3D4E5F60001001008AA /* DiagnosticLogView.swift in Sources */,
+				A1B2C3D4E5F60001002000AA /* IonTheme.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		A1B2C3D4E5F60001000704AA /* ToolGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000705AA /* ToolGrouping.swift */; };
 		A1B2C3D4E5F60001000800AA /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000801AA /* ActivityIndicatorView.swift */; };
 		A1B2C3D4E5F60001000900AA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000901AA /* AppDelegate.swift */; };
+		A1B2C3D4E5F60001001000AA /* LayoutCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001001AA /* LayoutCache.swift */; };
+		A1B2C3D4E5F60001001002AA /* PeerStatusPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001003AA /* PeerStatusPoller.swift */; };
+		A1B2C3D4E5F60001001004AA /* DesktopPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -185,6 +188,9 @@
 		A1B2C3D4E5F60001000703AA /* ToolGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolGroupView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000705AA /* ToolGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolGrouping.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000801AA /* ActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001001001AA /* LayoutCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutCache.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001001003AA /* PeerStatusPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerStatusPoller.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopPickerMenu.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -277,6 +283,7 @@
 				A1B2C3D4E5F60001000223AA /* TransportManager+Receive.swift */,
 				A1B2C3D4E5F60001000012AA /* BonjourBrowser.swift */,
 				A1B2C3D4E5F600010000A1AA /* TerminalOutputRouter.swift */,
+				A1B2C3D4E5F60001001003AA /* PeerStatusPoller.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -323,6 +330,7 @@
 				A1B2C3D4E5F60001000701AA /* MessageBubble.swift */,
 				A1B2C3D4E5F60001000703AA /* ToolGroupView.swift */,
 				A1B2C3D4E5F60001000801AA /* ActivityIndicatorView.swift */,
+				A1B2C3D4E5F60001001005AA /* DesktopPickerMenu.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -380,6 +388,7 @@
 				A1B2C3D4E5F600010000D3AA /* AnsiParser.swift */,
 				A1B2C3D4E5F600010000F7AA /* MarkdownFormatter.swift */,
 				A1B2C3D4E5F60001000705AA /* ToolGrouping.swift */,
+				A1B2C3D4E5F60001001001AA /* LayoutCache.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -552,6 +561,9 @@
 				A1B2C3D4E5F60001000704AA /* ToolGrouping.swift in Sources */,
 				A1B2C3D4E5F60001000800AA /* ActivityIndicatorView.swift in Sources */,
 				A1B2C3D4E5F60001000900AA /* AppDelegate.swift in Sources */,
+				A1B2C3D4E5F60001001000AA /* LayoutCache.swift in Sources */,
+				A1B2C3D4E5F60001001002AA /* PeerStatusPoller.swift in Sources */,
+				A1B2C3D4E5F60001001004AA /* DesktopPickerMenu.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IonRemote/App/IonRemoteApp.swift
+++ b/ios/IonRemote/App/IonRemoteApp.swift
@@ -11,6 +11,7 @@ struct IonRemoteApp: App {
             ContentView()
                 .environment(viewModel)
                 .preferredColorScheme(.dark)
+                .tint(IonTheme.accent)
                 .onAppear {
                     appDelegate.sessionViewModel = viewModel
                 }
@@ -35,6 +36,8 @@ struct IonRemoteApp: App {
 
 struct ContentView: View {
     @Environment(SessionViewModel.self) private var viewModel
+    @State private var connectingElapsed: Int = 0
+    @State private var showTroubleshooting = false
 
     var body: some View {
         Group {
@@ -60,6 +63,9 @@ struct ContentView: View {
     private var disconnectedView: some View {
         VStack(spacing: 16) {
             Spacer()
+            Image(systemName: "bolt.shield.fill")
+                .font(.system(size: 50))
+                .foregroundStyle(IonTheme.accent)
             ProgressView()
                 .controlSize(.large)
             Text(viewModel.connectionState.label)
@@ -67,11 +73,45 @@ struct ContentView: View {
             Text("Waiting for Ion desktop...")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+            if viewModel.connectionState == .connecting && connectingElapsed > 0 {
+                Text("Attempting connection… \(connectingElapsed)s")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
             Button("Retry") {
                 viewModel.reconnect()
             }
             .buttonStyle(.borderedProminent)
+            .tint(IonTheme.accent)
             .padding(.top, 8)
+            if connectingElapsed > 10 {
+                DisclosureGroup("Troubleshooting", isExpanded: $showTroubleshooting) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Label("Make sure Ion desktop is running", systemImage: "desktopcomputer")
+                        Label("Check you're on the same network", systemImage: "wifi")
+                        Label("Try tapping Retry", systemImage: "arrow.clockwise")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                .font(.caption)
+                .padding(.horizontal, 32)
+                .tint(.secondary)
+            }
+            if connectingElapsed > 10, viewModel.pairedDevices.count > 1 {
+                let others = viewModel.pairedDevices.filter { $0.id != viewModel.activeDeviceId }
+                if let other = others.first {
+                    Button {
+                        viewModel.switchToDevice(id: other.id)
+                        connectingElapsed = 0
+                    } label: {
+                        Label("Try \(other.name)", systemImage: "arrow.right.arrow.left")
+                            .font(.caption)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(IonTheme.accent)
+                }
+            }
             Spacer()
             Button("Unpair and Start Over", role: .destructive) {
                 viewModel.resetAll()
@@ -91,12 +131,16 @@ struct ContentView: View {
                     viewModel.reconnect()
                 }
             case .connecting:
-                // Break out of a stuck handshake after 15 seconds and keep retrying.
+                connectingElapsed = 0
                 while !Task.isCancelled {
-                    try? await Task.sleep(for: .seconds(15))
+                    try? await Task.sleep(for: .seconds(1))
                     guard !Task.isCancelled,
                           viewModel.connectionState == .connecting else { return }
-                    viewModel.reconnect()
+                    connectingElapsed += 1
+                    if connectingElapsed >= 15 {
+                        viewModel.reconnect()
+                        connectingElapsed = 0
+                    }
                 }
             default:
                 break

--- a/ios/IonRemote/App/IonRemoteApp.swift
+++ b/ios/IonRemote/App/IonRemoteApp.swift
@@ -5,7 +5,6 @@ struct IonRemoteApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var viewModel = SessionViewModel()
     @Environment(\.scenePhase) private var scenePhase
-    @State private var didGoToBackground = false
 
     var body: some Scene {
         WindowGroup {
@@ -19,24 +18,13 @@ struct IonRemoteApp: App {
                     switch newPhase {
                     case .active:
                         guard !viewModel.pairedDevices.isEmpty else { break }
-                        if didGoToBackground {
-                            didGoToBackground = false
-                            // Returning from a true app switch (went through .background).
-                            // disconnect() already fired; only reconnect if a retry loop
-                            // hasn't already started a new attempt.
-                            if viewModel.connectionState == .disconnected {
-                                viewModel.reconnect()
-                            }
-                        } else {
-                            // Returning from screen lock (.inactive only, no .background).
-                            // Reconnect on any non-connected state to recover silent relay drops.
-                            if viewModel.connectionState != .connected {
-                                viewModel.reconnect()
-                            }
-                        }
+                        // Resume transport without wiping state.
+                        viewModel.resumeTransport()
                     case .background:
-                        didGoToBackground = true
-                        viewModel.disconnect()
+                        // Stop transport but preserve all state (tabs, messages,
+                        // navigation, typed input) so the user returns to the
+                        // same view when the app foregrounds.
+                        viewModel.suspendTransport()
                     default:
                         break
                     }
@@ -52,12 +40,13 @@ struct ContentView: View {
         Group {
             if viewModel.pairedDevices.isEmpty || viewModel.connectionState == .authFailed {
                 PairingView()
-            } else if viewModel.connectionState == .disconnected || viewModel.connectionState == .connecting {
+            } else if !viewModel.hasConnectedBefore && viewModel.tabs.isEmpty
+                        && viewModel.connectionState != .connected {
+                // First launch with no cached data — show the connecting screen.
                 disconnectedView
             } else {
-                // .connected and .reconnecting both show the tab list.
-                // During .reconnecting the transport stays alive and will
-                // auto-recover; the signal-quality bars give visual feedback.
+                // Show tab list whenever we have data (live or cached).
+                // A reconnecting banner handles transient disconnects.
                 TabListView()
             }
         }
@@ -103,8 +92,6 @@ struct ContentView: View {
                 }
             case .connecting:
                 // Break out of a stuck handshake after 15 seconds and keep retrying.
-                // Loop because reconnect() may batch .connecting→.disconnected→.connecting
-                // in a single SwiftUI update so .task(id:) wouldn't restart.
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .seconds(15))
                     guard !Task.isCancelled,

--- a/ios/IonRemote/Networking/LANClient.swift
+++ b/ios/IonRemote/Networking/LANClient.swift
@@ -69,6 +69,7 @@ final class LANClient {
         // callback from the old task sees a stale gen and bails out.
         connectionGen &+= 1
         let gen = connectionGen
+        DiagnosticLog.log("LAN-WS: connect gen=\(gen) \(host):\(port)")
 
         // Create a fresh stream for this connection.
         var continuation: AsyncStream<Data>.Continuation!
@@ -87,6 +88,7 @@ final class LANClient {
     }
 
     func disconnect() {
+        DiagnosticLog.log("LAN-WS: disconnect gen=\(connectionGen)")
         intentionallyClosed = true
         messageContinuation?.finish()
         task?.cancel(with: .normalClosure, reason: nil)
@@ -114,11 +116,17 @@ final class LANClient {
             // the old task's cancellation-failure fires handleDisconnect()
             // which finishes the NEW connection's continuation, killing the
             // listener stream ~100ms after auth.
-            guard gen == self.connectionGen else { return }
+            guard gen == self.connectionGen else {
+                DiagnosticLog.log("LAN-WS: stale recv gen=\(gen) cur=\(self.connectionGen)")
+                return
+            }
 
             switch result {
             case .success(let message):
-                if !self.isConnected { self.isConnected = true }
+                if !self.isConnected {
+                    self.isConnected = true
+                    DiagnosticLog.log("LAN-WS: first msg, isConnected=true gen=\(gen)")
+                }
                 switch message {
                 case .data(let data):
                     self.messageContinuation?.yield(data)
@@ -131,7 +139,8 @@ final class LANClient {
                 }
                 self.receiveLoop(wsTask, gen: gen)
 
-            case .failure:
+            case .failure(let error):
+                DiagnosticLog.log("LAN-WS: recv failure gen=\(gen) err=\(error.localizedDescription)")
                 self.handleDisconnect(gen: gen)
             }
         }
@@ -141,7 +150,11 @@ final class LANClient {
         // Only act if this disconnect belongs to the current connection.
         // A stale receiveLoop from a previous connect() must not touch
         // the new connection's state or continuation.
-        guard gen == connectionGen else { return }
+        guard gen == connectionGen else {
+            DiagnosticLog.log("LAN-WS: stale disconnect gen=\(gen) cur=\(connectionGen)")
+            return
+        }
+        DiagnosticLog.log("LAN-WS: handleDisconnect gen=\(gen)")
         isConnected = false
         task = nil
         session?.invalidateAndCancel()

--- a/ios/IonRemote/Networking/LANClient.swift
+++ b/ios/IonRemote/Networking/LANClient.swift
@@ -21,6 +21,12 @@ final class LANClient {
     private var session: URLSession?
     private var intentionallyClosed = false
 
+    /// Monotonically increasing connection generation. Each `connect()` call
+    /// bumps this so that stale `receiveLoop` callbacks from a previous
+    /// URLSessionWebSocketTask can detect they belong to a superseded
+    /// connection and avoid finishing the current continuation.
+    private var connectionGen: UInt64 = 0
+
     /// Continuation for the current connection's message stream.
     /// Replaced on each `connect()` so old iterators terminate cleanly.
     private var messageContinuation: AsyncStream<Data>.Continuation?
@@ -59,6 +65,11 @@ final class LANClient {
         session?.invalidateAndCancel()
         session = nil
 
+        // Bump generation BEFORE creating the new stream so any in-flight
+        // callback from the old task sees a stale gen and bails out.
+        connectionGen &+= 1
+        let gen = connectionGen
+
         // Create a fresh stream for this connection.
         var continuation: AsyncStream<Data>.Continuation!
         self.messages = AsyncStream { continuation = $0 }
@@ -72,7 +83,7 @@ final class LANClient {
         self.task = wsTask
 
         wsTask.resume()
-        receiveLoop(wsTask)
+        receiveLoop(wsTask, gen: gen)
     }
 
     func disconnect() {
@@ -94,9 +105,16 @@ final class LANClient {
 
     // MARK: - Receive loop
 
-    private func receiveLoop(_ wsTask: URLSessionWebSocketTask) {
+    private func receiveLoop(_ wsTask: URLSessionWebSocketTask, gen: UInt64) {
         wsTask.receive { [weak self] result in
             guard let self else { return }
+
+            // If connect() was called again, this callback belongs to a
+            // superseded connection — drop it silently. Without this guard
+            // the old task's cancellation-failure fires handleDisconnect()
+            // which finishes the NEW connection's continuation, killing the
+            // listener stream ~100ms after auth.
+            guard gen == self.connectionGen else { return }
 
             switch result {
             case .success(let message):
@@ -111,15 +129,19 @@ final class LANClient {
                 @unknown default:
                     break
                 }
-                self.receiveLoop(wsTask)
+                self.receiveLoop(wsTask, gen: gen)
 
             case .failure:
-                self.handleDisconnect()
+                self.handleDisconnect(gen: gen)
             }
         }
     }
 
-    private func handleDisconnect() {
+    private func handleDisconnect(gen: UInt64) {
+        // Only act if this disconnect belongs to the current connection.
+        // A stale receiveLoop from a previous connect() must not touch
+        // the new connection's state or continuation.
+        guard gen == connectionGen else { return }
         isConnected = false
         task = nil
         session?.invalidateAndCancel()

--- a/ios/IonRemote/Networking/PeerStatusPoller.swift
+++ b/ios/IonRemote/Networking/PeerStatusPoller.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Lightweight HTTP poller that checks whether the "ion" role is connected
+/// on a relay channel. Used by the desktop picker to show online/offline
+/// status for non-active paired devices without opening a WebSocket.
+enum PeerStatusPoller {
+
+    /// Check whether the desktop ("ion" role) is connected on a channel.
+    /// Returns `true` if connected, `false` if not, `nil` on error.
+    static func checkDesktopOnline(
+        relayURL: String,
+        apiKey: String,
+        channelId: String
+    ) async -> Bool? {
+        guard !relayURL.isEmpty,
+              let base = URL(string: relayURL) else { return nil }
+
+        // Build the status URL: {relayURL}/v1/channel/{channelId}/status
+        var components = URLComponents()
+        switch base.scheme {
+        case "wss": components.scheme = "https"
+        case "ws":  components.scheme = "http"
+        default:    components.scheme = base.scheme
+        }
+        components.host = base.host(percentEncoded: false)
+        components.port = base.port
+        let basePath = base.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components.path = basePath.isEmpty
+            ? "/v1/channel/\(channelId)/status"
+            : "/\(basePath)/v1/channel/\(channelId)/status"
+
+        guard let url = components.url else { return nil }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 5
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return nil
+            }
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Bool] else {
+                return nil
+            }
+            return json["ion"] ?? false
+        } catch {
+            return nil
+        }
+    }
+}

--- a/ios/IonRemote/Networking/TransportManager+Receive.swift
+++ b/ios/IonRemote/Networking/TransportManager+Receive.swift
@@ -54,6 +54,7 @@ extension TransportManager {
         lanListenTask?.cancel()
         lanListenTask = Task { [weak self] in
             guard let lan = self?.lan else { return }
+            DiagnosticLog.log("LAN-LISTEN: starting for-await, isConnected=\(lan.isConnected)")
             for await data in lan.messages {
                 guard !Task.isCancelled, let self else { break }
                 self.handleIncomingData(data, isRelay: false)
@@ -84,6 +85,7 @@ extension TransportManager {
                 guard let self else { break }
                 let connected = self.lan.isConnected
                 if connected != wasConnected {
+                    DiagnosticLog.log("LAN-STATE-OBS: \(wasConnected) -> \(connected)")
                     wasConnected = connected
                     if !connected {
                         self.updateState()

--- a/ios/IonRemote/Networking/TransportManager+Receive.swift
+++ b/ios/IonRemote/Networking/TransportManager+Receive.swift
@@ -61,6 +61,7 @@ extension TransportManager {
             // LAN stream ended naturally -- emit peerDisconnected if no relay fallback.
             // Skip if cancelled (transport.stop() was called): yielding peerDisconnected
             // here would call disconnect() and clobber a new connection being set up.
+            DiagnosticLog.log("LAN-LISTEN: stream ended cancelled=\(Task.isCancelled)")
             guard !Task.isCancelled else { return }
             guard let self else { return }
             // If the LAN client already reconnected (Bonjour observation called
@@ -102,11 +103,13 @@ extension TransportManager {
            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let type = json["type"] as? String, type.hasPrefix("relay:") {
             if type == "relay:peer-disconnected" {
+                DiagnosticLog.log("RELAY-CTRL: peer-disconnected")
                 // The relay told us the desktop disconnected. Start grace
                 // period with force=true because the relay WebSocket itself
                 // is still connected — the *peer* is gone.
                 startDisconnectGracePeriod(force: true)
             } else if type == "relay:peer-reconnected" {
+                DiagnosticLog.log("RELAY-CTRL: peer-reconnected")
                 cancelDisconnectGracePeriod()
                 // Peer is back — reset dedup so fresh seq=1 messages aren't dropped.
                 lastReceivedSeq = 0

--- a/ios/IonRemote/Networking/TransportManager+Receive.swift
+++ b/ios/IonRemote/Networking/TransportManager+Receive.swift
@@ -62,10 +62,16 @@ extension TransportManager {
             // Skip if cancelled (transport.stop() was called): yielding peerDisconnected
             // here would call disconnect() and clobber a new connection being set up.
             guard !Task.isCancelled else { return }
-            if let self, self.relay == nil || !(self.relay?.isConnected ?? false) {
+            guard let self else { return }
+            // If the LAN client already reconnected (Bonjour observation called
+            // startLANWithAuth which creates a new stream), don't emit
+            // peerDisconnected — the new connection is alive and a new listener
+            // task was started by that reconnection.
+            if self.lan.isConnected { return }
+            if self.relay == nil || !(self.relay?.isConnected ?? false) {
                 self.eventContinuation.yield(.peerDisconnected)
             }
-            self?.updateState()
+            self.updateState()
         }
     }
 

--- a/ios/IonRemote/Networking/TransportManager+Send.swift
+++ b/ios/IonRemote/Networking/TransportManager+Send.swift
@@ -35,6 +35,7 @@ extension TransportManager {
             group.addTask { [weak self] in
                 try? await Task.sleep(for: .seconds(8))
                 guard !Task.isCancelled else { return false }
+                DiagnosticLog.log("AUTH: timeout fired, disconnecting LAN")
                 self?.lan.disconnect()
                 return false
             }
@@ -45,17 +46,31 @@ extension TransportManager {
     }
 
     private func performLANAuthCore() async -> Bool {
-        // Wait for the first message (should be AuthChallenge).
+        // IMPORTANT: AsyncStream is single-consumer. We must use exactly ONE
+        // `for await` loop here so that `startLANListener` can later create
+        // the next (and only) iterator on the same stream. Nested `for await`
+        // loops on the same stream create multiple iterators which corrupts
+        // the stream state and causes the listener's iterator to terminate
+        // immediately.
+        var awaitingResult = false
+        DiagnosticLog.log("AUTH-CORE: entering for-await on lan.messages")
+
         for await data in lan.messages {
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let type = json["type"] as? String else { continue }
 
-            if type == "auth_challenge", let nonceB64 = json["nonce"] as? String {
+            if !awaitingResult {
+                // Phase 1: waiting for auth_challenge
+                guard type == "auth_challenge",
+                      let nonceB64 = json["nonce"] as? String else {
+                    DiagnosticLog.log("AUTH-CORE: unexpected type=\(type) in phase1, returning false")
+                    return false
+                }
+
                 DiagnosticLog.log("AUTH: challenge received")
                 guard let nonceData = Data(base64Encoded: nonceB64) else { return false }
                 let proof = E2ECrypto.createAuthProof(nonce: nonceData, sharedSecret: sharedKey)
 
-                // Send auth_response as a WireMessage with payload.
                 let authResponse: [String: Any] = [
                     "type": "auth_response",
                     "deviceId": deviceId ?? "",
@@ -68,30 +83,27 @@ extension TransportManager {
                         try? await lan.send(data: wireData)
                     }
                 }
-
-                // Wait for AuthResult.
-                for await resultData in lan.messages {
-                    guard let resultJson = try? JSONSerialization.jsonObject(with: resultData) as? [String: Any],
-                          let rType = resultJson["type"] as? String else { continue }
-
-                    if rType == "auth_result" {
-                        let ok = resultJson["success"] as? Bool == true
-                        DiagnosticLog.log("AUTH: result success=\(ok)")
-                        return ok
-                    }
-                    // Also check for WireMessage wrapping an auth_result
-                    if let payload = resultJson["payload"] as? String,
-                       let inner = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
-                       inner["type"] as? String == "auth_result" {
-                        let ok = inner["success"] as? Bool == true
-                        DiagnosticLog.log("AUTH: result(wire) success=\(ok)")
-                        return ok
-                    }
+                awaitingResult = true
+                DiagnosticLog.log("AUTH-CORE: sent response, awaiting result")
+            } else {
+                // Phase 2: waiting for auth_result
+                if type == "auth_result" {
+                    let ok = json["success"] as? Bool == true
+                    DiagnosticLog.log("AUTH: result success=\(ok)")
+                    return ok
                 }
-                return false
+                // Also check for WireMessage wrapping an auth_result
+                if let payload = json["payload"] as? String,
+                   let inner = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
+                   inner["type"] as? String == "auth_result" {
+                    let ok = inner["success"] as? Bool == true
+                    DiagnosticLog.log("AUTH: result(wire) success=\(ok)")
+                    return ok
+                }
+                DiagnosticLog.log("AUTH-CORE: unexpected type=\(type) in phase2")
             }
-            return false
         }
+        DiagnosticLog.log("AUTH-CORE: for-await ended (stream finished)")
         return false
     }
 

--- a/ios/IonRemote/Networking/TransportManager+Send.swift
+++ b/ios/IonRemote/Networking/TransportManager+Send.swift
@@ -51,6 +51,7 @@ extension TransportManager {
                   let type = json["type"] as? String else { continue }
 
             if type == "auth_challenge", let nonceB64 = json["nonce"] as? String {
+                DiagnosticLog.log("AUTH: challenge received")
                 guard let nonceData = Data(base64Encoded: nonceB64) else { return false }
                 let proof = E2ECrypto.createAuthProof(nonce: nonceData, sharedSecret: sharedKey)
 
@@ -74,13 +75,17 @@ extension TransportManager {
                           let rType = resultJson["type"] as? String else { continue }
 
                     if rType == "auth_result" {
-                        return resultJson["success"] as? Bool == true
+                        let ok = resultJson["success"] as? Bool == true
+                        DiagnosticLog.log("AUTH: result success=\(ok)")
+                        return ok
                     }
                     // Also check for WireMessage wrapping an auth_result
                     if let payload = resultJson["payload"] as? String,
                        let inner = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
                        inner["type"] as? String == "auth_result" {
-                        return inner["success"] as? Bool == true
+                        let ok = inner["success"] as? Bool == true
+                        DiagnosticLog.log("AUTH: result(wire) success=\(ok)")
+                        return ok
                     }
                 }
                 return false

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -173,6 +173,7 @@ final class TransportManager {
 
     /// Disconnect all transports and stop discovery.
     func stop() {
+        DiagnosticLog.log("TM: stop() called")
         isStopped = true
 
         relayListenTask?.cancel()

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -139,9 +139,11 @@ final class TransportManager {
     /// Connect to a LAN host with challenge-response auth handshake.
     /// Returns `true` if auth succeeded, `false` if rejected.
     func startLANWithAuth(host: String, port: UInt16) async -> Bool {
+        DiagnosticLog.log("LAN-AUTH: start \(host):\(port) devId=\(deviceId?.prefix(8) ?? "nil")")
         await lan.connect(host: host, port: port)
 
         let success = await performLANAuth()
+        DiagnosticLog.log("LAN-AUTH: result=\(success ? "OK" : "FAIL") \(host):\(port)")
         if success {
             // Record as current LAN host so Bonjour observation doesn't re-discover and clobber us.
             currentLANHost = DiscoveredHost(
@@ -200,6 +202,7 @@ final class TransportManager {
     func setState(_ newState: TransportState) {
         guard state != newState else { return }
         print("[Ion] TransportManager: \(state) -> \(newState)")
+        DiagnosticLog.log("TM-STATE: \(state) -> \(newState)")
         state = newState
     }
 
@@ -234,6 +237,7 @@ final class TransportManager {
     ///   doesn't mean the peer is reachable.
     func startDisconnectGracePeriod(force: Bool = false) {
         guard disconnectGraceTask == nil else { return }
+        DiagnosticLog.log("GRACE: start force=\(force)")
         eventContinuation.yield(.transportReconnecting)
         disconnectGraceTask = Task { [weak self] in
             try? await Task.sleep(for: Self.disconnectGracePeriod)
@@ -280,6 +284,7 @@ final class TransportManager {
 
                 // Detect LAN socket disconnect even if Bonjour hasn't noticed yet.
                 if self.currentLANHost != nil, !self.lan.isConnected {
+                    DiagnosticLog.log("BONJOUR: LAN socket lost, clearing host")
                     self.currentLANHost = nil
                     self.lanListenTask?.cancel()
                     self.lanListenTask = nil
@@ -287,6 +292,7 @@ final class TransportManager {
                 }
 
                 let needsConnect = self.currentLANHost == nil && !self.lan.isConnected
+                if needsConnect { DiagnosticLog.log("BONJOUR: needsConnect=true") }
 
                 // When disconnected with no hosts visible, restart the Bonjour
                 // browser once to force NWBrowser to re-discover services.
@@ -301,6 +307,7 @@ final class TransportManager {
                 if countChanged || needsConnect {
                     if let host = self.matchingLANHost(hosts),
                        !self.lan.isConnected {
+                        DiagnosticLog.log("BONJOUR: connecting to \(host.name) \(host.host):\(host.port)")
                         self.currentLANHost = host
                         let authed = await self.startLANWithAuth(host: host.host, port: host.port)
                         if authed {
@@ -335,7 +342,11 @@ final class TransportManager {
     private func matchingLANHost(_ hosts: [DiscoveredService]) -> DiscoveredService? {
         let ionHosts = hosts.filter { $0.kind == .ionDirect }
         if let name = deviceName {
-            return ionHosts.first { $0.name == name }
+            let match = ionHosts.first { $0.name == name }
+            if match == nil && !ionHosts.isEmpty {
+                DiagnosticLog.log("BONJOUR-MATCH: filter=\(name) no match in \(ionHosts.map(\.name))")
+            }
+            return match
         }
         // Fallback: no name filter (single desktop / legacy).
         return ionHosts.first

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -53,6 +53,10 @@ final class TransportManager {
 
     let sharedKey: SymmetricKey
     var deviceId: String?
+    /// Bonjour service name of the paired desktop (e.g. "MacBookPro").
+    /// Used to filter Bonjour discovery to the correct host when multiple
+    /// Ion instances are on the network.
+    var deviceName: String?
 
     // MARK: - Internals
 
@@ -284,14 +288,14 @@ final class TransportManager {
                 // browser once to force NWBrowser to re-discover services.
                 // NWBrowser can miss re-advertisements of a service with the
                 // same name after the old one disappears.
-                if needsConnect, hosts.first(where: { $0.kind == .ionDirect }) == nil, !didRestartBrowser {
+                if needsConnect, self.matchingLANHost(hosts) == nil, !didRestartBrowser {
                     didRestartBrowser = true
                     lastKnownCount = 0
                     await MainActor.run { self.bonjour.startBrowsing() }
                 }
 
                 if countChanged || needsConnect {
-                    if let host = hosts.first(where: { $0.kind == .ionDirect }),
+                    if let host = self.matchingLANHost(hosts),
                        !self.lan.isConnected {
                         self.currentLANHost = host
                         let authed = await self.startLANWithAuth(host: host.host, port: host.port)
@@ -318,6 +322,19 @@ final class TransportManager {
                 try? await Task.sleep(for: .milliseconds(500))
             }
         }
+    }
+
+    /// Find the Bonjour host that matches the active paired device.
+    /// When `deviceName` is set, only the host with a matching Bonjour service
+    /// name is returned. This prevents connecting to the wrong desktop when
+    /// multiple Ion instances are on the network.
+    private func matchingLANHost(_ hosts: [DiscoveredService]) -> DiscoveredService? {
+        let ionHosts = hosts.filter { $0.kind == .ionDirect }
+        if let name = deviceName {
+            return ionHosts.first { $0.name == name }
+        }
+        // Fallback: no name filter (single desktop / legacy).
+        return ionHosts.first
     }
 
     // MARK: - Network monitor

--- a/ios/IonRemote/Networking/TransportManager.swift
+++ b/ios/IonRemote/Networking/TransportManager.swift
@@ -157,6 +157,10 @@ final class TransportManager {
             startLANListener()
             startLANStateObservation()
             startNetworkMonitor()
+            // Start Bonjour browsing so the observation loop can auto-reconnect
+            // if this connection drops. In LAN-only mode (no relay), the browser
+            // wouldn't be started otherwise since start() is never called.
+            await MainActor.run { self.bonjour.startBrowsing() }
             startBonjourObservation()
             setState(.lanPreferred)
         } else {

--- a/ios/IonRemote/Utilities/DiagnosticLog.swift
+++ b/ios/IonRemote/Utilities/DiagnosticLog.swift
@@ -1,0 +1,62 @@
+import Foundation
+import os
+
+/// Thread-safe in-memory ring buffer for connection diagnostics.
+///
+/// Captures key lifecycle events (connect, auth, Bonjour, transport state
+/// changes) so they can be inspected on-device or shared via AirDrop
+/// without needing a USB cable or Xcode console.
+///
+/// Usage: `DiagnosticLog.log("connect: device=\(name)")`
+final class DiagnosticLog: Sendable {
+
+    static let shared = DiagnosticLog()
+
+    /// Maximum entries before oldest are dropped.
+    private static let maxEntries = 500
+
+    private let lock = OSAllocatedUnfairLock(initialState: [Entry]())
+    private let logger = Logger(subsystem: "com.sprague.ion.mobile", category: "diag")
+
+    struct Entry: Sendable {
+        let timestamp: Date
+        let message: String
+    }
+
+    // MARK: - Public API
+
+    /// Append a diagnostic message. Also echoes to os_log.
+    static func log(_ message: String) {
+        shared.append(message)
+    }
+
+    /// Return all current entries (oldest first).
+    static func entries() -> [Entry] {
+        shared.lock.withLock { $0 }
+    }
+
+    /// Clear all entries.
+    static func clear() {
+        shared.lock.withLock { $0.removeAll() }
+    }
+
+    /// Format all entries as a shareable plain-text string.
+    static func exportText() -> String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "HH:mm:ss.SSS"
+        return entries().map { "\(fmt.string(from: $0.timestamp)) \($0.message)" }
+            .joined(separator: "\n")
+    }
+
+    // MARK: - Internal
+
+    private func append(_ message: String) {
+        logger.info("\(message, privacy: .public)")
+        lock.withLock { state in
+            state.append(Entry(timestamp: Date(), message: message))
+            if state.count > Self.maxEntries {
+                state.removeFirst(state.count - Self.maxEntries)
+            }
+        }
+    }
+}

--- a/ios/IonRemote/Utilities/LayoutCache.swift
+++ b/ios/IonRemote/Utilities/LayoutCache.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Cached tab/group layout for a paired desktop, persisted to disk.
+/// Restored on app launch or device switch so the user sees the last-known
+/// layout immediately while the real snapshot loads from the desktop.
+struct CachedLayout: Codable {
+    let deviceId: String
+    let tabs: [RemoteTabState]
+    let tabGroupMode: String
+    let tabGroups: [RemoteTabGroup]
+    let recentDirectories: [String]
+    let cachedAt: Date
+}
+
+/// Disk-backed layout cache keyed by paired device ID.
+enum LayoutCache {
+
+    private static var cacheDirectory: URL {
+        let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("layout-cache", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func fileURL(for deviceId: String) -> URL {
+        cacheDirectory.appendingPathComponent("\(deviceId).json")
+    }
+
+    /// Save the current layout for a device.
+    static func save(
+        deviceId: String,
+        tabs: [RemoteTabState],
+        tabGroupMode: String,
+        tabGroups: [RemoteTabGroup],
+        recentDirectories: [String]
+    ) {
+        let layout = CachedLayout(
+            deviceId: deviceId,
+            tabs: tabs,
+            tabGroupMode: tabGroupMode,
+            tabGroups: tabGroups,
+            recentDirectories: recentDirectories,
+            cachedAt: Date()
+        )
+        do {
+            let data = try JSONEncoder().encode(layout)
+            try data.write(to: fileURL(for: deviceId), options: .atomic)
+        } catch {
+            print("[Ion] LayoutCache.save failed: \(error)")
+        }
+    }
+
+    /// Load the cached layout for a device. Returns nil if no cache exists.
+    static func load(deviceId: String) -> CachedLayout? {
+        let url = fileURL(for: deviceId)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(CachedLayout.self, from: data)
+    }
+
+    /// Delete the cached layout for a device.
+    static func delete(deviceId: String) {
+        try? FileManager.default.removeItem(at: fileURL(for: deviceId))
+    }
+
+    /// Delete all cached layouts.
+    static func deleteAll() {
+        try? FileManager.default.removeItem(at: cacheDirectory)
+    }
+}

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -67,6 +67,7 @@ extension SessionViewModel {
             handleRelayConfig(relayUrl: relayUrl, relayApiKey: relayApiKey)
 
         case .transportReconnecting:
+            DiagnosticLog.log("EVENT: transportReconnecting was=\(connectionState)")
             if connectionState == .connected {
                 connectionState = .reconnecting
             }
@@ -77,6 +78,7 @@ extension SessionViewModel {
             connectionQuality.recordHeartbeat(senderTs: senderTs, buffered: buffered)
 
         case .peerDisconnected:
+            DiagnosticLog.log("EVENT: peerDisconnected was=\(connectionState)")
             // Don't tear down the transport — the relay auto-reconnects and
             // startRelayStateObservation re-sends sync when the peer returns.
             if connectionState == .connected || connectionState == .connecting {
@@ -317,6 +319,7 @@ extension SessionViewModel {
         // A legitimate relay upgrade must provide both values.
         if let device = activeDevice, device.relayAPIKey == "lan-direct" {
             guard !relayUrl.isEmpty, !relayApiKey.isEmpty else {
+                DiagnosticLog.log("RELAY-CFG: rejected empty for lan-direct \(device.name)")
                 print("[Ion] handleRelayConfig: ignoring incomplete relay config for LAN-direct device \(device.name)")
                 return
             }
@@ -330,6 +333,7 @@ extension SessionViewModel {
             pairedDevices[idx].relayURL = relayUrl
             pairedDevices[idx].relayAPIKey = relayApiKey
             savePairedDevices()
+            DiagnosticLog.log("RELAY-CFG: accepted for \(device.id.prefix(8))")
         }
     }
 

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -310,6 +310,19 @@ extension SessionViewModel {
     @MainActor
     private func handleRelayConfig(relayUrl: String, relayApiKey: String) {
         // Desktop pushed updated relay config -- persist it for roaming.
+        // Guard: if the active device is a LAN-only pairing (apiKey "lan-direct")
+        // and the incoming config doesn't provide BOTH a relay URL and API key,
+        // keep the LAN-direct sentinel intact. Without this, a desktop with no
+        // relay would overwrite the "lan-direct" marker, breaking reconnects.
+        // A legitimate relay upgrade must provide both values.
+        if let device = activeDevice, device.relayAPIKey == "lan-direct" {
+            guard !relayUrl.isEmpty, !relayApiKey.isEmpty else {
+                print("[Ion] handleRelayConfig: ignoring incomplete relay config for LAN-direct device \(device.name)")
+                return
+            }
+            // Legitimate upgrade from LAN-direct to relay — fall through.
+        }
+
         self.relayURL = relayUrl
         self.relayAPIKey = relayApiKey
         if let device = activeDevice,

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -20,16 +20,15 @@ extension SessionViewModel {
                 await self.eventBatcher.enqueue(event)
             }
 
-            // Stream ended naturally -- flush remaining events and wipe state.
-            // Skip if cancelled (disconnect/reconnect): connect() may have already
-            // advanced connectionState to .connecting and we must not clobber it.
+            // Stream ended naturally -- flush remaining events.
+            // Don't wipe state here: softReconnect keeps state alive.
+            // Only wipe if cancelled explicitly via disconnect().
             guard !Task.isCancelled else { return }
             let remaining = await self.eventBatcher.drain()
-            await MainActor.run {
-                for event in remaining {
-                    self.handleEvent(event)
+            if !remaining.isEmpty {
+                await MainActor.run {
+                    for event in remaining { self.handleEvent(event) }
                 }
-                self.wipeTransientState()
             }
         }
 
@@ -290,13 +289,22 @@ extension SessionViewModel {
 
     @MainActor
     private func handleUnpair() {
-        // Desktop revoked our pairing -- clear everything and return to discovery.
-        // Clear pairedDevices BEFORE disconnect so SwiftUI doesn't briefly show
-        // the disconnected view (which auto-triggers reconnect while devices exist).
-        pairedDevices = []
-        try? KeychainStore.deleteAll()
-        pairingState = .idle
-        disconnect()
+        // Desktop revoked our pairing -- remove only the active device.
+        if let device = activeDevice {
+            pairedDevices.removeAll { $0.id == device.id }
+            LayoutCache.delete(deviceId: device.id)
+        }
+        savePairedDevices()
+        if pairedDevices.isEmpty {
+            try? KeychainStore.deleteAll()
+            activeDeviceId = nil
+            pairingState = .idle
+            disconnect()
+        } else {
+            // Switch to the next available device.
+            let nextId = pairedDevices.first!.id
+            switchToDevice(id: nextId)
+        }
     }
 
     @MainActor
@@ -304,9 +312,10 @@ extension SessionViewModel {
         // Desktop pushed updated relay config -- persist it for roaming.
         self.relayURL = relayUrl
         self.relayAPIKey = relayApiKey
-        if !pairedDevices.isEmpty {
-            pairedDevices[0].relayURL = relayUrl
-            pairedDevices[0].relayAPIKey = relayApiKey
+        if let device = activeDevice,
+           let idx = pairedDevices.firstIndex(where: { $0.id == device.id }) {
+            pairedDevices[idx].relayURL = relayUrl
+            pairedDevices[idx].relayAPIKey = relayApiKey
             savePairedDevices()
         }
     }

--- a/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
@@ -15,6 +15,7 @@ extension SessionViewModel {
 
         guard let device = activeDevice else {
             ionLog.warning("connect: no paired devices")
+            DiagnosticLog.log("CONNECT: no paired devices")
             return
         }
 
@@ -29,6 +30,7 @@ extension SessionViewModel {
            let host = url.host(percentEncoded: false),
            let port = url.port {
             ionLog.info("connect: device=\(device.name) via LAN-only (\(host):\(port))")
+            DiagnosticLog.log("CONNECT: LAN-direct \(device.name) \(host):\(port) id=\(device.id.prefix(8))")
             restoreCachedLayout(for: device.id)
             connectLAN(host: host, port: UInt16(port))
             return
@@ -38,6 +40,7 @@ extension SessionViewModel {
         let channelId = E2ECrypto.deriveChannelId(sharedSecret: sharedKey)
 
         ionLog.info("connect: device=\(device.name) relayURL=\(effectiveRelayURL) channelId=\(channelId.prefix(8))...")
+        DiagnosticLog.log("CONNECT: relay \(device.name) url=\(effectiveRelayURL) ch=\(channelId.prefix(8))")
 
         guard !effectiveRelayURL.isEmpty,
               let url = URL(string: effectiveRelayURL) else {
@@ -72,6 +75,7 @@ extension SessionViewModel {
         guard let device = activeDevice else { return }
 
         ionLog.info("connectLAN: device=\(device.name) host=\(host):\(port)")
+        DiagnosticLog.log("LAN-CONNECT: \(device.name) \(host):\(port) id=\(device.id.prefix(8))")
 
         let sharedKey = SymmetricKey(data: device.sharedSecret)
         let tm = TransportManager(sharedKey: sharedKey, deviceId: device.id)
@@ -83,12 +87,14 @@ extension SessionViewModel {
             let authed = await tm.startLANWithAuth(host: host, port: port)
             if authed {
                 ionLog.info("connectLAN: auth succeeded for \(device.name)")
+                DiagnosticLog.log("LAN-CONNECT: auth OK \(device.name)")
                 await MainActor.run {
                     self.connectionState = .connected
                     self.send(.sync)
                 }
             } else {
                 ionLog.error("connectLAN: auth FAILED for \(device.name)")
+                DiagnosticLog.log("LAN-CONNECT: auth FAILED \(device.name)")
                 await MainActor.run {
                     self.connectionState = .authFailed
                     self.transport?.stop()
@@ -111,6 +117,7 @@ extension SessionViewModel {
         let effectiveAPIKey = device.relayAPIKey ?? relayAPIKey
 
         ionLog.info("softReconnect: device=\(device.name) apiKey=\(effectiveAPIKey) relayURL=\(effectiveRelayURL)")
+        DiagnosticLog.log("SOFT-RECONN: \(device.name) key=\(effectiveAPIKey.prefix(8)) url=\(effectiveRelayURL)")
 
         // LAN-only device: reconnect directly without a relay.
         if effectiveAPIKey == "lan-direct",
@@ -130,6 +137,7 @@ extension SessionViewModel {
               let url = URL(string: effectiveRelayURL) else { return }
 
         connectionState = .reconnecting
+        DiagnosticLog.log("SOFT-RECONN: relay path \(effectiveRelayURL)")
 
         let tm = TransportManager(
             relayURL: url,
@@ -157,6 +165,7 @@ extension SessionViewModel {
 
     /// Stop the transport without wiping state. Called when the app backgrounds.
     func suspendTransport() {
+        DiagnosticLog.log("SUSPEND: tearing down transport")
         tearDownTransport()
         // Keep connectionState as-is (not .disconnected) so the view
         // hierarchy stays intact and doesn't flash the pairing screen.
@@ -165,6 +174,7 @@ extension SessionViewModel {
     /// Rebuild the transport after suspend. Called when the app foregrounds.
     func resumeTransport() {
         guard !pairedDevices.isEmpty else { return }
+        DiagnosticLog.log("RESUME: transport=\(transport == nil ? "nil" : "exists")")
         if transport == nil {
             softReconnect()
         }
@@ -176,6 +186,7 @@ extension SessionViewModel {
     func switchToDevice(id: String) {
         guard id != activeDevice?.id else { return }
         ionLog.info("switchToDevice: \(id)")
+        DiagnosticLog.log("SWITCH: \(activeDevice?.id.prefix(8) ?? "nil") → \(id.prefix(8))")
         disconnect()
         activeDeviceId = id
         restoreCachedLayout(for: id)
@@ -205,6 +216,7 @@ extension SessionViewModel {
 
     /// Disconnect from the current transport and wipe all transient state.
     func disconnect() {
+        DiagnosticLog.log("DISCONNECT: tearing down")
         reconnectSafetyTask?.cancel()
         reconnectSafetyTask = nil
         tearDownTransport()

--- a/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
@@ -5,36 +5,46 @@ import CryptoKit
 
 extension SessionViewModel {
 
-    /// Connect to the first paired device using its relay configuration.
+    /// Connect to the active paired device using its relay configuration.
+    /// Falls back to LAN-only mode when no real relay is configured.
     func connect() {
-        // Tear down any existing transport before creating a new one.
-        // This prevents stale reconnect timers from fighting the new connection.
-        if transport != nil {
-            eventTask?.cancel()
-            eventTask = nil
-            flushTask?.cancel()
-            flushTask = nil
-            transport?.stop()
-            transport = nil
-        }
+        tearDownTransport()
 
-        guard let device = pairedDevices.first else {
+        guard let device = activeDevice else {
             print("[Ion] connect: no paired devices")
             return
         }
-        let sharedKey = SymmetricKey(data: device.sharedSecret)
-        let channelId = E2ECrypto.deriveChannelId(sharedSecret: sharedKey)
 
         let effectiveRelayURL = device.relayURL ?? relayURL
         let effectiveAPIKey = device.relayAPIKey ?? relayAPIKey
 
-        print("[Ion] connect: relayURL=\(effectiveRelayURL) apiKey=\(effectiveAPIKey.prefix(8))... channelId=\(channelId.prefix(8))...")
+        // When the device was paired over LAN without a relay, the stored
+        // relay URL is actually the LAN address (ws://host:port) with
+        // apiKey "lan-direct". Use LAN-only mode in that case.
+        if effectiveAPIKey == "lan-direct",
+           let url = URL(string: effectiveRelayURL),
+           let host = url.host(percentEncoded: false),
+           let port = url.port {
+            print("[Ion] connect: device=\(device.name) via LAN-only (\(host):\(port))")
+            restoreCachedLayout(for: device.id)
+            connectLAN(host: host, port: UInt16(port))
+            return
+        }
+
+        let sharedKey = SymmetricKey(data: device.sharedSecret)
+        let channelId = E2ECrypto.deriveChannelId(sharedSecret: sharedKey)
+
+        print("[Ion] connect: device=\(device.name) relayURL=\(effectiveRelayURL) channelId=\(channelId.prefix(8))...")
 
         guard !effectiveRelayURL.isEmpty,
               let url = URL(string: effectiveRelayURL) else {
             print("[Ion] connect: invalid or empty relay URL, aborting")
             return
         }
+
+        // Restore cached layout before transport connects so the UI
+        // shows the last-known tab/group layout immediately.
+        restoreCachedLayout(for: device.id)
 
         let tm = TransportManager(
             relayURL: url,
@@ -43,32 +53,24 @@ extension SessionViewModel {
             sharedKey: sharedKey,
             apnsToken: apnsToken
         )
+        tm.deviceId = device.id
+        tm.deviceName = device.name
         self.transport = tm
         connectionState = .connecting
 
-        Task {
-            await tm.start()
-        }
+        Task { await tm.start() }
         startListening()
     }
 
     /// Connect directly to an Ion LAN server (no relay).
-    /// Uses TransportManager with LAN auth handshake.
     func connectLAN(host: String, port: UInt16) {
-        // Tear down any existing transport before creating a new one.
-        if transport != nil {
-            eventTask?.cancel()
-            eventTask = nil
-            flushTask?.cancel()
-            flushTask = nil
-            transport?.stop()
-            transport = nil
-        }
+        tearDownTransport()
 
-        guard let device = pairedDevices.first else { return }
+        guard let device = activeDevice else { return }
 
         let sharedKey = SymmetricKey(data: device.sharedSecret)
         let tm = TransportManager(sharedKey: sharedKey, deviceId: device.id)
+        tm.deviceName = device.name
         self.transport = tm
         connectionState = .connecting
 
@@ -90,28 +92,128 @@ extension SessionViewModel {
         startListening()
     }
 
-    /// Reconnect using relay with automatic LAN upgrade via Bonjour.
-    /// Tears down the old transport first to prevent stale reconnect
-    /// timers from fighting the new connection on the same relay channel.
+    // MARK: - Reconnect Strategies
+
+    /// Soft reconnect: tears down and rebuilds the transport without wiping
+    /// transient state. Used for transient disconnects and app resume.
+    func softReconnect() {
+        tearDownTransport()
+        guard let device = activeDevice else { return }
+
+        let effectiveRelayURL = device.relayURL ?? relayURL
+        let effectiveAPIKey = device.relayAPIKey ?? relayAPIKey
+
+        // LAN-only device: reconnect directly without a relay.
+        if effectiveAPIKey == "lan-direct",
+           let url = URL(string: effectiveRelayURL),
+           let host = url.host(percentEncoded: false),
+           let port = url.port {
+            connectionState = .reconnecting
+            connectLAN(host: host, port: UInt16(port))
+            startReconnectSafetyTimer()
+            return
+        }
+
+        let sharedKey = SymmetricKey(data: device.sharedSecret)
+        let channelId = E2ECrypto.deriveChannelId(sharedSecret: sharedKey)
+
+        guard !effectiveRelayURL.isEmpty,
+              let url = URL(string: effectiveRelayURL) else { return }
+
+        connectionState = .reconnecting
+
+        let tm = TransportManager(
+            relayURL: url,
+            apiKey: effectiveAPIKey,
+            channelId: channelId,
+            sharedKey: sharedKey,
+            apnsToken: apnsToken
+        )
+        tm.deviceId = device.id
+        tm.deviceName = device.name
+        self.transport = tm
+        Task { await tm.start() }
+        startListening()
+        startReconnectSafetyTimer()
+    }
+
+    /// Hard reconnect: full disconnect + state wipe + reconnect.
+    /// Used only for explicit user actions (switch desktop, unpair).
     func reconnect() {
         disconnect()
         connect()
     }
 
+    // MARK: - Suspend/Resume (background/foreground)
+
+    /// Stop the transport without wiping state. Called when the app backgrounds.
+    func suspendTransport() {
+        tearDownTransport()
+        // Keep connectionState as-is (not .disconnected) so the view
+        // hierarchy stays intact and doesn't flash the pairing screen.
+    }
+
+    /// Rebuild the transport after suspend. Called when the app foregrounds.
+    func resumeTransport() {
+        guard !pairedDevices.isEmpty else { return }
+        if transport == nil {
+            softReconnect()
+        }
+    }
+
+    // MARK: - Multi-Desktop Switching
+
+    /// Switch to a different paired desktop.
+    func switchToDevice(id: String) {
+        guard id != activeDevice?.id else { return }
+        disconnect()
+        activeDeviceId = id
+        restoreCachedLayout(for: id)
+        connect()
+    }
+
+    /// Connect with fallback: try the active device, then fall back to others.
+    func connectWithFallback() {
+        guard !pairedDevices.isEmpty else { return }
+        restoreCachedLayout(for: activeDevice?.id)
+        connect()
+        // If the connection doesn't succeed within 10s, try the next device.
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(10))
+            guard let self, self.connectionState != .connected else { return }
+            // Try other devices in order
+            let activeId = self.activeDevice?.id
+            for device in self.pairedDevices where device.id != activeId {
+                self.switchToDevice(id: device.id)
+                try? await Task.sleep(for: .seconds(10))
+                if self.connectionState == .connected { return }
+            }
+        }
+    }
+
+    // MARK: - Disconnect
+
     /// Disconnect from the current transport and wipe all transient state.
     func disconnect() {
         reconnectSafetyTask?.cancel()
         reconnectSafetyTask = nil
+        tearDownTransport()
+        wipeTransientState()
+    }
+
+    /// Tear down transport and event tasks without wiping state.
+    private func tearDownTransport() {
         eventTask?.cancel()
         eventTask = nil
         flushTask?.cancel()
         flushTask = nil
         transport?.stop()
         transport = nil
-        wipeTransientState()
     }
 
-    /// Start a safety timer that forces a full reconnect if the app stays
+    // MARK: - Reconnect Safety Timer
+
+    /// Start a safety timer that forces a soft reconnect if the app stays
     /// in `.reconnecting` for too long (e.g. the relay can't reach the peer).
     func startReconnectSafetyTimer() {
         reconnectSafetyTask?.cancel()
@@ -119,7 +221,7 @@ extension SessionViewModel {
             try? await Task.sleep(for: .seconds(30))
             guard !Task.isCancelled, let self else { return }
             if self.connectionState == .reconnecting {
-                self.reconnect()
+                self.softReconnect()
             }
         }
     }
@@ -129,6 +231,8 @@ extension SessionViewModel {
         reconnectSafetyTask?.cancel()
         reconnectSafetyTask = nil
     }
+
+    // MARK: - State Wipe
 
     /// Clear all transient state (tabs, messages, etc.) to prevent stale data.
     func wipeTransientState() {
@@ -169,29 +273,52 @@ extension SessionViewModel {
         connectionQuality.transportState = .disconnected
     }
 
+    // MARK: - Layout Cache
+
+    /// Restore cached layout for a device so the UI shows last-known state.
+    func restoreCachedLayout(for deviceId: String?) {
+        guard let deviceId, let cached = LayoutCache.load(deviceId: deviceId) else { return }
+        tabs = cached.tabs
+        tabIds = Set(cached.tabs.map(\.id))
+        tabGroupMode = cached.tabGroupMode
+        tabGroups = cached.tabGroups
+        if !cached.recentDirectories.isEmpty {
+            recentDirectories = cached.recentDirectories
+        }
+    }
+
     // MARK: - Device Management
 
     func unpairDevice(_ device: PairedDevice) {
-        // Notify desktop before disconnecting so it removes the device.
-        Task {
-            try? await transport?.send(.unpair)
-            await MainActor.run {
-                self.pairedDevices.removeAll { $0.id == device.id }
-                self.savePairedDevices()
-                if self.pairedDevices.isEmpty {
-                    self.disconnect()
-                }
-            }
+        let isActive = device.id == activeDevice?.id
+        // Only send unpair to the desktop if this device is the active connection.
+        if isActive {
+            Task { try? await transport?.send(.unpair) }
+        }
+        pairedDevices.removeAll { $0.id == device.id }
+        savePairedDevices()
+        LayoutCache.delete(deviceId: device.id)
+        deviceOnlineStatus.removeValue(forKey: device.id)
+
+        if pairedDevices.isEmpty {
+            activeDeviceId = nil
+            disconnect()
+        } else if isActive {
+            // Auto-switch to the next device.
+            let nextId = pairedDevices.first!.id
+            switchToDevice(id: nextId)
         }
     }
 
     func resetAll() {
-        // Notify desktop before disconnecting so it removes the device.
         Task {
             try? await transport?.send(.unpair)
             await MainActor.run {
                 self.disconnect()
                 self.pairedDevices = []
+                self.activeDeviceId = nil
+                self.hasConnectedBefore = false
+                UserDefaults.standard.set(false, forKey: "hasConnectedBefore")
                 self.liveText = [:]
                 self.messages = [:]
                 self.loadingConversation = []
@@ -202,15 +329,18 @@ extension SessionViewModel {
                 self.relayURL = ""
                 self.relayAPIKey = ""
                 self.pairingState = .idle
+                self.deviceOnlineStatus = [:]
                 try? KeychainStore.deleteAll()
+                LayoutCache.deleteAll()
             }
         }
     }
 
     func saveRelayConfig() {
-        guard !pairedDevices.isEmpty else { return }
-        pairedDevices[0].relayURL = relayURL
-        pairedDevices[0].relayAPIKey = relayAPIKey
+        guard let device = activeDevice,
+              let idx = pairedDevices.firstIndex(where: { $0.id == device.id }) else { return }
+        pairedDevices[idx].relayURL = relayURL
+        pairedDevices[idx].relayAPIKey = relayAPIKey
         savePairedDevices()
     }
 

--- a/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Lifecycle.swift
@@ -1,5 +1,8 @@
 import Foundation
 import CryptoKit
+import os
+
+private let ionLog = Logger(subsystem: "com.sprague.ion.mobile", category: "lifecycle")
 
 // MARK: - Lifecycle
 
@@ -11,7 +14,7 @@ extension SessionViewModel {
         tearDownTransport()
 
         guard let device = activeDevice else {
-            print("[Ion] connect: no paired devices")
+            ionLog.warning("connect: no paired devices")
             return
         }
 
@@ -25,7 +28,7 @@ extension SessionViewModel {
            let url = URL(string: effectiveRelayURL),
            let host = url.host(percentEncoded: false),
            let port = url.port {
-            print("[Ion] connect: device=\(device.name) via LAN-only (\(host):\(port))")
+            ionLog.info("connect: device=\(device.name) via LAN-only (\(host):\(port))")
             restoreCachedLayout(for: device.id)
             connectLAN(host: host, port: UInt16(port))
             return
@@ -34,11 +37,11 @@ extension SessionViewModel {
         let sharedKey = SymmetricKey(data: device.sharedSecret)
         let channelId = E2ECrypto.deriveChannelId(sharedSecret: sharedKey)
 
-        print("[Ion] connect: device=\(device.name) relayURL=\(effectiveRelayURL) channelId=\(channelId.prefix(8))...")
+        ionLog.info("connect: device=\(device.name) relayURL=\(effectiveRelayURL) channelId=\(channelId.prefix(8))...")
 
         guard !effectiveRelayURL.isEmpty,
               let url = URL(string: effectiveRelayURL) else {
-            print("[Ion] connect: invalid or empty relay URL, aborting")
+            ionLog.error("connect: invalid or empty relay URL for device=\(device.name) apiKey=\(effectiveAPIKey), aborting")
             return
         }
 
@@ -68,6 +71,8 @@ extension SessionViewModel {
 
         guard let device = activeDevice else { return }
 
+        ionLog.info("connectLAN: device=\(device.name) host=\(host):\(port)")
+
         let sharedKey = SymmetricKey(data: device.sharedSecret)
         let tm = TransportManager(sharedKey: sharedKey, deviceId: device.id)
         tm.deviceName = device.name
@@ -77,11 +82,13 @@ extension SessionViewModel {
         Task {
             let authed = await tm.startLANWithAuth(host: host, port: port)
             if authed {
+                ionLog.info("connectLAN: auth succeeded for \(device.name)")
                 await MainActor.run {
                     self.connectionState = .connected
                     self.send(.sync)
                 }
             } else {
+                ionLog.error("connectLAN: auth FAILED for \(device.name)")
                 await MainActor.run {
                     self.connectionState = .authFailed
                     self.transport?.stop()
@@ -102,6 +109,8 @@ extension SessionViewModel {
 
         let effectiveRelayURL = device.relayURL ?? relayURL
         let effectiveAPIKey = device.relayAPIKey ?? relayAPIKey
+
+        ionLog.info("softReconnect: device=\(device.name) apiKey=\(effectiveAPIKey) relayURL=\(effectiveRelayURL)")
 
         // LAN-only device: reconnect directly without a relay.
         if effectiveAPIKey == "lan-direct",
@@ -166,6 +175,7 @@ extension SessionViewModel {
     /// Switch to a different paired desktop.
     func switchToDevice(id: String) {
         guard id != activeDevice?.id else { return }
+        ionLog.info("switchToDevice: \(id)")
         disconnect()
         activeDeviceId = id
         restoreCachedLayout(for: id)

--- a/ios/IonRemote/ViewModels/SessionViewModel+Pairing.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Pairing.swift
@@ -29,9 +29,10 @@ extension SessionViewModel {
         self.relayURL = relayURL
         self.relayAPIKey = relayAPIKey
 
-        if !pairedDevices.isEmpty {
-            pairedDevices[0].relayURL = relayURL
-            pairedDevices[0].relayAPIKey = relayAPIKey
+        if let device = activeDevice,
+           let idx = pairedDevices.firstIndex(where: { $0.id == device.id }) {
+            pairedDevices[idx].relayURL = relayURL
+            pairedDevices[idx].relayAPIKey = relayAPIKey
             savePairedDevices()
         }
 
@@ -114,10 +115,11 @@ extension SessionViewModel {
                 session.invalidateAndCancel()
 
                 await MainActor.run {
-                    self.pairedDevices = [device]
+                    self.addOrUpdateDevice(device)
                     self.relayURL = relayUrl
                     self.relayAPIKey = relayApiKey
                     self.savePairedDevices()
+                    self.activeDeviceId = device.id
                     self.pairingState = .paired
                     self.connectLAN(host: host, port: port)
                 }
@@ -174,7 +176,6 @@ extension SessionViewModel {
             guard let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any],
                   let peerPublicKeyB64 = json["publicKey"] as? String,
                   let peerPublicKeyData = Data(base64Encoded: peerPublicKeyB64) else {
-                // Desktop rejected recovery (pair_error response) -- not a known device.
                 ws.cancel(with: .normalClosure, reason: nil)
                 session.invalidateAndCancel()
                 return false
@@ -205,10 +206,11 @@ extension SessionViewModel {
             session.invalidateAndCancel()
 
             await MainActor.run {
-                self.pairedDevices = [device]
+                self.addOrUpdateDevice(device)
                 self.relayURL = relayUrl
                 self.relayAPIKey = relayApiKey
                 self.savePairedDevices()
+                self.activeDeviceId = device.id
                 self.pairingState = .paired
                 self.connectLAN(host: host, port: port)
             }
@@ -221,5 +223,16 @@ extension SessionViewModel {
     func cancelPairing() {
         pairingBrowser.stopBrowsing()
         pairingState = .idle
+    }
+
+    // MARK: - Helpers
+
+    /// Add a new device or update an existing one (dedup by id).
+    private func addOrUpdateDevice(_ device: PairedDevice) {
+        if let idx = pairedDevices.firstIndex(where: { $0.id == device.id }) {
+            pairedDevices[idx] = device
+        } else {
+            pairedDevices.append(device)
+        }
     }
 }

--- a/ios/IonRemote/ViewModels/SessionViewModel+Snapshot.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Snapshot.swift
@@ -103,5 +103,20 @@ extension SessionViewModel {
         for tabId in loadingConversation {
             send(.loadConversation(tabId: tabId, before: conversationCursor[tabId]))
         }
+
+        // Cache layout for the active device so reconnects restore it.
+        if let deviceId = activeDevice?.id {
+            if !hasConnectedBefore {
+                hasConnectedBefore = true
+                UserDefaults.standard.set(true, forKey: "hasConnectedBefore")
+            }
+            LayoutCache.save(
+                deviceId: deviceId,
+                tabs: merged,
+                tabGroupMode: tabGroupMode,
+                tabGroups: tabGroups,
+                recentDirectories: recentDirectories
+            )
+        }
     }
 }

--- a/ios/IonRemote/ViewModels/SessionViewModel.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel.swift
@@ -185,6 +185,30 @@ final class SessionViewModel {
     var pairedDevices: [PairedDevice] = []
     var connectionState: ConnectionState = .disconnected
     var pairingState: PairingState = .idle
+
+    /// Which desktop is currently selected (persisted in UserDefaults).
+    var activeDeviceId: String? {
+        get { UserDefaults.standard.string(forKey: "activeDeviceId") }
+        set { UserDefaults.standard.set(newValue, forKey: "activeDeviceId") }
+    }
+
+    /// The currently active paired device, falling back to the first device.
+    var activeDevice: PairedDevice? {
+        if let id = activeDeviceId {
+            return pairedDevices.first { $0.id == id } ?? pairedDevices.first
+        }
+        return pairedDevices.first
+    }
+
+    /// True once we've received at least one snapshot (enables cached layout restoration).
+    var hasConnectedBefore: Bool = false
+
+    /// Online status of non-active paired devices (from relay polling).
+    /// Key: device ID. Value: true=online, false=offline, nil=unknown/error.
+    var deviceOnlineStatus: [String: Bool?] = [:]
+    /// Background task for periodic device status polling.
+    var deviceStatusTask: Task<Void, Never>?
+
     /// Recent base directories from the desktop, updated via snapshot events.
     var recentDirectories: [String] = []
     /// Tab ID to auto-navigate to after remote creation.
@@ -234,6 +258,28 @@ final class SessionViewModel {
     /// Navigate to a specific tab (e.g. from a push notification tap).
     func navigateToTab(_ tabId: String) {
         pendingNavigationTabId = tabId
+    }
+
+    /// Poll relay channel status for all non-active paired devices.
+    func pollDeviceStatus() {
+        let activeId = activeDevice?.id
+        let devices = pairedDevices.filter { $0.id != activeId }
+        guard !devices.isEmpty else { return }
+        Task {
+            for device in devices {
+                let relayUrl = device.relayURL ?? relayURL
+                let apiKey = device.relayAPIKey ?? relayAPIKey
+                let channelId = E2ECrypto.deriveChannelId(
+                    sharedSecret: SymmetricKey(data: device.sharedSecret)
+                )
+                let online = await PeerStatusPoller.checkDesktopOnline(
+                    relayURL: relayUrl, apiKey: apiKey, channelId: channelId
+                )
+                await MainActor.run {
+                    self.deviceOnlineStatus[device.id] = online
+                }
+            }
+        }
     }
 
     /// Compute the compound key for the active engine instance.
@@ -316,5 +362,7 @@ final class SessionViewModel {
 
     init() {
         loadPairedDevices()
+        // Restore hasConnectedBefore from UserDefaults
+        hasConnectedBefore = UserDefaults.standard.bool(forKey: "hasConnectedBefore")
     }
 }

--- a/ios/IonRemote/Views/ActivityIndicatorView.swift
+++ b/ios/IonRemote/Views/ActivityIndicatorView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct ActivityIndicatorView: View {
     let text: String
 
-    private let dotSize: CGFloat = 4 // matches desktop 4×4px dots
+    private let dotSize: CGFloat = 5 // matches desktop 4×4px dots (bumped to 5 for mobile)
     private let dotColor = Color(hex: 0xE8854A) // matches desktop statusRunning
 
     var body: some View {
@@ -21,9 +21,11 @@ struct ActivityIndicatorView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 12)
         .padding(.vertical, 6)
+        .background(Capsule().fill(Color(.tertiarySystemFill)))
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 16)
     }
 }
 
@@ -58,7 +60,7 @@ private struct BouncingDot: View {
     ///   80%–100%: hold at 0
     private static func yOffset(date: Date, delay: Double) -> CGFloat {
         let cycle = 1.2 // seconds — matches desktop
-        let peak: CGFloat = -3.5
+        let peak: CGFloat = -4.5
 
         // Seconds since reference, shifted by per-dot stagger
         let t = (date.timeIntervalSinceReferenceDate - delay)

--- a/ios/IonRemote/Views/AskUserQuestionCardView.swift
+++ b/ios/IonRemote/Views/AskUserQuestionCardView.swift
@@ -22,7 +22,7 @@ struct AskUserQuestionCardView: View {
                 // Header
                 HStack(spacing: 6) {
                     Image(systemName: "questionmark.circle.fill")
-                        .foregroundStyle(Color(hex: 0x4ECDC4))
+                        .foregroundStyle(IonTheme.accent)
                     Text(data.header)
                         .font(.headline)
                 }
@@ -38,37 +38,29 @@ struct AskUserQuestionCardView: View {
                     ForEach(data.options, id: \.self) { option in
                         if let label = option["label"] {
                             Button {
-                                triggerHaptic()
+                                Haptic.medium()
                                 viewModel.dismissSpecialPermission(tabId: tabId, questionId: request.questionId)
                                 viewModel.sendPrompt(tabId: tabId, text: label)
                             } label: {
                                 Text(label)
                                     .font(.subheadline.weight(.medium))
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 8)
+                                    .padding(.horizontal, 16)
+                                    .padding(.vertical, 10)
                             }
                             .buttonStyle(.borderedProminent)
-                            .tint(Color(hex: 0x4ECDC4))
+                            .clipShape(Capsule())
+                            .tint(IonTheme.accent)
                             .help(option["description"] ?? "")
                         }
                     }
                 }
             }
             .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.ultraThickMaterial)
-                    .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
-            )
+            .cardStyle()
         } else {
             // Fallback to generic card if question data can't be parsed
             PermissionCardGenericView(tabId: tabId, request: request)
         }
-    }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
     }
 }
 

--- a/ios/IonRemote/Views/ConnectionQualityView.swift
+++ b/ios/IonRemote/Views/ConnectionQualityView.swift
@@ -13,7 +13,10 @@ struct ConnectionQualityView: View {
     @State private var showPopover = false
 
     var body: some View {
-        if viewModel.connectionState == .connected || viewModel.connectionState == .reconnecting {
+        let showView = viewModel.connectionState == .connected
+            || viewModel.connectionState == .reconnecting
+            || viewModel.connectionState == .connecting
+        if showView {
             content
         } else {
             EmptyView()

--- a/ios/IonRemote/Views/ConversationView.swift
+++ b/ios/IonRemote/Views/ConversationView.swift
@@ -128,8 +128,8 @@ struct ConversationView: View {
                         Image(systemName: "chevron.down")
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(.secondary)
-                            .frame(width: 36, height: 36)
-                            .background(.ultraThinMaterial)
+                            .frame(width: 40, height: 40)
+                            .background(.regularMaterial)
                             .clipShape(Circle())
                             .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
                     }
@@ -137,7 +137,7 @@ struct ConversationView: View {
                     .transition(.opacity.combined(with: .scale))
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: isNearBottom)
+            .animation(IonTheme.snappySpring, value: isNearBottom)
 
             // Activity indicator — pinned above input, always visible
             if isRunning {
@@ -146,7 +146,8 @@ struct ConversationView: View {
 
             if let request = pendingPermission {
                 PermissionCardView(tabId: tabId, request: request)
-                    .padding()
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
@@ -159,7 +160,9 @@ struct ConversationView: View {
                         .font(.caption)
                 }
                 .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
                 .padding(.vertical, 4)
+                .background(Capsule().fill(Color(.tertiarySystemFill)))
             }
 
             InputBar(tabId: tabId)
@@ -211,7 +214,10 @@ struct ConversationView: View {
                             Text(tab?.permissionMode == .plan ? "Plan" : "Auto")
                                 .font(.caption.weight(.medium))
                         }
-                        .foregroundStyle(tab?.permissionMode == .plan ? Color(hex: 0x2EB8A6) : .secondary)
+                        .foregroundStyle(tab?.permissionMode == .plan ? IonTheme.accent : .secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(Color(.tertiarySystemFill)))
                     }
                 }
             }
@@ -290,7 +296,7 @@ struct ConversationView: View {
     private var messageList: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: 4) {
+                LazyVStack(spacing: 6) {
                     // "Load more" button at the top
                     if viewModel.conversationHasMore[tabId] == true {
                         Button {
@@ -328,6 +334,22 @@ struct ConversationView: View {
                         .padding(.top, 40)
                     }
 
+                    // Empty conversation welcome state
+                    if conversationMessages.isEmpty && !isLoading && !loadFailed {
+                        VStack(spacing: 12) {
+                            Image("IonIcon")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 48, height: 48)
+                                .foregroundStyle(.tertiary)
+                            Text("Send a message to get started")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 80)
+                    }
+
                     // Messages (grouped)
                     ForEach(groupedItems) { item in
                         conversationItemView(item)
@@ -348,6 +370,7 @@ struct ConversationView: View {
                 .padding(.vertical)
                 .background(ScrollOffsetReader(isNearBottom: $isNearBottom))
             }
+            .scrollDismissesKeyboard(.interactively)
             .onAppear { scrollProxy = proxy }
         }
     }

--- a/ios/IonRemote/Views/DesktopPickerMenu.swift
+++ b/ios/IonRemote/Views/DesktopPickerMenu.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Toolbar menu for switching between paired desktops.
+/// Shows the active device with a green dot, other devices with status
+/// indicators, and an option to pair a new desktop.
+struct DesktopPickerMenu: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Binding var showPairingSheet: Bool
+
+    var body: some View {
+        Menu {
+            ForEach(viewModel.pairedDevices) { device in
+                let isActive = device.id == viewModel.activeDeviceId
+                    || (viewModel.activeDeviceId == nil && device.id == viewModel.pairedDevices.first?.id)
+                Button {
+                    if !isActive {
+                        viewModel.switchToDevice(id: device.id)
+                    }
+                } label: {
+                    HStack {
+                        Label(device.name, systemImage: "desktopcomputer")
+                        Spacer()
+                        if isActive {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+                .disabled(isActive)
+            }
+
+            Divider()
+
+            Button {
+                showPairingSheet = true
+            } label: {
+                Label("Pair New Desktop…", systemImage: "plus")
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(activeDeviceName)
+                    .font(.headline)
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                statusDot
+            }
+        }
+        .onAppear { pollDeviceStatus() }
+    }
+
+    // MARK: - Helpers
+
+    private var activeDeviceName: String {
+        viewModel.activeDevice?.name ?? "Ion"
+    }
+
+    @ViewBuilder
+    private var statusDot: some View {
+        Circle()
+            .fill(activeStatusColor)
+            .frame(width: 8, height: 8)
+    }
+
+    private var activeStatusColor: Color {
+        switch viewModel.connectionState {
+        case .connected: .green
+        case .reconnecting, .connecting: .orange
+        default: .red
+        }
+    }
+
+    private func pollDeviceStatus() {
+        viewModel.pollDeviceStatus()
+    }
+}

--- a/ios/IonRemote/Views/DesktopPickerMenu.swift
+++ b/ios/IonRemote/Views/DesktopPickerMenu.swift
@@ -15,10 +15,22 @@ struct DesktopPickerMenu: View {
                 Button {
                     if !isActive {
                         viewModel.switchToDevice(id: device.id)
+                        Haptic.success()
                     }
                 } label: {
                     HStack {
-                        Label(device.name, systemImage: "desktopcomputer")
+                        VStack(alignment: .leading, spacing: 2) {
+                            Label(device.name, systemImage: "desktopcomputer")
+                            if isActive {
+                                Text(connectionStateLabel)
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            } else if let lastSeen = device.lastSeen {
+                                Text("Last seen \(lastSeen.formatted(.relative(presentation: .named)))")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
                         Spacer()
                         if isActive {
                             Image(systemName: "checkmark")
@@ -31,12 +43,19 @@ struct DesktopPickerMenu: View {
             Divider()
 
             Button {
+                viewModel.reconnect()
+            } label: {
+                Label("Reconnect", systemImage: "arrow.clockwise")
+            }
+
+            Button {
                 showPairingSheet = true
             } label: {
                 Label("Pair New Desktop…", systemImage: "plus")
             }
+            .tint(IonTheme.accent)
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: 6) {
                 Text(activeDeviceName)
                     .font(.headline)
                 Image(systemName: "chevron.down")
@@ -44,6 +63,9 @@ struct DesktopPickerMenu: View {
                     .foregroundStyle(.secondary)
                 statusDot
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(.regularMaterial, in: Capsule())
         }
         .onAppear { pollDeviceStatus() }
     }
@@ -59,6 +81,7 @@ struct DesktopPickerMenu: View {
         Circle()
             .fill(activeStatusColor)
             .frame(width: 8, height: 8)
+            .shadow(color: activeStatusColor.opacity(0.4), radius: 3)
     }
 
     private var activeStatusColor: Color {
@@ -66,6 +89,18 @@ struct DesktopPickerMenu: View {
         case .connected: .green
         case .reconnecting, .connecting: .orange
         default: .red
+        }
+    }
+
+    private var connectionStateLabel: String {
+        let connection = viewModel.connectionState.label
+        switch viewModel.transportState {
+        case .lanPreferred:
+            return "\(connection) · LAN"
+        case .relayOnly:
+            return "\(connection) · Relay"
+        case .disconnected:
+            return connection
         }
     }
 

--- a/ios/IonRemote/Views/DiagnosticLogView.swift
+++ b/ios/IonRemote/Views/DiagnosticLogView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// On-device diagnostic log viewer.
+///
+/// Shows timestamped connection lifecycle events in a scrollable list.
+/// Use the Share button to AirDrop/copy the full log to a Mac for analysis.
+struct DiagnosticLogView: View {
+    @State private var entries: [DiagnosticLog.Entry] = []
+    @State private var showShareSheet = false
+
+    private let timeFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    var body: some View {
+        List {
+            if entries.isEmpty {
+                Text("No diagnostic entries yet.\nConnect or switch desktops to generate logs.")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            } else {
+                ForEach(Array(entries.enumerated().reversed()), id: \.offset) { _, entry in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(timeFmt.string(from: entry.timestamp))
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .monospaced()
+                        Text(entry.message)
+                            .font(.caption)
+                            .monospaced()
+                    }
+                    .listRowInsets(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12))
+                }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle("Diagnostic Log")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    ShareLink(item: DiagnosticLog.exportText()) {
+                        Label("Share Log", systemImage: "square.and.arrow.up")
+                    }
+                    Button(role: .destructive) {
+                        DiagnosticLog.clear()
+                        entries = []
+                    } label: {
+                        Label("Clear Log", systemImage: "trash")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+        .onAppear { entries = DiagnosticLog.entries() }
+        .refreshable { entries = DiagnosticLog.entries() }
+    }
+}

--- a/ios/IonRemote/Views/EngineView.swift
+++ b/ios/IonRemote/Views/EngineView.swift
@@ -33,6 +33,17 @@ struct EngineView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            // Context usage bar
+            if let fields = viewModel.engineStatusFields[compoundKey] {
+                GeometryReader { geo in
+                    Rectangle()
+                        .fill(contextBarColor(fields.contextPercent))
+                        .frame(width: geo.size.width * min(CGFloat(fields.contextPercent) / 100, 1))
+                }
+                .frame(height: 3)
+                .background(Color(.tertiarySystemFill))
+            }
+
             // Engine instance bar (shown when multiple instances exist)
             if instances.count > 1 {
                 EngineInstanceBar(
@@ -55,8 +66,10 @@ struct EngineView: View {
                 .foregroundStyle(.secondary)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
+                .background(Capsule().fill(Color(.tertiarySystemFill)))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.ultraThinMaterial)
             }
 
             // Pinned prompt header
@@ -69,11 +82,11 @@ struct EngineView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
-                .font(.caption.monospaced())
+                .font(IonTheme.codeFont(size: 12))
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.ultraThinMaterial)
+                .background(Color(.secondarySystemFill).opacity(0.7))
             }
 
             // Conversation messages area
@@ -113,7 +126,7 @@ struct EngineView: View {
                 VStack(spacing: 0) {
                     // Collapsible header
                     Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
+                        withAnimation(IonTheme.snappySpring) {
                             agentsPanelExpanded.toggle()
                         }
                     } label: {
@@ -166,17 +179,19 @@ struct EngineView: View {
             // Input bar
             HStack(spacing: 8) {
                 TextField("Send a prompt...", text: $promptText)
-                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color(.tertiarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.medium))
+                    .overlay(RoundedRectangle(cornerRadius: IonTheme.Radius.medium).stroke(Color(.separator), lineWidth: 1))
                     .focused($isInputFocused)
-                    .onSubmit {
-                        submitPrompt()
-                    }
+                    .onSubmit { submitPrompt() }
 
                 Button {
                     submitPrompt()
                 } label: {
                     Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
+                        .font(.title)
                         .foregroundStyle(.orange)
                 }
                 .disabled(promptText.trimmingCharacters(in: .whitespaces).isEmpty)
@@ -218,8 +233,15 @@ struct EngineView: View {
     private func submitPrompt() {
         let trimmed = promptText.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
+        Haptic.light()
         viewModel.submitEnginePrompt(tabId: tabId, text: promptText)
         promptText = ""
+    }
+
+    private func contextBarColor(_ percent: Double) -> Color {
+        if percent < 50 { return .green }
+        if percent < 80 { return .orange }
+        return .red
     }
 }
 

--- a/ios/IonRemote/Views/FileEditorView.swift
+++ b/ios/IonRemote/Views/FileEditorView.swift
@@ -117,7 +117,7 @@ struct FileEditorView: View {
             } label: {
                 Text("Save")
                     .fontWeight(.semibold)
-                    .foregroundStyle(isDirty ? Color(hex: 0x2EB8A6) : .secondary)
+                    .foregroundStyle(isDirty ? IonTheme.accent : .secondary)
             }
             .disabled(!isDirty)
         }
@@ -134,12 +134,28 @@ struct FileEditorView: View {
                     .padding(.vertical, 12)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
-                Text(editedContent)
-                    .font(.system(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
+                HStack(alignment: .top, spacing: 0) {
+                    // Line number gutter
+                    VStack(alignment: .trailing, spacing: 0) {
+                        ForEach(1...max(editedContent.components(separatedBy: "\n").count, 1), id: \.self) { lineNum in
+                            Text("\(lineNum)")
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.tertiary)
+                                .frame(height: 20)
+                        }
+                    }
+                    .padding(.top, 8)
+                    .padding(.horizontal, 4)
+                    .frame(width: 40)
+                    .background(Color(.secondarySystemBackground))
+
+                    Text(editedContent)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                }
             }
         }
     }
@@ -148,12 +164,33 @@ struct FileEditorView: View {
 
     private var editorView: some View {
         ZStack(alignment: .topTrailing) {
-            TextEditor(text: $editedContent)
-                .font(.system(.body, design: .monospaced))
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-                .scrollContentBackground(.hidden)
-                .background(Color(.systemBackground))
+            HStack(alignment: .top, spacing: 0) {
+                // Line number gutter
+                ScrollView {
+                    VStack(alignment: .trailing, spacing: 0) {
+                        ForEach(1...max(editedContent.components(separatedBy: "\n").count, 1), id: \.self) { lineNum in
+                            Text("\(lineNum)")
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.tertiary)
+                                .frame(height: 20)
+                        }
+                    }
+                    .padding(.top, 8)
+                    .padding(.horizontal, 4)
+                }
+                .frame(width: 40)
+                .background(Color(.secondarySystemBackground))
+                .scrollDisabled(true)
+
+                Divider()
+
+                TextEditor(text: $editedContent)
+                    .font(.system(.body, design: .monospaced))
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .scrollContentBackground(.hidden)
+                    .background(Color(.systemBackground))
+            }
 
             if let msg = saveMessage {
                 saveMessageBadge(msg)

--- a/ios/IonRemote/Views/FileExplorerView.swift
+++ b/ios/IonRemote/Views/FileExplorerView.swift
@@ -135,7 +135,7 @@ struct FileExplorerView: View {
 
     private func handleTap(_ entry: FsEntry) {
         guard entry.isDirectory else { return }
-        withAnimation(.easeInOut(duration: 0.2)) {
+        withAnimation(IonTheme.snappySpring) {
             if expandedPaths.contains(entry.path) {
                 expandedPaths.remove(entry.path)
             } else {

--- a/ios/IonRemote/Views/GitChangesListView.swift
+++ b/ios/IonRemote/Views/GitChangesListView.swift
@@ -7,6 +7,9 @@ struct GitChangesListView: View {
     let directory: String
     @State private var commitMessage = ""
     @State private var showDiff = false
+    @State private var selectMode = false
+    @State private var selectedPaths: Set<String> = []
+    @State private var recentCommitMessages: [String] = []
 
     private var changesResponse: GitChangesResponse? {
         viewModel.gitChanges[directory]
@@ -73,6 +76,33 @@ struct GitChangesListView: View {
                 // Commit bar
                 if !stagedFiles.isEmpty {
                     commitBar
+                }
+
+                // Batch actions
+                if selectMode && !selectedPaths.isEmpty {
+                    HStack(spacing: 12) {
+                        Button {
+                            viewModel.gitStage(directory: directory, paths: Array(selectedPaths))
+                            selectedPaths.removeAll()
+                        } label: {
+                            Label("Stage \(selectedPaths.count)", systemImage: "plus.circle")
+                                .font(.caption.weight(.medium))
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.green)
+
+                        Button {
+                            viewModel.gitUnstage(directory: directory, paths: Array(selectedPaths))
+                            selectedPaths.removeAll()
+                        } label: {
+                            Label("Unstage \(selectedPaths.count)", systemImage: "minus.circle")
+                                .font(.caption.weight(.medium))
+                        }
+                        .buttonStyle(.bordered)
+                        .tint(.orange)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
                 }
             }
             .fullScreenCover(isPresented: $showDiff) {
@@ -145,6 +175,13 @@ struct GitChangesListView: View {
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
             Spacer()
+            if count >= 3 {
+                Button(selectMode ? "Done" : "Select") {
+                    selectMode.toggle()
+                    if !selectMode { selectedPaths.removeAll() }
+                }
+                .font(.caption)
+            }
             Button(actionLabel, action: action)
                 .font(.caption)
         }
@@ -171,9 +208,21 @@ struct GitChangesListView: View {
                     .foregroundStyle(.primary)
                     .lineLimit(1)
                 Spacer()
-                Image(systemName: "chevron.right")
-                    .font(.caption2)
-                    .foregroundStyle(.quaternary)
+                if selectMode {
+                    Image(systemName: selectedPaths.contains(file.path) ? "checkmark.circle.fill" : "circle")
+                        .foregroundStyle(selectedPaths.contains(file.path) ? IonTheme.accent : Color(.tertiaryLabel))
+                        .onTapGesture {
+                            if selectedPaths.contains(file.path) {
+                                selectedPaths.remove(file.path)
+                            } else {
+                                selectedPaths.insert(file.path)
+                            }
+                        }
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.quaternary)
+                }
             }
             .padding(.leading, indented ? 28 : 12)
             .padding(.trailing, 12)
@@ -223,12 +272,26 @@ struct GitChangesListView: View {
 
     private var commitBar: some View {
         HStack(spacing: 8) {
+            if commitMessage.isEmpty && !recentCommitMessages.isEmpty {
+                Menu {
+                    ForEach(recentCommitMessages, id: \.self) { msg in
+                        Button(msg) { commitMessage = msg }
+                    }
+                } label: {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
             TextField("Commit message", text: $commitMessage)
                 .textFieldStyle(.roundedBorder)
                 .font(.subheadline)
 
             Button {
                 guard !commitMessage.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+                recentCommitMessages.insert(commitMessage, at: 0)
+                if recentCommitMessages.count > 5 { recentCommitMessages.removeLast() }
                 viewModel.gitCommit(directory: directory, message: commitMessage)
                 commitMessage = ""
             } label: {
@@ -237,7 +300,7 @@ struct GitChangesListView: View {
                     .foregroundStyle(
                         commitMessage.trimmingCharacters(in: .whitespaces).isEmpty
                             ? .secondary
-                            : Color(hex: 0x2EB8A6)
+                            : IonTheme.accent
                     )
             }
             .disabled(commitMessage.trimmingCharacters(in: .whitespaces).isEmpty)

--- a/ios/IonRemote/Views/GitPaneView.swift
+++ b/ios/IonRemote/Views/GitPaneView.swift
@@ -123,7 +123,7 @@ struct GitPaneView: View {
     ) -> some View {
         VStack(spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
+                withAnimation(IonTheme.snappySpring) {
                     isExpanded.wrappedValue.toggle()
                 }
             } label: {

--- a/ios/IonRemote/Views/InputBar.swift
+++ b/ios/IonRemote/Views/InputBar.swift
@@ -9,6 +9,13 @@ struct InputBar: View {
     @FocusState private var isFocused: Bool
     @State private var keyboardVisible = false
     @State private var slashFilter: String?
+    @State private var placeholderIndex = 0
+
+    private let placeholders = [
+        "Ask a question…",
+        "Describe what you need…",
+        "Type / for commands…"
+    ]
 
     private var tab: RemoteTabState? {
         viewModel.tab(for: tabId)
@@ -56,16 +63,29 @@ struct InputBar: View {
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
-            Divider()
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [Color(.separator).opacity(0), Color(.separator), Color(.separator).opacity(0)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(height: 0.5)
 
             HStack(spacing: 8) {
-                TextField("Message", text: $promptText, axis: .vertical)
-                    .textFieldStyle(.roundedBorder)
+                TextField("", text: $promptText, prompt: Text(placeholders[placeholderIndex]).foregroundStyle(.tertiary), axis: .vertical)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(Color(.tertiarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.medium))
+                    .overlay(RoundedRectangle(cornerRadius: IonTheme.Radius.medium).stroke(Color(.separator), lineWidth: 1))
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .lineLimit(1...5)
                     .focused($isFocused)
                     .disabled(!isConnected)
+                    .onSubmit { sendMessage() }
 
                 if isRunning {
                     Button {
@@ -74,23 +94,31 @@ struct InputBar: View {
                         Image(systemName: "stop.circle.fill")
                             .font(.title2)
                             .foregroundStyle(.red)
+                            .shadow(color: .red.opacity(0.3), radius: 6)
                     }
                 }
 
                 Button {
-                    guard !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-                    viewModel.sendPrompt(tabId: tabId, text: promptText)
-                    isFocused = false
-                    promptText = ""
+                    sendMessage()
                 } label: {
                     Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
+                        .font(.title)
                         .foregroundStyle(sendButtonColor)
                 }
                 .disabled(promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !isConnected)
             }
             .padding(.horizontal)
             .padding(.vertical, 8)
+
+            if promptText.count > 500 {
+                HStack {
+                    Spacer()
+                    Text("\(promptText.count)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .padding(.trailing, 16)
+                }
+            }
 
             // Queue indicator
             if isQueued && !promptText.isEmpty {
@@ -100,9 +128,9 @@ struct InputBar: View {
                     .padding(.bottom, 4)
             }
         }
-        .background(.ultraThinMaterial)
-        .animation(.easeInOut(duration: 0.15), value: keyboardVisible)
-        .animation(.easeInOut(duration: 0.15), value: slashFilter)
+        .background(.regularMaterial)
+        .animation(IonTheme.snappySpring, value: keyboardVisible)
+        .animation(IonTheme.snappySpring, value: slashFilter)
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { _ in
             keyboardVisible = true
         }
@@ -124,13 +152,29 @@ struct InputBar: View {
         .onChange(of: workingDirectory) {
             fetchCommandsIfNeeded()
         }
+        .task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(4))
+                withAnimation {
+                    placeholderIndex = (placeholderIndex + 1) % placeholders.count
+                }
+            }
+        }
+    }
+
+    private func sendMessage() {
+        guard !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        Haptic.light()
+        viewModel.sendPrompt(tabId: tabId, text: promptText)
+        isFocused = false
+        promptText = ""
     }
 
     private var sendButtonColor: Color {
         if !isConnected {
             return .gray
         }
-        return isQueued ? .orange : Color(hex: 0x4ECDC4)
+        return isQueued ? .orange : IonTheme.accent
     }
 
     /// Detect if the user is typing a slash command prefix.

--- a/ios/IonRemote/Views/IonTheme.swift
+++ b/ios/IonRemote/Views/IonTheme.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+// MARK: - IonTheme
+
+/// Centralized design tokens — single source of truth for the entire app.
+enum IonTheme {
+
+    // MARK: Colors
+
+    static let accent = Color(hex: 0x4ECDC4)
+    static let surfaceElevated = Color(.tertiarySystemBackground)
+    static let codeBg = Color(.secondarySystemFill).opacity(0.7)
+    static let userBubbleTint = Color(hex: 0x4ECDC4).opacity(0.08)
+
+    static let statusRunning = Color(hex: 0xE8854A)
+    static let statusDone = Color.green
+    static let statusError = Color.red
+    static let statusPending = Color.orange
+
+    // MARK: Spacing
+
+    static let xs: CGFloat = 4
+    static let sm: CGFloat = 8
+    static let md: CGFloat = 12
+    static let lg: CGFloat = 16
+    static let xl: CGFloat = 24
+    static let xxl: CGFloat = 32
+
+    // MARK: Radii
+
+    enum Radius {
+        static let small: CGFloat = 8
+        static let medium: CGFloat = 12
+        static let large: CGFloat = 16
+        static let card: CGFloat = 20
+    }
+
+    // MARK: Animations
+
+    static let snappySpring = Animation.spring(.snappy)
+    static let gentleSpring = Animation.spring(.bouncy)
+
+    // MARK: Typography
+
+    /// Returns JetBrains Mono at the given size, falling back to system monospaced.
+    static func codeFont(size: CGFloat = 14) -> Font {
+        .custom("JetBrainsMonoNLNerdFontMono-Regular", size: size)
+    }
+}
+
+// MARK: - Haptic
+
+/// Centralized haptic feedback — replaces per-file `triggerHaptic()` calls.
+enum Haptic {
+    static func light() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    static func medium() {
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+
+    static func success() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
+
+    static func error() {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+    }
+}
+
+// MARK: - CardStyle ViewModifier
+
+/// Apple-like card: regular material, soft shadow, rounded corners, top-edge highlight.
+struct CardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.card))
+            .overlay(
+                RoundedRectangle(cornerRadius: IonTheme.Radius.card)
+                    .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                    .mask(
+                        LinearGradient(
+                            colors: [.white, .clear],
+                            startPoint: .top,
+                            endPoint: .center
+                        )
+                    )
+            )
+            .shadow(color: .black.opacity(0.2), radius: 12, y: 6)
+    }
+}
+
+extension View {
+    func cardStyle() -> some View {
+        modifier(CardStyle())
+    }
+}

--- a/ios/IonRemote/Views/KeyboardUtilityBar.swift
+++ b/ios/IonRemote/Views/KeyboardUtilityBar.swift
@@ -27,6 +27,14 @@ struct KeyboardUtilityBar: View {
                 utilityButton("selection.pin.in.out", label: "Select All") {
                     UIApplication.shared.sendAction(#selector(UIResponder.selectAll(_:)), to: nil, from: nil, for: nil)
                 }
+
+                utilityButton("arrow.right.to.line", label: "Tab") {
+                    promptText.append("\t")
+                }
+
+                utilityButton("return", label: "New Line") {
+                    promptText.append("\n")
+                }
             }
 
             Spacer()
@@ -38,12 +46,14 @@ struct KeyboardUtilityBar: View {
                 Image(systemName: "keyboard.chevron.compact.down")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                    .frame(width: 36, height: 36)
+                    .frame(width: 40, height: 40)
+                    .contentShape(Circle())
+                    .background(Circle().fill(Color(.tertiarySystemFill)))
             }
         }
         .padding(.horizontal, 8)
-        .frame(height: 36)
-        .background(.ultraThinMaterial)
+        .frame(height: 40)
+        .background(.regularMaterial)
     }
 
     private func utilityButton(_ icon: String, label: String, action: @escaping () -> Void) -> some View {
@@ -51,7 +61,9 @@ struct KeyboardUtilityBar: View {
             Image(systemName: icon)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
-                .frame(width: 44, height: 36)
+                .frame(width: 40, height: 40)
+                .contentShape(Circle())
+                .background(Circle().fill(Color(.tertiarySystemFill)))
         }
         .accessibilityLabel(label)
     }

--- a/ios/IonRemote/Views/MarkdownContentView.swift
+++ b/ios/IonRemote/Views/MarkdownContentView.swift
@@ -7,7 +7,7 @@ struct MarkdownContentView: View {
     let blocks: [MarkdownBlock]
 
     var body: some View {
-        LazyVStack(alignment: .leading, spacing: 14) {
+        LazyVStack(alignment: .leading, spacing: 16) {
             ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
                 blockView(block)
             }
@@ -51,7 +51,15 @@ struct MarkdownContentView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             if level <= 2 {
-                Divider()
+                Rectangle()
+                    .fill(
+                        LinearGradient(
+                            colors: [Color(.separator), Color(.separator).opacity(0)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(height: 0.5)
             }
         }
     }
@@ -79,26 +87,30 @@ struct MarkdownContentView: View {
         code: String
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
-            if let lang = language, !lang.isEmpty {
-                Text(lang)
-                    .font(.caption2.monospaced())
-                    .foregroundStyle(.tertiary)
-                    .padding(.horizontal, 12)
-                    .padding(.top, 10)
-                    .padding(.bottom, 4)
+            HStack {
+                if let lang = language, !lang.isEmpty {
+                    Text(lang)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer()
+                CodeBlockCopyButton(code: code)
             }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 4)
 
             ScrollView(.horizontal, showsIndicators: false) {
                 Text(code)
                     .font(.system(.callout, design: .monospaced))
                     .textSelection(.enabled)
                     .padding(.horizontal, 12)
-                    .padding(.vertical, language != nil ? 6 : 10)
+                    .padding(.vertical, 6)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.tertiarySystemFill))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(Color(.secondarySystemFill).opacity(0.7))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
     // MARK: - Block quote
@@ -106,8 +118,8 @@ struct MarkdownContentView: View {
     private func blockQuoteView(text: AttributedString) -> some View {
         HStack(alignment: .top, spacing: 0) {
             RoundedRectangle(cornerRadius: 1.5)
-                .fill(Color(hex: 0x4ECDC4).opacity(0.6))
-                .frame(width: 3)
+                .fill(IonTheme.accent.opacity(0.6))
+                .frame(width: 3.5)
 
             Text(text)
                 .foregroundStyle(.secondary)
@@ -165,7 +177,7 @@ struct MarkdownContentView: View {
 
                 ForEach(
                     Array(rows.enumerated()), id: \.offset
-                ) { _, row in
+                ) { rowIndex, row in
                     GridRow {
                         ForEach(0..<colCount, id: \.self) { col in
                             tableCellContent(
@@ -178,6 +190,11 @@ struct MarkdownContentView: View {
                             )
                         }
                     }
+                    .background(
+                        rowIndex.isMultiple(of: 2)
+                            ? Color(.tertiarySystemFill).opacity(0.5)
+                            : Color.clear
+                    )
                 }
             }
             .clipShape(RoundedRectangle(cornerRadius: 6))
@@ -237,5 +254,30 @@ struct MarkdownContentView: View {
     private var thematicBreakView: some View {
         Divider()
             .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Code block copy button
+
+private struct CodeBlockCopyButton: View {
+    let code: String
+    @State private var copied = false
+
+    var body: some View {
+        Button {
+            UIPasteboard.general.string = code
+            copied = true
+            Haptic.light()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                copied = false
+            }
+        } label: {
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .font(.caption2)
+                .foregroundStyle(copied ? Color.green : Color(.tertiaryLabel))
+                .frame(width: 24, height: 24)
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/ios/IonRemote/Views/MessageBubble.swift
+++ b/ios/IonRemote/Views/MessageBubble.swift
@@ -11,6 +11,8 @@ struct MessageBubble: View {
 
     @State private var isToolExpanded = false
     @State private var showRewindConfirm = false
+    @State private var showCopyButton = false
+    @State private var showCopiedCheck = false
 
     var body: some View {
         switch message.role {
@@ -23,6 +25,15 @@ struct MessageBubble: View {
         case .system:
             systemBubble
         }
+    }
+
+    // MARK: - Timestamp helper
+
+    private var relativeTimestamp: String {
+        let date = Date(timeIntervalSince1970: message.timestamp / 1000)
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
     }
 
     // MARK: - User
@@ -40,20 +51,34 @@ struct MessageBubble: View {
                     }
                     .foregroundStyle(.secondary)
                 }
-                MarkdownContentView(
-                    blocks: MarkdownBlockCache.shared.blocks(for: message.content)
+                HStack(spacing: 0) {
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(IonTheme.accent)
+                        .frame(width: 2.5)
+                    MarkdownContentView(
+                        blocks: MarkdownBlockCache.shared.blocks(for: message.content)
+                    )
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+                .background(
+                    ZStack {
+                        Color(.tertiarySystemBackground)
+                        IonTheme.userBubbleTint
+                    }
                 )
-                .textSelection(.enabled)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
-                .background(Color(hex: 0x4ECDC4).opacity(0.15))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.large))
                 .overlay(
                     message.content.hasPrefix("! ")
-                        ? RoundedRectangle(cornerRadius: 12)
+                        ? RoundedRectangle(cornerRadius: IonTheme.Radius.large)
                             .stroke(Color(hex: 0xF472B6, opacity: 0.5), lineWidth: 2)
                         : nil
                 )
+
+                Text(relativeTimestamp)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
             }
             .padding(.trailing, 12)
             .padding(.vertical, 2)
@@ -97,27 +122,66 @@ struct MessageBubble: View {
 
     private var assistantBubble: some View {
         VStack(alignment: .leading, spacing: 4) {
-            if !message.content.isEmpty {
-                MarkdownContentView(
-                    blocks: MarkdownBlockCache.shared.blocks(for: message.content)
-                )
-                .textSelection(.enabled)
+            ZStack(alignment: .bottomTrailing) {
+                VStack(alignment: .leading, spacing: 4) {
+                    if !message.content.isEmpty {
+                        MarkdownContentView(
+                            blocks: MarkdownBlockCache.shared.blocks(for: message.content)
+                        )
+                        .textSelection(.enabled)
+                    }
+
+                    // Blinking cursor for streaming
+                    if isRunning && message.isAssistant {
+                        RoundedRectangle(cornerRadius: 0.5)
+                            .fill(Color.primary)
+                            .frame(width: 2, height: 18)
+                            .modifier(BlinkingModifier())
+                    }
+                }
+
+                // Copy button overlay
+                if showCopyButton {
+                    Button {
+                        UIPasteboard.general.string = copyableContent ?? message.content
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showCopiedCheck = true
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                            withAnimation { showCopiedCheck = false }
+                        }
+                    } label: {
+                        Image(systemName: showCopiedCheck ? "checkmark" : "doc.on.doc")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(6)
+                            .background(.ultraThinMaterial)
+                            .clipShape(Circle())
+                    }
+                    .transition(.opacity)
+                    .padding(4)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: UIScreen.main.bounds.width * 0.92, alignment: .leading)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.large))
+            .contentShape(Rectangle())
+            .onTapGesture {
+                guard !showCopyButton else { return }
+                withAnimation(.easeInOut(duration: 0.2)) { showCopyButton = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    withAnimation(.easeOut(duration: 0.3)) { showCopyButton = false }
+                }
             }
 
-            // Blinking cursor for streaming
-            if isRunning && message.isAssistant {
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(Color.primary)
-                    .frame(width: 8, height: 16)
-                    .opacity(0.6)
-                    .modifier(BlinkingModifier())
-            }
+            Text(relativeTimestamp)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .padding(.leading, 4)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.secondarySystemFill))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
         .padding(.horizontal, 12)
         .padding(.vertical, 2)
         .contextMenu {
@@ -139,60 +203,75 @@ struct MessageBubble: View {
 
     // MARK: - Tool
 
+    private var toolAccentColor: Color {
+        switch message.toolStatus {
+        case .running:  return .orange
+        case .completed: return .green
+        case .error:    return .red
+        case nil:       return .gray
+        }
+    }
+
     private var toolBubble: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isToolExpanded.toggle()
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    toolStatusIcon
+        HStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(toolAccentColor)
+                .frame(width: 2)
 
-                    Text(message.toolName ?? "Tool")
-                        .font(.subheadline.monospaced())
-                        .foregroundStyle(.primary)
-
-                    Spacer()
-
-                    Image(systemName: isToolExpanded ? "chevron.up" : "chevron.down")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-            }
-            .buttonStyle(.plain)
-
-            if isToolExpanded {
-                VStack(alignment: .leading, spacing: 4) {
-                    if let input = message.toolInput, !input.isEmpty {
-                        Text("Input:")
-                            .font(.caption.bold())
-                            .foregroundStyle(.secondary)
-                        Text(input)
-                            .font(.caption.monospaced())
-                            .textSelection(.enabled)
-                            .lineLimit(10)
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    withAnimation(IonTheme.snappySpring) {
+                        isToolExpanded.toggle()
                     }
-                    if !message.content.isEmpty {
-                        Text(message.toolStatus == .error ? "Error:" : "Result:")
-                            .font(.caption.bold())
-                            .foregroundStyle(message.toolStatus == .error ? .red : .secondary)
-                        Text(message.content)
-                            .font(.caption.monospaced())
-                            .textSelection(.enabled)
-                            .lineLimit(20)
-                            .foregroundStyle(message.toolStatus == .error ? .red : .primary)
+                } label: {
+                    HStack(spacing: 8) {
+                        toolStatusIcon
+
+                        Text(message.toolName ?? "Tool")
+                            .font(.subheadline.monospaced())
+                            .foregroundStyle(.primary)
+
+                        Spacer()
+
+                        Image(systemName: isToolExpanded ? "chevron.up" : "chevron.down")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
                     }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
                 }
-                .padding(.horizontal, 12)
-                .padding(.bottom, 8)
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .buttonStyle(.plain)
+
+                if isToolExpanded {
+                    VStack(alignment: .leading, spacing: 4) {
+                        if let input = message.toolInput, !input.isEmpty {
+                            Text("Input:")
+                                .font(.caption.bold())
+                                .foregroundStyle(.secondary)
+                            Text(input)
+                                .font(.caption.monospaced())
+                                .textSelection(.enabled)
+                                .lineLimit(10)
+                        }
+                        if !message.content.isEmpty {
+                            Text(message.toolStatus == .error ? "Error:" : "Result:")
+                                .font(.caption.bold())
+                                .foregroundStyle(message.toolStatus == .error ? .red : .secondary)
+                            Text(message.content)
+                                .font(.caption.monospaced())
+                                .textSelection(.enabled)
+                                .lineLimit(20)
+                                .foregroundStyle(message.toolStatus == .error ? .red : .primary)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 8)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
         }
         .background(Color(.tertiarySystemFill))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
         .padding(.horizontal, 12)
         .padding(.vertical, 1)
     }
@@ -222,30 +301,32 @@ struct MessageBubble: View {
     // MARK: - System
 
     private var systemBubble: some View {
-        HStack {
-            Spacer()
+        HStack(spacing: 8) {
+            VStack { Divider() }
             Text(message.content)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)
-            Spacer()
+                .lineLimit(2)
+                .layoutPriority(1)
+            VStack { Divider() }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 6)
     }
 }
 
 // MARK: - BlinkingModifier
 
 struct BlinkingModifier: ViewModifier {
-    @State private var isVisible = true
+    @State private var pulse = false
 
     func body(content: Content) -> some View {
         content
-            .opacity(isVisible ? 1 : 0)
+            .opacity(pulse ? 0.3 : 1.0)
             .onAppear {
-                withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
-                    isVisible = false
+                withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                    pulse = true
                 }
             }
     }

--- a/ios/IonRemote/Views/PairingView.swift
+++ b/ios/IonRemote/Views/PairingView.swift
@@ -14,6 +14,15 @@ struct PairingView: View {
     @State private var attemptingRecovery = false
     @State private var recoveryAttempted = false
 
+    // Discovery pulse animation
+    @State private var pulseScale: CGFloat = 1.0
+
+    // Code field focus
+    @FocusState private var codeFieldFocused: Bool
+
+    // Clipboard paste detection
+    @State private var clipboardHasCode = false
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
@@ -46,8 +55,25 @@ struct PairingView: View {
         Group {
             if browser.discoveredHosts.isEmpty {
                 VStack(spacing: 16) {
-                    ProgressView()
-                        .scaleEffect(1.2)
+                    ZStack {
+                        Circle()
+                            .stroke(IonTheme.accent.opacity(0.3), lineWidth: 2)
+                            .frame(width: 80, height: 80)
+                            .scaleEffect(pulseScale)
+                            .opacity(2 - pulseScale)
+                        Circle()
+                            .stroke(IonTheme.accent.opacity(0.15), lineWidth: 2)
+                            .frame(width: 80, height: 80)
+                            .scaleEffect(pulseScale * 0.7 + 0.3)
+                            .opacity(2 - pulseScale)
+                        ProgressView()
+                            .scaleEffect(1.2)
+                    }
+                    .onAppear {
+                        withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: false)) {
+                            pulseScale = 1.8
+                        }
+                    }
                     Text("Searching your network...")
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -92,8 +118,10 @@ struct PairingView: View {
         } label: {
             HStack {
                 Image(systemName: icon)
-                    .foregroundStyle(Color(hex: 0x4ECDC4))
-                    .frame(width: 24)
+                    .font(.caption)
+                    .foregroundStyle(IonTheme.accent)
+                    .frame(width: 28, height: 28)
+                    .background(IonTheme.accent.opacity(0.12), in: Circle())
                 VStack(alignment: .leading, spacing: 2) {
                     Text(service.name)
                         .font(.headline)
@@ -102,6 +130,14 @@ struct PairingView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
+                if viewModel.pairedDevices.contains(where: { $0.name == service.name }) {
+                    Text("Paired")
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.green.opacity(0.15), in: Capsule())
+                }
                 Image(systemName: "chevron.right")
                     .foregroundStyle(.tertiary)
             }
@@ -116,7 +152,7 @@ struct PairingView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "server.rack")
                         .font(.system(size: 40))
-                        .foregroundStyle(Color(hex: 0x4ECDC4))
+                        .foregroundStyle(IonTheme.accent)
                     Text(service.name)
                         .font(.title2.bold())
                     Text("\(service.host):\(service.port)")
@@ -157,7 +193,7 @@ struct PairingView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "desktopcomputer")
                         .font(.system(size: 40))
-                        .foregroundStyle(Color(hex: 0x4ECDC4))
+                        .foregroundStyle(IonTheme.accent)
                     Text(service.name)
                         .font(.title2.bold())
                     Text("\(service.host):\(service.port)")
@@ -182,13 +218,48 @@ struct PairingView: View {
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
 
-                        TextField("000000", text: $pairingCodeInput)
+                        HStack(spacing: 8) {
+                            ForEach(0..<6, id: \.self) { index in
+                                let char = index < pairingCodeInput.count
+                                    ? String(pairingCodeInput[pairingCodeInput.index(pairingCodeInput.startIndex, offsetBy: index)])
+                                    : ""
+                                Text(char)
+                                    .font(.system(.title, design: .monospaced))
+                                    .frame(width: 40, height: 52)
+                                    .background(Color(.tertiarySystemFill))
+                                    .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.small))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: IonTheme.Radius.small)
+                                            .stroke(index == pairingCodeInput.count ? IonTheme.accent : Color(.separator), lineWidth: index == pairingCodeInput.count ? 2 : 1)
+                                    )
+                            }
+                        }
+
+                        // Hidden text field to capture input
+                        TextField("", text: $pairingCodeInput)
                             .keyboardType(.numberPad)
-                            .font(.system(.largeTitle, design: .monospaced))
-                            .multilineTextAlignment(.center)
-                            .frame(maxWidth: 200)
-                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 1, height: 1)
+                            .opacity(0.01)
+                            .focused($codeFieldFocused)
+                            .onChange(of: pairingCodeInput) { _, newValue in
+                                // Limit to 6 digits
+                                let filtered = String(newValue.prefix(6).filter(\.isNumber))
+                                if filtered != newValue { pairingCodeInput = filtered }
+                            }
+
+                        if clipboardHasCode, let clip = UIPasteboard.general.string {
+                            Button {
+                                pairingCodeInput = String(clip.prefix(6))
+                                clipboardHasCode = false
+                            } label: {
+                                Label("Paste \(clip.prefix(6))", systemImage: "doc.on.clipboard")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.bordered)
+                            .tint(IonTheme.accent)
+                        }
                     }
+                    .onTapGesture { codeFieldFocused = true }
                     .padding(.horizontal)
 
                     Button {
@@ -202,10 +273,10 @@ struct PairingView: View {
                         Text("Pair")
                             .font(.headline)
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
+                            .padding(.vertical, 14)
                     }
                     .buttonStyle(.borderedProminent)
-                    .tint(Color(hex: 0x4ECDC4))
+                    .tint(IonTheme.accent)
                     .disabled(pairingCodeInput.count != 6 || viewModel.pairingState.isConnecting)
                     .padding(.horizontal, 40)
 
@@ -226,7 +297,10 @@ struct PairingView: View {
                 }
             }
             .onChange(of: viewModel.pairedDevices.count) { oldCount, newCount in
-                if newCount > oldCount { selectedService = nil }
+                if newCount > oldCount {
+                    Haptic.success()
+                    selectedService = nil
+                }
             }
             .task {
                 // Auto-attempt codeless recovery before showing code entry.
@@ -249,6 +323,15 @@ struct PairingView: View {
             }
         }
         .presentationDetents([.medium])
+        .onAppear {
+            if let clip = UIPasteboard.general.string,
+               clip.count == 6, clip.allSatisfy(\.isNumber) {
+                clipboardHasCode = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if !attemptingRecovery { codeFieldFocused = true }
+            }
+        }
     }
 
     // MARK: - Status Indicator

--- a/ios/IonRemote/Views/PairingView.swift
+++ b/ios/IonRemote/Views/PairingView.swift
@@ -225,8 +225,8 @@ struct PairingView: View {
                     }
                 }
             }
-            .onChange(of: viewModel.pairedDevices.count) { _, count in
-                if count > 0 { selectedService = nil }
+            .onChange(of: viewModel.pairedDevices.count) { oldCount, newCount in
+                if newCount > oldCount { selectedService = nil }
             }
             .task {
                 // Auto-attempt codeless recovery before showing code entry.

--- a/ios/IonRemote/Views/PermissionCardView.swift
+++ b/ios/IonRemote/Views/PermissionCardView.swift
@@ -23,6 +23,8 @@ struct PermissionCardGenericView: View {
     let tabId: String
     let request: PermissionRequest
 
+    @State private var dragOffset: CGFloat = 0
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text(request.toolName)
@@ -41,7 +43,7 @@ struct PermissionCardGenericView: View {
             HStack(spacing: 12) {
                 ForEach(request.options) { option in
                     Button {
-                        triggerHaptic()
+                        Haptic.medium()
                         viewModel.respondPermission(
                             tabId: tabId,
                             questionId: request.questionId,
@@ -51,7 +53,7 @@ struct PermissionCardGenericView: View {
                         Text(option.label)
                             .font(.subheadline.weight(.semibold))
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, 10)
+                            .padding(.vertical, 12)
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(buttonTint(for: option))
@@ -59,10 +61,22 @@ struct PermissionCardGenericView: View {
             }
         }
         .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(.ultraThickMaterial)
-                .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+        .cardStyle()
+        .offset(y: dragOffset)
+        .gesture(
+            DragGesture(minimumDistance: 20)
+                .onChanged { value in
+                    if value.translation.height > 0 {
+                        dragOffset = value.translation.height
+                    }
+                }
+                .onEnded { value in
+                    if value.translation.height > 80 {
+                        Haptic.medium()
+                        dismissAsDeny()
+                    }
+                    withAnimation(IonTheme.snappySpring) { dragOffset = 0 }
+                }
         )
     }
 
@@ -73,12 +87,28 @@ struct PermissionCardGenericView: View {
         if label.contains("deny") || label.contains("reject") || label.contains("no") {
             return .red
         }
-        return Color(hex: 0x4ECDC4)
+        return IonTheme.accent
     }
 
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
+    /// Finds the deny/reject/no option and responds with it, or dismisses the card.
+    private func dismissAsDeny() {
+        let denyOption = request.options.first { option in
+            let label = option.label.lowercased()
+            return label.contains("deny") || label.contains("reject") || label.contains("no")
+        }
+        if let denyOption {
+            viewModel.respondPermission(
+                tabId: tabId,
+                questionId: request.questionId,
+                optionId: denyOption.id
+            )
+        } else if let firstOption = request.options.first {
+            viewModel.respondPermission(
+                tabId: tabId,
+                questionId: request.questionId,
+                optionId: firstOption.id
+            )
+        }
     }
 
     private func formatJSON(_ dict: [String: AnyCodable]) -> String {

--- a/ios/IonRemote/Views/PlanApprovalCardView.swift
+++ b/ios/IonRemote/Views/PlanApprovalCardView.swift
@@ -14,10 +14,12 @@ struct PlanApprovalCardView: View {
         VStack(alignment: .leading, spacing: 12) {
             // Header
             HStack(spacing: 6) {
-                Image(systemName: "checkmark.seal.fill")
-                    .foregroundStyle(.green)
                 Text("Plan Ready")
-                    .font(.headline)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.green)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Color.green.opacity(0.15), in: Capsule())
                 Spacer()
                 if planContent != nil {
                     Button { showFullPlan = true } label: {
@@ -37,27 +39,32 @@ struct PlanApprovalCardView: View {
                 .frame(maxHeight: 300)
                 .background(Color(.tertiarySystemFill))
                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                .mask(
+                    VStack(spacing: 0) {
+                        LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
+                            .frame(height: 8)
+                        Color.black
+                        LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+                            .frame(height: 8)
+                    }
+                )
             }
 
             // Action buttons
             Button {
-                triggerHaptic()
+                Haptic.medium()
                 implement()
             } label: {
                 Text("Implement")
                     .font(.subheadline.weight(.semibold))
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 10)
+                    .padding(.vertical, 14)
             }
             .buttonStyle(.borderedProminent)
             .tint(.green)
         }
         .padding()
-        .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(.ultraThickMaterial)
-                .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
-        )
+        .cardStyle()
         .fullScreenCover(isPresented: $showFullPlan) {
             if let content = planContent {
                 PlanFullScreenView(content: content)
@@ -83,10 +90,5 @@ struct PlanApprovalCardView: View {
             .font(.caption)
             .textSelection(.enabled)
             .padding(8)
-    }
-
-    private func triggerHaptic() {
-        let generator = UIImpactFeedbackGenerator(style: .medium)
-        generator.impactOccurred()
     }
 }

--- a/ios/IonRemote/Views/SettingsView.swift
+++ b/ios/IonRemote/Views/SettingsView.swift
@@ -171,6 +171,10 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            NavigationLink("Diagnostic Log") {
+                DiagnosticLogView()
+            }
+
             Button(role: .destructive) {
                 dismiss()
                 viewModel.resetAll()

--- a/ios/IonRemote/Views/SettingsView.swift
+++ b/ios/IonRemote/Views/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
         NavigationStack {
             List {
                 connectionSection
+                diagnosticsSection
                 newTabSection
                 tabGroupsSection
                 pairedDevicesSection
@@ -37,6 +38,14 @@ struct SettingsView: View {
         }
     }
 
+    private var transportLabel: String {
+        switch viewModel.transportState {
+        case .lanPreferred: return "LAN (Bonjour)"
+        case .relayOnly: return "Relay (WebSocket)"
+        case .disconnected: return "Disconnected"
+        }
+    }
+
     // MARK: - Sections
 
     @ViewBuilder
@@ -61,6 +70,37 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
+            }
+        }
+    }
+
+    private var diagnosticsSection: some View {
+        Section("Diagnostics") {
+            HStack {
+                Label("Transport", systemImage: "antenna.radiowaves.left.and.right")
+                Spacer()
+                Text(transportLabel)
+                    .foregroundStyle(.secondary)
+            }
+            if let latency = viewModel.connectionQuality.latencyLabel {
+                HStack {
+                    Label("Latency", systemImage: "timer")
+                    Spacer()
+                    Text(latency)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            HStack {
+                Label("Buffered", systemImage: "tray.full")
+                Spacer()
+                Text("\(viewModel.connectionQuality.lastBuffered)")
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Label("Signal", systemImage: "wifi")
+                Spacer()
+                Text(viewModel.connectionQuality.signalLevel.label)
+                    .foregroundStyle(.secondary)
             }
         }
     }
@@ -128,10 +168,12 @@ struct SettingsView: View {
                                 if isActive {
                                     Text("Active")
                                         .font(.caption2)
-                                        .foregroundStyle(.white)
+                                        .foregroundStyle(.green)
                                         .padding(.horizontal, 6)
                                         .padding(.vertical, 2)
-                                        .background(Color.green, in: Capsule())
+                                        .background(
+                                            Capsule().stroke(Color.green, lineWidth: 1)
+                                        )
                                 }
                             }
                             Text("Paired \(device.pairedAt.formatted(date: .abbreviated, time: .shortened))")
@@ -144,6 +186,20 @@ struct SettingsView: View {
                             }
                         }
                         Spacer()
+                        Circle()
+                            .fill(isActive && viewModel.connectionState == .connected ? Color.green : Color(.tertiaryLabel))
+                            .frame(width: 8, height: 8)
+                    }
+                    .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                        if !isActive {
+                            Button {
+                                viewModel.switchToDevice(id: device.id)
+                                Haptic.success()
+                            } label: {
+                                Label("Switch to", systemImage: "arrow.right.arrow.left")
+                            }
+                            .tint(IonTheme.accent)
+                        }
                     }
                 }
                 .onDelete { offsets in
@@ -165,11 +221,20 @@ struct SettingsView: View {
     private var aboutSection: some View {
         Section("About") {
             HStack {
-                Text("Version")
                 Spacer()
-                Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
-                    .foregroundStyle(.secondary)
+                VStack(spacing: 8) {
+                    Image(systemName: "bolt.shield.fill")
+                        .font(.system(size: 40))
+                        .foregroundStyle(IonTheme.accent)
+                    Text("Ion Remote")
+                        .font(.headline)
+                    Text("v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
             }
+            .listRowBackground(Color.clear)
 
             NavigationLink("Diagnostic Log") {
                 DiagnosticLogView()
@@ -179,8 +244,16 @@ struct SettingsView: View {
                 dismiss()
                 viewModel.resetAll()
             } label: {
-                Text("Unpair All Devices")
+                HStack {
+                    Spacer()
+                    Text("Unpair All Devices")
+                        .font(.subheadline.weight(.medium))
+                    Spacer()
+                }
             }
+            .buttonStyle(.bordered)
+            .tint(.red)
+            .listRowBackground(Color.clear)
         }
     }
 }

--- a/ios/IonRemote/Views/SettingsView.swift
+++ b/ios/IonRemote/Views/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(SessionViewModel.self) private var viewModel
     @Environment(\.dismiss) private var dismiss
+    @State private var showPairingSheet = false
     var body: some View {
         NavigationStack {
             List {
@@ -18,6 +19,9 @@ struct SettingsView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Done") { dismiss() }
                 }
+            }
+            .sheet(isPresented: $showPairingSheet) {
+                PairingView()
             }
         }
     }
@@ -109,23 +113,37 @@ struct SettingsView: View {
     }
 
     private var pairedDevicesSection: some View {
-        Section("Paired Device") {
+        Section("Paired Desktops") {
             if viewModel.pairedDevices.isEmpty {
                 Text("No paired devices")
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(viewModel.pairedDevices) { device in
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(device.name)
-                            .font(.headline)
-                        Text("Paired \(device.pairedAt.formatted(date: .abbreviated, time: .shortened))")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        if let lastSeen = device.lastSeen {
-                            Text("Last seen \(lastSeen.formatted(.relative(presentation: .named)))")
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
+                    let isActive = device.id == viewModel.activeDevice?.id
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(spacing: 6) {
+                                Text(device.name)
+                                    .font(.headline)
+                                if isActive {
+                                    Text("Active")
+                                        .font(.caption2)
+                                        .foregroundStyle(.white)
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 2)
+                                        .background(Color.green, in: Capsule())
+                                }
+                            }
+                            Text("Paired \(device.pairedAt.formatted(date: .abbreviated, time: .shortened))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            if let lastSeen = device.lastSeen {
+                                Text("Last seen \(lastSeen.formatted(.relative(presentation: .named)))")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
+                        Spacer()
                     }
                 }
                 .onDelete { offsets in
@@ -134,6 +152,12 @@ struct SettingsView: View {
                         viewModel.unpairDevice(device)
                     }
                 }
+            }
+
+            Button {
+                showPairingSheet = true
+            } label: {
+                Label("Pair New Desktop…", systemImage: "plus")
             }
         }
     }
@@ -151,7 +175,7 @@ struct SettingsView: View {
                 dismiss()
                 viewModel.resetAll()
             } label: {
-                Text("Unpair Device")
+                Text("Unpair All Devices")
             }
         }
     }

--- a/ios/IonRemote/Views/SlashCommandMenu.swift
+++ b/ios/IonRemote/Views/SlashCommandMenu.swift
@@ -42,7 +42,7 @@ struct SlashCommandMenu: View {
             }
             .frame(maxHeight: 260)
             .background(.ultraThinMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .clipShape(RoundedRectangle(cornerRadius: IonTheme.Radius.large))
             .shadow(color: .black.opacity(0.15), radius: 8, y: -2)
             .padding(.horizontal)
         }
@@ -78,9 +78,9 @@ struct SlashCommandMenu: View {
 
                     if !cmd.description.isEmpty {
                         Text(cmd.description)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
                     }
                 }
 
@@ -91,5 +91,6 @@ struct SlashCommandMenu: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .hoverEffect(.highlight)
     }
 }

--- a/ios/IonRemote/Views/TabListView.swift
+++ b/ios/IonRemote/Views/TabListView.swift
@@ -19,6 +19,15 @@ struct TabListView: View {
                             NavigationLink(value: tab.id) {
                                 TabRowView(tab: tab, showDirectory: viewModel.tabGroupMode == "manual")
                             }
+                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                Button {
+                                    renameText = tab.displayTitle
+                                    renamingTabId = tab.id
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
+                                .tint(.orange)
+                            }
                             .contextMenu {
                                 Button {
                                     renameText = tab.displayTitle
@@ -55,6 +64,7 @@ struct TabListView: View {
                                 .foregroundStyle(.secondary)
                             Spacer()
                             if let dir = group.directory {
+
                                 Button {
                                     viewModel.createTab(workingDirectory: dir)
                                 } label: {
@@ -81,6 +91,7 @@ struct TabListView: View {
                                 }
                             }
                         }
+                        .padding(.top, 4)
                     }
                 }
             }
@@ -138,9 +149,23 @@ struct TabListView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .contextMenu {
+                        if let defaultDir = allDirectories.first {
+                            Button { viewModel.createTab(workingDirectory: defaultDir.fullPath) } label: {
+                                Label("New Tab", systemImage: "plus")
+                            }
+                            Button { viewModel.createTerminalTab(workingDirectory: defaultDir.fullPath) } label: {
+                                Label("New Terminal", systemImage: "terminal")
+                            }
+                            Button { requestEngineTab(directory: defaultDir.fullPath) } label: {
+                                Label("New Engine", systemImage: "bolt.fill")
+                            }
+                        }
+                    }
                 }
             }
             .refreshable {
+                Haptic.light()
                 viewModel.sync()
             }
             .onChange(of: viewModel.pendingNavigationTabId) { _, tabId in
@@ -222,11 +247,18 @@ struct TabListView: View {
             }
             .overlay {
                 if viewModel.tabs.isEmpty {
-                    ContentUnavailableView(
-                        "No Tabs",
-                        systemImage: "terminal",
-                        description: Text("Tap + to create a new tab or pull to refresh.")
-                    )
+                    VStack(spacing: 12) {
+                        Image(systemName: "terminal")
+                            .font(.system(size: 40))
+                            .foregroundStyle(IonTheme.accent)
+                        Text("No Tabs")
+                            .font(.title3.weight(.semibold))
+                        Text("Tap + to create a new tab or pull to refresh.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
                 }
             }
         }
@@ -290,8 +322,9 @@ private struct TabRowView: View {
         HStack(spacing: 12) {
             Circle()
                 .fill(statusInfo.color)
-                .frame(width: 10, height: 10)
+                .frame(width: 8, height: 8)
                 .opacity(statusInfo.pulse ? pulseOpacity : 1.0)
+                .shadow(color: statusInfo.pulse ? statusInfo.color.opacity(0.6) : .clear, radius: 3)
                 .onChange(of: statusInfo.pulse) { _, shouldPulse in
                     if shouldPulse {
                         withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
@@ -332,6 +365,13 @@ private struct TabRowView: View {
                         .lineLimit(1)
                 }
 
+                if tab.status == .running || tab.status == .connecting {
+                    Text("Running…")
+                        .font(.caption2)
+                        .foregroundStyle(IonTheme.statusRunning)
+                        .lineLimit(1)
+                }
+
                 if let message = tab.lastMessage {
                     Text(message)
                         .font(.caption2)
@@ -341,6 +381,12 @@ private struct TabRowView: View {
             }
 
             Spacer()
+
+            if !tab.permissionQueue.isEmpty && tab.status != .running {
+                Circle()
+                    .fill(Color.orange)
+                    .frame(width: 6, height: 6)
+            }
         }
         .padding(.vertical, 4)
     }

--- a/ios/IonRemote/Views/TabListView.swift
+++ b/ios/IonRemote/Views/TabListView.swift
@@ -4,6 +4,7 @@ struct TabListView: View {
     @Environment(SessionViewModel.self) private var viewModel
     @State private var showSettings = false
     @State private var showNewTab = false
+    @State private var showPairingSheet = false
     @State private var navigationPath = NavigationPath()
     @State private var enginePickerDirectory: String? = nil
     @State private var renamingTabId: String?
@@ -83,7 +84,12 @@ struct TabListView: View {
                     }
                 }
             }
-            .navigationTitle("Ion")
+            .navigationTitle("")
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    DesktopPickerMenu(showPairingSheet: $showPairingSheet)
+                }
+            }
             .alert("Rename Tab", isPresented: .init(
                 get: { renamingTabId != nil },
                 set: { if !$0 { renamingTabId = nil } }
@@ -137,11 +143,6 @@ struct TabListView: View {
             .refreshable {
                 viewModel.sync()
             }
-            .onChange(of: viewModel.connectionState) { _, newState in
-                if newState == .disconnected {
-                    navigationPath = NavigationPath()
-                }
-            }
             .onChange(of: viewModel.pendingNavigationTabId) { _, tabId in
                 if let tabId {
                     navigationPath.append(tabId)
@@ -150,6 +151,9 @@ struct TabListView: View {
             }
             .sheet(isPresented: $showSettings) {
                 SettingsView()
+            }
+            .sheet(isPresented: $showPairingSheet) {
+                PairingView()
             }
             .sheet(isPresented: $showNewTab) {
                 NavigationStack {
@@ -227,6 +231,9 @@ struct TabListView: View {
             }
         }
     }
+
+    // MARK: - Reconnecting Indicator
+
 
     /// Handle engine tab creation with profile selection.
     /// - 0 profiles: auto-create without a profileId (engine uses default)

--- a/ios/IonRemote/Views/ToolGroupView.swift
+++ b/ios/IonRemote/Views/ToolGroupView.swift
@@ -10,6 +10,21 @@ struct ToolGroupView: View {
     var isTabRunning: Bool = false
 
     @State private var isExpanded = false
+    @State private var forceExpandAll: Bool?
+
+    // MARK: Composite accent color
+
+    private var compositeAccentColor: Color {
+        if tools.contains(where: { $0.toolStatus == .running }) {
+            return .orange
+        } else if tools.contains(where: { $0.toolStatus == .error }) {
+            return .red
+        } else if tools.allSatisfy({ $0.toolStatus == .completed }) {
+            return .green
+        } else {
+            return Color(.tertiaryLabel)
+        }
+    }
 
     // MARK: Body
 
@@ -25,46 +40,65 @@ struct ToolGroupView: View {
     // MARK: - Group card (2+ tools)
 
     private var groupCard: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header row — always visible.
-            Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.toggle()
-                }
-            } label: {
-                HStack(spacing: 8) {
-                    compositeStatusIcon
+        HStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(compositeAccentColor)
+                .frame(width: 2)
 
-                    if isExpanded {
-                        Text("Used \(tools.count) tools")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Text(toolGroupSummary(tools))
-                            .font(.subheadline.monospaced())
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
+            VStack(alignment: .leading, spacing: 0) {
+                // Header row — always visible.
+                Button {
+                    withAnimation(IonTheme.snappySpring) {
+                        isExpanded.toggle()
                     }
+                } label: {
+                    HStack(spacing: 8) {
+                        compositeStatusIcon
 
-                    Spacer()
+                        if isExpanded {
+                            Text("Used \(tools.count) tools")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text(toolGroupSummary(tools))
+                                .font(.subheadline.monospaced())
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                        }
 
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-            }
-            .buttonStyle(.plain)
+                        Spacer()
 
-            // Expanded: individual tool rows.
-            if isExpanded {
-                VStack(alignment: .leading, spacing: 0) {
-                    ForEach(tools) { tool in
-                        ToolItemRow(message: tool)
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
                     }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
                 }
-                .transition(.opacity.combined(with: .move(edge: .top)))
+                .buttonStyle(.plain)
+
+                // Expanded: individual tool rows.
+                if isExpanded {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(tools) { tool in
+                            ToolItemRow(message: tool, forceExpanded: forceExpandAll)
+                        }
+
+                        if tools.count >= 3 {
+                            Button {
+                                let newState = !(forceExpandAll ?? false)
+                                forceExpandAll = newState
+                            } label: {
+                                Text(forceExpandAll == true ? "Collapse all" : "Expand all")
+                                    .font(.caption2)
+                                    .foregroundStyle(IonTheme.accent)
+                            }
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
         }
         .background(Color(.tertiarySystemFill))
@@ -105,12 +139,13 @@ struct ToolGroupView: View {
 /// description, and can be tapped to reveal input/output.
 private struct ToolItemRow: View {
     let message: Message
+    var forceExpanded: Bool? = nil
     @State private var isDetailExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) {
+                withAnimation(IonTheme.snappySpring) {
                     isDetailExpanded.toggle()
                 }
             } label: {
@@ -168,6 +203,13 @@ private struct ToolItemRow: View {
         // Subtle separator between items (except the last).
         Divider()
             .padding(.horizontal, 12)
+            .onChange(of: forceExpanded) { _, val in
+                if let v = val {
+                    withAnimation(IonTheme.snappySpring) {
+                        isDetailExpanded = v
+                    }
+                }
+            }
     }
 
     private var itemStatusIcon: some View {

--- a/relay/main.go
+++ b/relay/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"os"
@@ -102,6 +103,19 @@ func main() {
 		}
 
 		hub.HandleWebSocket(w, r, channelID, role, pusher)
+	})
+
+	mux.HandleFunc("GET /v1/channel/{channelId}/status", func(w http.ResponseWriter, r *http.Request) {
+		if !auth.Validate(r) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		channelID := r.PathValue("channelId")
+		ion, mobile := hub.ChannelStatus(channelID)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]bool{"ion": ion, "mobile": mobile}); err != nil {
+			log.Printf("channel status: encode error: %v", err)
+		}
 	})
 
 	server := &http.Server{

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -92,6 +92,19 @@ func (h *Hub) ChannelCount() int {
 	return len(h.channels)
 }
 
+// ChannelStatus returns whether the ion and mobile roles are connected for a channel.
+func (h *Hub) ChannelStatus(channelID string) (ionConnected, mobileConnected bool) {
+	h.mu.RLock()
+	ch, ok := h.channels[channelID]
+	h.mu.RUnlock()
+	if !ok {
+		return false, false
+	}
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+	return ch.ion != nil, ch.mobile != nil
+}
+
 // controlMessage is a relay-originated control frame.
 type controlMessage struct {
 	Type string `json:"type"`


### PR DESCRIPTION
- **feat(relay): add channel status endpoint for peer polling**
- **feat(ios): multi-desktop pairing, layout cache, graceful reconnect**
- **fix(ios): prevent relay_config from corrupting lan-direct devices**
- **feat(ios): add on-device diagnostic log for wireless debugging**
- **feat(ios): add design system and app-wide visual polish**
- **fix(ios): flatten auth to single iterator, add LAN diagnostic logging**
