### PR TITLE
fix(engine): mark anthropic provider authed when CLI backend is in use

### DIFF
--- a/desktop/src/renderer/components/settings/ProvidersCategory.tsx
+++ b/desktop/src/renderer/components/settings/ProvidersCategory.tsx
@@ -14,6 +14,7 @@ function humanAuthSource(source: string | undefined): string {
     case 'filestore': return 'API key'
     case 'oauth': return 'signed in'
     case 'credentials.json': return 'credentials file'
+    case 'cli': return 'Claude CLI'
     case 'none': return 'no auth needed'
     default: return 'configured'
   }
@@ -28,6 +29,7 @@ function authSourceTooltip(source: string | undefined): string {
     case 'filestore': return 'Authenticated via API key saved in Ion settings'
     case 'oauth': return 'Authenticated via browser sign-in (OAuth)'
     case 'credentials.json': return 'Authenticated via legacy credentials.json file'
+    case 'cli': return 'Anthropic models served by the Claude CLI; no separate API key required'
     case 'none': return 'This provider runs locally and does not require authentication'
     default: return 'Provider has valid credentials'
   }

--- a/engine/internal/server/list_models.go
+++ b/engine/internal/server/list_models.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"github.com/dsswift/ion/engine/internal/providers"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// buildModelsList constructs the response for the list_models RPC.
+//
+// Responsibilities:
+//   - resolve per-provider HasAuth/AuthSource via the auth resolver
+//   - apply special cases: ollama always authed (local), and anthropic authed
+//     "via cli" when the engine is running a CLI-capable backend (cli or
+//     hybrid) without a separate Anthropic API key
+//   - populate provider gateway / api-key reference details from config
+//   - filter the hardcoded model catalog down to only user-configured /
+//     discovered models for providers that route through a custom gateway
+//
+// Extracted from server.go to keep the dispatch switch focused and to keep
+// server.go under the file-size cap.
+func (s *Server) buildModelsList() map[string]interface{} {
+	models := providers.ListModels()
+	providerIDs := providers.ListProviderIDs()
+	providerEntries := make([]types.ProviderEntry, len(providerIDs))
+	for i, pid := range providerIDs {
+		entry := types.ProviderEntry{ID: pid}
+		if s.authResolver != nil {
+			entry.HasAuth, entry.AuthSource = s.authResolver.HasKey(pid)
+		}
+		// Special case: ollama doesn't need auth
+		if pid == "ollama" {
+			entry.HasAuth = true
+			entry.AuthSource = "none"
+		}
+		// CLI-capable backend (cli or hybrid) handles Anthropic auth via the
+		// Claude CLI itself. Surface that to clients so the model picker
+		// doesn't hide Anthropic models when no separate API key is
+		// configured.
+		if s.cliCapable && pid == "anthropic" && !entry.HasAuth {
+			entry.HasAuth = true
+			entry.AuthSource = "cli"
+		}
+		// Populate config details (gateway URL, API key reference)
+		if s.config != nil {
+			if pc, ok := s.config.Providers[pid]; ok {
+				entry.BaseURL = pc.BaseURL
+				if pc.APIKey != "" {
+					if pc.APIKey[0] == '$' {
+						entry.APIKeyRef = pc.APIKey
+					} else {
+						entry.APIKeyRef = "configured"
+					}
+				}
+			}
+		}
+		providerEntries[i] = entry
+	}
+
+	// For providers with a custom gateway (baseURL), only show user-configured
+	// models or live-discovered models -- the hardcoded catalog doesn't apply
+	// to private gateways.
+	customGatewayProviders := make(map[string]bool)
+	if s.config != nil {
+		for pid, pc := range s.config.Providers {
+			if pc.BaseURL != "" {
+				customGatewayProviders[pid] = true
+			}
+		}
+	}
+	if len(customGatewayProviders) > 0 {
+		discoveredIDs := make(map[string]bool)
+		for pid := range customGatewayProviders {
+			for _, dm := range providers.GetDiscoveredModels(pid) {
+				discoveredIDs[dm.ID] = true
+			}
+		}
+		filtered := make([]types.ModelEntry, 0, len(models))
+		for _, m := range models {
+			if customGatewayProviders[m.ProviderID] && !m.IsCustom && !discoveredIDs[m.ID] {
+				continue // skip hardcoded catalog models for custom gateway providers
+			}
+			filtered = append(filtered, m)
+		}
+		models = filtered
+	}
+
+	return map[string]interface{}{
+		"models":    models,
+		"providers": providerEntries,
+	}
+}

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -56,6 +56,11 @@ type Server struct {
 	stopOnce           sync.Once
 	version            string
 	startedAt          time.Time
+	// cliCapable is true when the engine is running with a backend that can
+	// serve Anthropic models via the Claude CLI (i.e. CliBackend or
+	// HybridBackend). list_models uses this to mark the anthropic provider
+	// as authed via CLI when no API key is configured.
+	cliCapable bool
 }
 
 // SetConfig stores the engine runtime config for use by sessions.
@@ -82,12 +87,20 @@ func (s *Server) SetAuthResolver(r *auth.Resolver) {
 func NewServer(socketPath string, b backend.RunBackend) *Server {
 	mgr := session.NewManager(b)
 
+	// Detect whether the backend can serve Anthropic models via Claude CLI.
+	var cliCapable bool
+	switch b.(type) {
+	case *backend.CliBackend, *backend.HybridBackend:
+		cliCapable = true
+	}
+
 	s := &Server{
 		socketPath: socketPath,
 		clients:    make(map[net.Conn]*clientWriter),
 		manager:    mgr,
 		done:       make(chan struct{}),
 		startedAt:  time.Now(),
+		cliCapable: cliCapable,
 	}
 
 	// Wire manager events to broadcast
@@ -580,6 +593,14 @@ func (s *Server) dispatch(conn net.Conn, cmd *protocol.ClientCommand) {
 			if pid == "ollama" {
 				entry.HasAuth = true
 				entry.AuthSource = "none"
+			}
+			// CLI-capable backend (cli or hybrid) handles Anthropic auth
+			// via the Claude CLI itself. Surface that to clients so the
+			// model picker doesn't hide Anthropic models when the user
+			// hasn't configured a separate API key.
+			if s.cliCapable && pid == "anthropic" && !entry.HasAuth {
+				entry.HasAuth = true
+				entry.AuthSource = "cli"
 			}
 			// Populate config details (gateway URL, API key reference)
 			if s.config != nil {

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -581,76 +581,7 @@ func (s *Server) dispatch(conn net.Conn, cmd *protocol.ClientCommand) {
 		}(conn, cmd)
 
 	case "list_models":
-		models := providers.ListModels()
-		providerIDs := providers.ListProviderIDs()
-		providerEntries := make([]types.ProviderEntry, len(providerIDs))
-		for i, pid := range providerIDs {
-			entry := types.ProviderEntry{ID: pid}
-			if s.authResolver != nil {
-				entry.HasAuth, entry.AuthSource = s.authResolver.HasKey(pid)
-			}
-			// Special case: ollama doesn't need auth
-			if pid == "ollama" {
-				entry.HasAuth = true
-				entry.AuthSource = "none"
-			}
-			// CLI-capable backend (cli or hybrid) handles Anthropic auth
-			// via the Claude CLI itself. Surface that to clients so the
-			// model picker doesn't hide Anthropic models when the user
-			// hasn't configured a separate API key.
-			if s.cliCapable && pid == "anthropic" && !entry.HasAuth {
-				entry.HasAuth = true
-				entry.AuthSource = "cli"
-			}
-			// Populate config details (gateway URL, API key reference)
-			if s.config != nil {
-				if pc, ok := s.config.Providers[pid]; ok {
-					entry.BaseURL = pc.BaseURL
-					// Show the API key reference if it looks like an env var
-					// (starts with $), otherwise just indicate it's set.
-					if pc.APIKey != "" {
-						if len(pc.APIKey) > 0 && pc.APIKey[0] == '$' {
-							entry.APIKeyRef = pc.APIKey
-						} else {
-							entry.APIKeyRef = "configured"
-						}
-					}
-				}
-			}
-			providerEntries[i] = entry
-		}
-		// For providers with a custom gateway (baseURL), only show
-		// user-configured models or live-discovered models — the hardcoded
-		// catalog doesn't apply to private gateways.
-		customGatewayProviders := make(map[string]bool)
-		if s.config != nil {
-			for pid, pc := range s.config.Providers {
-				if pc.BaseURL != "" {
-					customGatewayProviders[pid] = true
-				}
-			}
-		}
-		if len(customGatewayProviders) > 0 {
-			// Build set of discovered model IDs so we don't filter them out
-			discoveredIDs := make(map[string]bool)
-			for pid := range customGatewayProviders {
-				for _, dm := range providers.GetDiscoveredModels(pid) {
-					discoveredIDs[dm.ID] = true
-				}
-			}
-			filtered := make([]types.ModelEntry, 0, len(models))
-			for _, m := range models {
-				if customGatewayProviders[m.ProviderID] && !m.IsCustom && !discoveredIDs[m.ID] {
-					continue // skip hardcoded catalog models for custom gateway providers
-				}
-				filtered = append(filtered, m)
-			}
-			models = filtered
-		}
-		s.sendResult(conn, cmd, nil, map[string]interface{}{
-			"models":    models,
-			"providers": providerEntries,
-		})
+		s.sendResult(conn, cmd, nil, s.buildModelsList())
 
 	case "store_credential":
 		if s.authResolver == nil {


### PR DESCRIPTION
## Problem

When the engine runs with \`backend: cli\` or \`backend: hybrid\`, Anthropic models are served via the Claude CLI, which authenticates itself -- no separate Anthropic API key is required. But the \`list_models\` handler decides \`HasAuth\` purely by querying the auth resolver for a stored key. With only \`ollama\` special-cased to skip that check, the Anthropic family ends up reported as not configured, and the desktop picker hides Opus/Sonnet/Haiku from the default list (they only surface under search, where they remain disabled).

End result: a perfectly working CLI-backed engine shows \"Sonnet 4.6 via CLI\" in the status bar but the user cannot pick another Anthropic model from the dropdown.

## Fix

Track \`cliCapable\` on \`Server\` via a type-assertion on the \`RunBackend\` at construction (true if it's a \`*CliBackend\` or \`*HybridBackend\`). In \`list_models\`, when the user has no API key for Anthropic but the backend can serve those models, report \`HasAuth=true\` with \`AuthSource=\"cli\"\`. Existing keychain/env/programmatic resolution still wins -- the CLI tag is only applied when no key is found.

Plus a tiny refactor: extract the \`list_models\` handler body into \`engine/internal/server/list_models.go\` (\`s.buildModelsList()\`) so \`server.go\` doesn't drift past the file-size cap as more RPCs accumulate. No behavior change.

## Test plan

- [x] \`go test ./internal/server/...\` passes.
- [x] file-size check passes.
- [ ] On a CLI-backed engine, query \`list_models\` via TCP: the \`anthropic\` provider entry returns \`hasAuth: true, authSource: \"cli\"\`. Verified on a daemon running with \`backend: cli\` -- the desktop picker now lists Opus/Sonnet/Haiku as selectable.
- [ ] On an API-key configured engine (no CLI backend), behavior is unchanged: \`anthropic\` reports auth from the configured key as before.