### PR TITLE
fix(desktop): declare NSBonjourServices for Local Network prompt

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -114,7 +114,11 @@
         "NSDesktopFolderUsageDescription": "Ion needs access to your Desktop to read and edit project files.",
         "NSDocumentsFolderUsageDescription": "Ion needs access to your Documents to read and edit project files.",
         "NSDownloadsFolderUsageDescription": "Ion needs access to your Downloads to read and edit project files.",
-        "NSLocalNetworkUsageDescription": "Ion needs access to your local network to connect to the engine running on a nearby Mac."
+        "NSLocalNetworkUsageDescription": "Ion needs access to your local network to connect to the engine running on a nearby Mac.",
+        "NSBonjourServices": [
+          "_ion-relay._tcp",
+          "_ion._tcp"
+        ]
       }
     },
     "dmg": {


### PR DESCRIPTION
## Problem

On macOS 15 (Sequoia) and 26 (Tahoe), `NSLocalNetworkUsageDescription` on its own is no longer sufficient to surface the Local Network permission prompt for an Electron app that performs Bonjour browse or advertise. Without a matching `NSBonjourServices` array, the kernel NECP layer silently denies outbound traffic to RFC-1918 addresses and to multicast, so the engine bridge appears unreachable on a fresh install with no visible prompt and no entry in System Settings → Privacy & Security → Local Network.

Reproduction on a freshly-installed signed build under macOS 26 Tahoe with `ION_DESKTOP_ENGINE_SOCKET` pointed at a LAN IP:

\`\`\`
kernel: tcp drop outgoing [<local>:<port> <-> <LAN-IP>:21017] reason: NECP
process: Ion:<pid>
\`\`\`

No prompt is shown. The app does bind UDP \*:5353 (so it is multicasting), but NECP drops every SYN. \`tccutil reset All <bundle-id>\` does not help because the Local Network ledger lives outside \`TCC.db\`.

## Fix

Declare the two Bonjour service types the desktop app actually uses, in the same \`extendInfo\` block as \`NSLocalNetworkUsageDescription\`:

- \`_ion-relay._tcp\` — browsed by \`RelayDiscovery\` when the user opens Settings → Remote
- \`_ion._tcp\` — advertised by the engine when running locally so other Ion clients on the LAN can discover it

With both keys present, macOS classifies the app as a legitimate Local Network client, surfaces the prompt on first use, and persists the user's decision.

## Test plan

- [x] JSON validates
- [ ] Build, install on a fresh macOS 15+ machine where the bundle has never been launched, point the app at a LAN engine, and confirm the Local Network prompt appears
- [ ] Confirm an \`ESTABLISHED\` TCP socket from the app to the engine after the user clicks Allow
- [ ] Confirm the app then appears in System Settings → Privacy & Security → Local Network