### PR TITLE
fix(engine): fix tool_call accumulation for CLI backend

### DIFF
--- a/engine/internal/session/event_translation.go
+++ b/engine/internal/session/event_translation.go
@@ -75,13 +75,21 @@ func (m *Manager) handleNormalizedEvent(runID string, event types.NormalizedEven
 			}
 			s.cliToolMeta[e.ToolID] = toolMeta{name: e.ToolName, index: e.Index}
 			s.cliToolIndexID[e.Index] = e.ToolID
+			s.cliLastToolID = e.ToolID
 			m.mu.Unlock()
 
 		case *types.ToolCallUpdateEvent:
-			// Accumulate partial input for tool_call hook
+			// Accumulate partial input for tool_call hook.
+			// ToolCallUpdateEvent.ToolID is always "" from the normalizer because
+			// content_block_delta events don't carry a toolID. Fall back to the
+			// last-started tool so the input accumulates under the right key.
 			m.mu.Lock()
 			if s.cliToolInputs != nil {
-				s.cliToolInputs[e.ToolID] += e.PartialInput
+				key := e.ToolID
+				if key == "" {
+					key = s.cliLastToolID
+				}
+				s.cliToolInputs[key] += e.PartialInput
 			}
 			m.mu.Unlock()
 

--- a/engine/internal/session/types.go
+++ b/engine/internal/session/types.go
@@ -84,6 +84,10 @@ type engineSession struct {
 	cliToolInputs  map[string]string
 	cliToolMeta    map[string]toolMeta
 	cliToolIndexID map[int]string
+	// cliLastToolID is the ToolID from the most-recently-started tool call.
+	// ToolCallUpdateEvent carries ToolID: "" (content_block_delta has no toolID),
+	// so accumulation falls back to this field to key under the correct toolID.
+	cliLastToolID string
 }
 
 


### PR DESCRIPTION
## Problem

When using `CliBackend` (Claude Code / Anthropic SDK), the `FireToolCall` extension hook never fires for agent dispatch calls.

Root cause: `ToolCallUpdateEvent.ToolID` is always `""` from the stream normalizer. Anthropic's `content_block_delta` events carry a `delta.index` but **not** a `toolID` — the tool ID only appears in the preceding `content_block_start` event. The normalizer emits `ToolCallEvent` (with a real ToolID) for the start, then `ToolCallUpdateEvent` (with `ToolID: ""`) for every subsequent delta.

In `handleNormalizedEvent`, the accumulator stored partial input under the empty-string key:

```go
s.cliToolInputs[e.ToolID] += e.PartialInput  // always stored under ""
```

But `ToolCallCompleteEvent` looked the accumulated input up by the real ToolID, found nothing, and passed `""` to `FireToolCall` — so the hook fired with empty input and extensions couldn't identify which tool was called.

## Fix

Track `cliLastToolID` on the session — set when a `ToolCallEvent` arrives (which does carry the real ToolID). When a `ToolCallUpdateEvent` has `ToolID: ""`, fall back to `cliLastToolID` as the accumulator key.

```go
// In ToolCallEvent handler:
s.cliLastToolID = e.ToolID

// In ToolCallUpdateEvent handler:
key := e.ToolID
if key == "" {
    key = s.cliLastToolID
}
s.cliToolInputs[key] += e.PartialInput
```

## Impact

- Extensions using `FireToolCall` (e.g. to intercept or log `Agent` dispatch) now receive the correct accumulated tool input when running against `CliBackend`.
- No change to behavior for other backends.
- 2 files changed, 14 insertions, 2 deletions.