### PR TITLE
fix(desktop): validate terminal CWD exists before pty.spawn, fall back to homedir

### DIFF
--- a/desktop/src/main/terminal-manager.ts
+++ b/desktop/src/main/terminal-manager.ts
@@ -1,6 +1,7 @@
 import { IPC } from '../shared/types'
 import { getCliEnv } from './cli-env'
 import { homedir } from 'os'
+import { existsSync } from 'fs'
 import type { IPty } from 'node-pty'
 
 // node-pty is a native module — require at runtime to avoid Vite bundling issues
@@ -26,7 +27,10 @@ export class TerminalManager {
       throw new Error('node-pty is not available')
     }
 
-    const resolvedCwd = cwd === '~' ? homedir() : cwd
+    const resolvedCwd = (() => {
+      const p = cwd === '~' ? homedir() : cwd
+      return existsSync(p) ? p : homedir()
+    })()
     const shell = process.env.SHELL || '/bin/zsh'
 
     const term = pty.spawn(shell, [], {


### PR DESCRIPTION
## Problem

Tabs saved with a `defaultBaseDirectory` that no longer exists on the current machine cause a `posix_spawnp` failure at spawn time with no useful error shown to the user. This is a common scenario when using Ion Desktop across multiple machines -- a tab created on machine A with a project path that doesn't exist on machine B fails silently.

## Changes

- `terminal-manager.ts`: wraps the CWD resolution in an `existsSync` check. If the resolved path doesn't exist, falls back to `homedir()` rather than passing a non-existent path to `pty.spawn`.

## Testing

Reproduced by saving a tab with a working directory set to a path that doesn't exist on the local machine, then restarting the app. Before this fix: `posix_spawnp` error. After: terminal opens in the user's home directory.