### PR TITLE
feat(ios): ElevenLabs TTS — speak assistant responses aloud

### DIFF
--- a/ios/IonRemote/Services/VoiceService.swift
+++ b/ios/IonRemote/Services/VoiceService.swift
@@ -1,0 +1,130 @@
+import AVFoundation
+import Foundation
+import Observation
+
+// MARK: - VoiceService
+
+@Observable
+@MainActor
+final class VoiceService {
+
+    var isEnabled: Bool = UserDefaults.standard.bool(forKey: "voiceEnabled") {
+        didSet { UserDefaults.standard.set(isEnabled, forKey: "voiceEnabled") }
+    }
+
+    private(set) var isSpeaking = false
+
+    private var audioPlayer: AVAudioPlayer?
+    private var speakTask: Task<Void, Never>?
+    private var pendingText: String?
+
+    private static let keychainService = "com.ion.remote.elevenlabs"
+    private static let voiceID = "21m00Tcm4TlvDq8ikWAM"  // Rachel (default)
+    private static let modelID = "eleven_turbo_v2_5"
+
+    private var apiKey: String? {
+        KeychainHelper.get(VoiceService.keychainService)
+    }
+
+    func speak(text: String) {
+        let cleaned = stripMarkdown(text)
+        guard isEnabled, !cleaned.isEmpty else { return }
+        if isSpeaking {
+            // Replace any earlier queued text; current audio finishes naturally.
+            pendingText = cleaned
+        } else {
+            pendingText = nil
+            speakTask = Task { await self.performSpeak(cleaned) }
+        }
+    }
+
+    func stop() {
+        speakTask?.cancel()
+        speakTask = nil
+        audioPlayer?.stop()
+        audioPlayer = nil
+        isSpeaking = false
+        pendingText = nil
+    }
+
+    // MARK: - Private
+
+    private func performSpeak(_ text: String) async {
+        isSpeaking = true
+        defer {
+            isSpeaking = false
+            if !Task.isCancelled, let pending = pendingText {
+                pendingText = nil
+                speakTask = Task { await self.performSpeak(pending) }
+            }
+        }
+
+        guard let audioData = await fetchAudio(text) else { return }
+        guard !Task.isCancelled else { return }
+
+        do {
+            #if os(iOS)
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default, options: .duckOthers)
+            try session.setActive(true)
+            defer {
+                try? session.setActive(false, options: .notifyOthersOnDeactivation)
+            }
+            #endif
+            audioPlayer = try AVAudioPlayer(data: audioData)
+            audioPlayer?.prepareToPlay()
+            audioPlayer?.play()
+            while audioPlayer?.isPlaying == true {
+                guard !Task.isCancelled else {
+                    audioPlayer?.stop()
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+        } catch {
+            #if DEBUG
+            print("[VoiceService] playback error: \(error)")
+            #endif
+        }
+
+        audioPlayer = nil
+    }
+
+    private func fetchAudio(_ text: String) async -> Data? {
+        guard let key = apiKey, !key.isEmpty else { return nil }
+        guard let url = URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(Self.voiceID)") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("audio/mpeg", forHTTPHeaderField: "Accept")
+        request.setValue(key, forHTTPHeaderField: "xi-api-key")
+
+        let body: [String: Any] = [
+            "text": text,
+            "model_id": Self.modelID,
+            "voice_settings": ["stability": 0.5, "similarity_boost": 0.75],
+        ]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return nil }
+        request.httpBody = bodyData
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+            return data
+        } catch {
+            return nil
+        }
+    }
+
+    private func stripMarkdown(_ text: String) -> String {
+        var s = text
+        s = s.replacingOccurrences(of: #"```[\s\S]*?```"#, with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"`[^`\n]+`"#, with: " ", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"\*{1,3}([^*\n]+)\*{1,3}"#, with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"(?m)^#{1,6}\s+"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"\[([^\]]+)\]\([^\)]+\)"#, with: "$1", options: .regularExpression)
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/ios/IonRemote/Utilities/KeychainHelper.swift
+++ b/ios/IonRemote/Utilities/KeychainHelper.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Security
+
+enum KeychainHelper {
+    static func set(_ value: String, service: String) {
+        let data = Data(value.utf8)
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+        ]
+        SecItemDelete(query as CFDictionary)
+        let insert: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        SecItemAdd(insert as CFDictionary, nil)
+    }
+
+    static func get(_ service: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func delete(_ service: String) {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios/IonRemote/ViewModels/SessionViewModel+EngineEvents.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EngineEvents.swift
@@ -67,6 +67,7 @@ extension SessionViewModel {
             msgs.append(EngineMessage(id: UUID().uuidString, role: "assistant", content: text, timestamp: Date().timeIntervalSince1970 * 1000))
         }
         engineMessages[key] = msgs
+        engineTurnHasText.insert(key)
         // Set tab running if this is the active instance
         let isActive = activeEngineInstance[tabId] == instanceId || (instanceId == nil)
         if isActive, let idx = tabs.firstIndex(where: { $0.id == tabId }) {
@@ -88,6 +89,16 @@ extension SessionViewModel {
             tabs[idx].contextTokens = inputTokens
             tabs[idx].contextPercent = contextPercent
         }
+        // Only speak if this LLM sub-turn produced text — prevents re-speaking the
+        // previous turn's response when the current sub-turn only used tools.
+        if engineTurnHasText.contains(key),
+           let lastAssistant = engineMessages[key]?.last(where: { $0.role == "assistant" }),
+           !lastAssistant.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           lastAssistant.content.count > 20
+        {
+            voiceService.speak(text: lastAssistant.content)
+        }
+        engineTurnHasText.remove(key)
     }
 
     @MainActor
@@ -128,5 +139,6 @@ extension SessionViewModel {
         activeTools.removeValue(forKey: removedKey)
         engineMessages.removeValue(forKey: removedKey)
         engineConversationLoaded.remove(removedKey)
+        engineTurnHasText.remove(removedKey)
     }
 }

--- a/ios/IonRemote/ViewModels/SessionViewModel.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel.swift
@@ -151,6 +151,7 @@ final class SessionViewModel {
     // Engine conversation messages (per compound key)
     var engineMessages: [String: [EngineMessage]] = [:]         // compoundKey -> messages
     var engineConversationLoaded: Set<String> = []               // compoundKeys that have loaded history
+    var engineTurnHasText: Set<String> = []                      // compoundKeys where current LLM sub-turn produced text
     // Engine instance state (per engine tab)
     var engineInstances: [String: [EngineInstanceInfo]] = [:]   // tabId -> instances
     var activeEngineInstance: [String: String] = [:]              // tabId -> active instanceId
@@ -292,7 +293,6 @@ final class SessionViewModel {
     /// Tabs grouped by working directory basename, preserving original order within each group.
     /// Duplicate basenames are disambiguated with the parent directory name.
     var tabsByDirectory: [(directory: String, fullPath: String, tabs: [RemoteTabState])] {
-        // Build ordered groups preserving tab order
         var order: [String] = []
         var groups: [String: [RemoteTabState]] = [:]
         for tab in tabs {
@@ -303,7 +303,6 @@ final class SessionViewModel {
             groups[key, default: []].append(tab)
         }
 
-        // Count how many distinct full paths share each basename
         var basenameCounts: [String: Int] = [:]
         for path in order {
             let base = (path as NSString).lastPathComponent
@@ -357,6 +356,10 @@ final class SessionViewModel {
             return (label: g.label, id: g.id, icon: "tray.2.fill", directory: dir, tabs: gTabs)
         }
     }
+
+    // MARK: - Voice
+
+    let voiceService = VoiceService()
 
     // MARK: - Init
 

--- a/ios/IonRemote/Views/SettingsView.swift
+++ b/ios/IonRemote/Views/SettingsView.swift
@@ -4,10 +4,12 @@ struct SettingsView: View {
     @Environment(SessionViewModel.self) private var viewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showPairingSheet = false
+    @State private var elevenLabsKey: String = ""
     var body: some View {
         NavigationStack {
             List {
                 connectionSection
+                voiceSection
                 diagnosticsSection
                 newTabSection
                 tabGroupsSection
@@ -47,6 +49,36 @@ struct SettingsView: View {
     }
 
     // MARK: - Sections
+
+    private var voiceSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { viewModel.voiceService.isEnabled },
+                set: { viewModel.voiceService.isEnabled = $0 }
+            )) {
+                Label("Voice Responses", systemImage: "waveform")
+            }
+            SecureField("ElevenLabs API Key", text: $elevenLabsKey)
+                .textContentType(.password)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            Button("Save Key") {
+                if elevenLabsKey.trimmingCharacters(in: .whitespaces).isEmpty {
+                    KeychainHelper.delete("com.ion.remote.elevenlabs")
+                } else {
+                    KeychainHelper.set(elevenLabsKey, service: "com.ion.remote.elevenlabs")
+                }
+            }
+            .foregroundStyle(IonTheme.accent)
+        } header: {
+            Text("Voice")
+        } footer: {
+            Text(viewModel.voiceService.isEnabled ? "Ion will speak assistant responses aloud." : "Voice is off.")
+        }
+        .onAppear {
+            elevenLabsKey = KeychainHelper.get("com.ion.remote.elevenlabs") ?? ""
+        }
+    }
 
     @ViewBuilder
     private var connectionSection: some View {


### PR DESCRIPTION
## Summary

Adds opt-in text-to-speech to Ion Remote using the ElevenLabs API. When enabled, the app speaks each complete assistant response aloud after `engine_message_end` fires. Off by default. API key stored in the iOS Keychain — never in UserDefaults or on disk.

- **`VoiceService`** — `@Observable @MainActor` service that streams audio from ElevenLabs. Queue model: new responses replace pending ones, current audio finishes naturally. Strips markdown before sending. Uses `AVAudioSession.playback` + `.duckOthers` so system audio is respected.
- **`KeychainHelper`** — generic `kSecClassGenericPassword` wrapper (set / get / delete) keyed by service string.
- **`SessionViewModel`** — adds `let voiceService = VoiceService()` and `var engineTurnHasText: Set<String>`. The set tracks which compound keys produced assistant text in the current sub-turn, preventing re-speaking the prior response when a tool-only sub-turn fires `engine_message_end`.
- **`SessionViewModel+EngineEvents`** — `handleEngineTextDelta` marks the key in `engineTurnHasText`; `handleEngineMessageEnd` calls `voiceService.speak()` only when the flag is set and the response is non-trivial (>20 chars). Cleans up on instance removal.
- **`SettingsView`** — new **Voice** section: toggle, `SecureField` for the API key, Save button that writes to / clears the Keychain.

## New files

| File | Purpose |
|------|---------|
| `ios/IonRemote/Services/VoiceService.swift` | ElevenLabs streaming TTS |
| `ios/IonRemote/Utilities/KeychainHelper.swift` | Generic Keychain wrapper |

## Modified files

| File | Change |
|------|--------|
| `ios/IonRemote/Views/SettingsView.swift` | Voice section (toggle + API key field) |
| `ios/IonRemote/ViewModels/SessionViewModel.swift` | `voiceService` + `engineTurnHasText` |
| `ios/IonRemote/ViewModels/SessionViewModel+EngineEvents.swift` | Speak call + turn-text guard |

## Design notes

- **No key = silent.** If no ElevenLabs key is saved, `VoiceService` returns without making a network call.
- **Queue model.** `speak()` replaces any pending (not yet started) text; audio already playing finishes before the queued text starts.
- **Minimum length guard.** Responses under 20 characters are skipped — avoids speaking one-word tool acknowledgements.
- **Voice / model defaults.** `voiceID = "21m00Tcm4TlvDq8ikWAM"` (Rachel), `modelID = "eleven_turbo_v2_5"` — both are top-level constants in `VoiceService`, easy to swap.

## Test plan

- [ ] Build with no ElevenLabs key — Voice section visible in Settings, no crash, no network call on assistant response
- [ ] Save a valid key, enable toggle — next complete assistant response plays aloud
- [ ] Tool-only sub-turn (agent calls a tool, no text delta) — no audio fires
- [ ] Long response interrupted by a new one — first audio stops, second queues and plays
- [ ] Clear key via empty Save — Keychain entry removed, subsequent responses are silent