### PR TITLE
fix(desktop): add NSLocalNetworkUsageDescription and log connect errors

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -99,7 +99,8 @@
         "NSAppleEventsUsageDescription": "Ion uses AppleScript to detect available monospace fonts on your system.",
         "NSDesktopFolderUsageDescription": "Ion needs access to your Desktop to read and edit project files.",
         "NSDocumentsFolderUsageDescription": "Ion needs access to your Documents to read and edit project files.",
-        "NSDownloadsFolderUsageDescription": "Ion needs access to your Downloads to read and edit project files."
+        "NSDownloadsFolderUsageDescription": "Ion needs access to your Downloads to read and edit project files.",
+        "NSLocalNetworkUsageDescription": "Ion needs access to your local network to connect to the engine running on a nearby Mac."
       }
     },
     "dmg": {

--- a/desktop/src/main/engine-bridge.ts
+++ b/desktop/src/main/engine-bridge.ts
@@ -140,6 +140,7 @@ export class EngineBridge extends EventEmitter {
 
       conn.on('error', (err: NodeJS.ErrnoException) => {
         if (!this.connected) {
+          warn(`connect err: ${err.code} (${REMOTE_SOCKET})`)
           reject(err)
           return
         }


### PR DESCRIPTION
## Problem

When Ion Desktop connects to a remote engine over TCP, macOS silently blocks the connection with `EHOSTUNREACH` if the user hasn't granted Local Network permission. The app receives no prompt and shows no useful error.

## Changes

- `desktop/extendInfo`: adds `NSLocalNetworkUsageDescription` so macOS prompts for Local Network permission instead of silently blocking
- `engine-bridge.ts`: logs `err.code` in the pre-connect error handler so network failures surface in `desktop.log` rather than being silently swallowed

## Testing

Verified on macOS Sequoia with a remote engine on the local network. Before this change: silent `EHOSTUNREACH`. After: macOS permission prompt appears on first connect; subsequent connects succeed.