### PR TITLE
fix(ios): improve voice TTS trigger and simplify settings UI

### DIFF
--- a/ios/IonRemote/ViewModels/SessionViewModel+EngineEvents.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EngineEvents.swift
@@ -89,15 +89,7 @@ extension SessionViewModel {
             tabs[idx].contextTokens = inputTokens
             tabs[idx].contextPercent = contextPercent
         }
-        // Only speak if this LLM sub-turn produced text — prevents re-speaking the
-        // previous turn's response when the current sub-turn only used tools.
-        if engineTurnHasText.contains(key),
-           let lastAssistant = engineMessages[key]?.last(where: { $0.role == "assistant" }),
-           !lastAssistant.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
-           lastAssistant.content.count > 20
-        {
-            voiceService.speak(text: lastAssistant.content)
-        }
+
         engineTurnHasText.remove(key)
     }
 

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -428,15 +428,13 @@ extension SessionViewModel {
             activeTools.removeValue(forKey: key)
         }
 
-        // Voice: speak the final assistant message if this engine turn produced text
-        let compoundKey = engineCompoundKey(tabId: tabId)
-        if engineTurnHasText.contains(compoundKey),
-           let msgs = engineMessages[compoundKey],
-           let lastAssistant = msgs.last(where: { $0.role == "assistant" }),
-           !lastAssistant.content.isEmpty {
+        // Speak the final assistant response via TTS (if voice is enabled)
+        let key = engineCompoundKey(tabId: tabId)
+        if let lastAssistant = engineMessages[key]?.last(where: { $0.role == "assistant" }),
+           !lastAssistant.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           lastAssistant.content.count > 20 {
             voiceService.speak(text: lastAssistant.content)
         }
-        engineTurnHasText.remove(compoundKey)
     }
 
     // MARK: - Permission/message events

--- a/ios/IonRemote/Views/SettingsView.swift
+++ b/ios/IonRemote/Views/SettingsView.swift
@@ -5,15 +5,15 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showPairingSheet = false
     @State private var elevenLabsKey: String = ""
-    @State private var showApiKey = false
+
     var body: some View {
         NavigationStack {
             List {
                 connectionSection
+                voiceSection
                 diagnosticsSection
                 newTabSection
                 modelsSection
-                voiceSection
                 tabGroupsSection
                 pairedDevicesSection
                 aboutSection
@@ -27,9 +27,6 @@ struct SettingsView: View {
             }
             .sheet(isPresented: $showPairingSheet) {
                 PairingView()
-            }
-            .onAppear {
-                elevenLabsKey = KeychainHelper.get("com.ion.remote.elevenlabs") ?? ""
             }
         }
     }
@@ -54,6 +51,36 @@ struct SettingsView: View {
     }
 
     // MARK: - Sections
+
+    private var voiceSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { viewModel.voiceService.isEnabled },
+                set: { viewModel.voiceService.isEnabled = $0 }
+            )) {
+                Label("Voice Responses", systemImage: "waveform")
+            }
+            SecureField("ElevenLabs API Key", text: $elevenLabsKey)
+                .textContentType(.password)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            Button("Save Key") {
+                if elevenLabsKey.trimmingCharacters(in: .whitespaces).isEmpty {
+                    KeychainHelper.delete("com.ion.remote.elevenlabs")
+                } else {
+                    KeychainHelper.set(elevenLabsKey, service: "com.ion.remote.elevenlabs")
+                }
+            }
+            .foregroundStyle(IonTheme.accent)
+        } header: {
+            Text("Voice")
+        } footer: {
+            Text(viewModel.voiceService.isEnabled ? "Ion will speak assistant responses aloud." : "Voice is off.")
+        }
+        .onAppear {
+            elevenLabsKey = KeychainHelper.get("com.ion.remote.elevenlabs") ?? ""
+        }
+    }
 
     @ViewBuilder
     private var connectionSection: some View {
@@ -150,56 +177,6 @@ struct SettingsView: View {
                     Text(model.label).tag(model.id)
                 }
             }
-        }
-    }
-
-    private var voiceSection: some View {
-        Section {
-            Toggle("Voice Readback", isOn: Binding<Bool>(
-                get: { viewModel.voiceService.isEnabled },
-                set: { viewModel.voiceService.isEnabled = $0 }
-            ))
-            if viewModel.voiceService.isEnabled {
-                HStack {
-                    Label("API Key", systemImage: "key")
-                    Spacer()
-                    if showApiKey {
-                        TextField("xi-...", text: $elevenLabsKey)
-                            .textContentType(.password)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                            .multilineTextAlignment(.trailing)
-                            .font(.system(.caption, design: .monospaced))
-                    } else {
-                        Text(elevenLabsKey.isEmpty ? "Not set" : "••••••\(elevenLabsKey.suffix(4))")
-                            .foregroundStyle(.secondary)
-                    }
-                    Button {
-                        showApiKey.toggle()
-                    } label: {
-                        Image(systemName: showApiKey ? "eye.slash" : "eye")
-                            .font(.caption)
-                    }
-                    .buttonStyle(.borderless)
-                }
-                if showApiKey {
-                    Button("Save API Key") {
-                        let trimmed = elevenLabsKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if trimmed.isEmpty {
-                            KeychainHelper.delete("com.ion.remote.elevenlabs")
-                        } else {
-                            KeychainHelper.set(trimmed, service: "com.ion.remote.elevenlabs")
-                        }
-                        elevenLabsKey = trimmed
-                        showApiKey = false
-                    }
-                    .disabled(elevenLabsKey.trimmingCharacters(in: .whitespacesAndNewlines) == (KeychainHelper.get("com.ion.remote.elevenlabs") ?? ""))
-                }
-            }
-        } header: {
-            Text("Voice")
-        } footer: {
-            Text("Speaks the final assistant response when a task completes. Requires an ElevenLabs API key.")
         }
     }
 


### PR DESCRIPTION
## Summary

Patches and enhances the ElevenLabs voice TTS feature merged in #85/#94.

### Changes

**Voice trigger logic:**
- Removes the duplicate speak call from `engine_message_end` — voice now fires only on `task_complete`
- Drops the `engineTurnHasText` guard at the sub-turn level (unnecessary now that speak only happens at task completion)
- Adds content-length threshold (>20 chars) and whitespace trimming to avoid speaking empty/trivial responses

**Settings UI cleanup:**
- Replaces the show/hide API key toggle with a native `SecureField` (simpler, more iOS-standard)
- Promotes voice section above diagnostics in settings order
- Scopes `onAppear` keychain load to the voice section instead of the entire view
- Removes unused `showApiKey` state variable

### Files changed
- `SessionViewModel+EngineEvents.swift` — remove speak call from `handleEngineStatusUpdate`
- `SessionViewModel+EventHandlers.swift` — rewrite speak logic in `handleEngineTaskComplete`
- `SettingsView.swift` — simplified voice settings section