### PR TITLE
fix(ios): raise WebSocket maximumMessageSize to 16 Mi

### DIFF
--- a/ios/IonRemote/Networking/LANClient.swift
+++ b/ios/IonRemote/Networking/LANClient.swift
@@ -81,6 +81,10 @@ final class LANClient {
         let urlSession = URLSession(configuration: .default)
         self.session = urlSession
         let wsTask = urlSession.webSocketTask(with: url)
+        // Default maximumMessageSize is 1 MiB. Encrypted snapshots with
+        // many tabs or large plan files can exceed that, causing an
+        // EMSGSIZE ("Message too long") receive failure.
+        wsTask.maximumMessageSize = 16 * 1024 * 1024
         self.task = wsTask
 
         wsTask.resume()

--- a/ios/IonRemote/Networking/RelayClient.swift
+++ b/ios/IonRemote/Networking/RelayClient.swift
@@ -144,6 +144,9 @@ final class RelayClient {
         let urlSession = URLSession(configuration: .default)
         self.session = urlSession
         let wsTask = urlSession.webSocketTask(with: request)
+        // Default maximumMessageSize is 1 MiB. Encrypted snapshots can
+        // exceed that, causing EMSGSIZE ("Message too long").
+        wsTask.maximumMessageSize = 16 * 1024 * 1024
         self.task = wsTask
 
         wsTask.resume()

--- a/ios/IonRemote/Views/TabListView.swift
+++ b/ios/IonRemote/Views/TabListView.swift
@@ -381,12 +381,6 @@ private struct TabRowView: View {
             }
 
             Spacer()
-
-            if !tab.permissionQueue.isEmpty && tab.status != .running {
-                Circle()
-                    .fill(Color.orange)
-                    .frame(width: 6, height: 6)
-            }
         }
         .padding(.vertical, 4)
     }


### PR DESCRIPTION
- **fix(ios): raise WebSocket maximumMessageSize to 16 MiB**
- **fix(ios): remove redundant permission badge from tab rows**
