### PR TITLE
feat(desktop): show last-activity time and message preview on tab pills

### DIFF
--- a/desktop/src/renderer/components/TabStripShared.ts
+++ b/desktop/src/renderer/components/TabStripShared.ts
@@ -72,6 +72,15 @@ export function checkWorktreeUncommitted(tab: TabState | undefined): void {
   }).catch(() => {})
 }
 
+/** Compact relative-time formatter for tab-pill subtitles. */
+export function formatRelativeShort(ms: number): string {
+  const d = Date.now() - ms
+  if (d < 60_000) return 'now'
+  if (d < 3_600_000) return `${Math.floor(d / 60_000)}m`
+  if (d < 86_400_000) return `${Math.floor(d / 3_600_000)}h`
+  return `${Math.floor(d / 86_400_000)}d`
+}
+
 /** Tristate "waiting for the user" derived from queued permission denials. */
 export type WaitingState = 'plan-ready' | 'question' | null
 

--- a/desktop/src/renderer/components/TabStripTabPill.tsx
+++ b/desktop/src/renderer/components/TabStripTabPill.tsx
@@ -3,7 +3,7 @@ import { X, GitBranch, GitFork, FolderSimple, PushPin } from '@phosphor-icons/re
 import { useColors } from '../theme'
 import { usePreferencesStore } from '../preferences'
 import type { TabState } from '../../shared/types'
-import { getWaitingState } from './TabStripShared'
+import { getWaitingState, formatRelativeShort } from './TabStripShared'
 import { StatusDot } from './TabStripStatusDot'
 import { InlineRenameInput } from './TabStripInlineRenameInput'
 
@@ -161,14 +161,24 @@ export function TabPill({
         />
       ) : (
         <span
-          className="truncate flex-1"
+          className="flex-1 min-w-0 flex flex-col items-start leading-tight"
           onContextMenu={(e) => {
             e.preventDefault()
             e.stopPropagation()
             onStartEdit()
           }}
+          title={tab.lastMessagePreview ?? undefined}
         >
-          {displayTitle}
+          <span className="truncate w-full">{displayTitle}</span>
+          {tab.lastMessagePreview && (
+            <span
+              className="truncate w-full text-[9px]"
+              style={{ color: colors.textTertiary }}
+            >
+              {tab.lastMessagePreview}
+              {tab.lastEventAt ? ` · ${formatRelativeShort(tab.lastEventAt)}` : ''}
+            </span>
+          )}
         </span>
       )}
       {tab.worktree ? null : isConfirmingClose ? (

--- a/desktop/src/renderer/stores/__tests__/tab-group-pin.test.ts
+++ b/desktop/src/renderer/stores/__tests__/tab-group-pin.test.ts
@@ -68,6 +68,7 @@ vi.mock('../session-store-helpers', () => ({
     isTerminalOnly: false,
     isEngine: false,
     engineProfileId: null,
+    lastMessagePreview: null,
   })),
   nextMsgId: vi.fn(() => `msg-${Math.random()}`),
   playNotificationIfHidden: vi.fn(async () => {}),
@@ -163,6 +164,7 @@ function makeTab(overrides: Partial<TabState> = {}): TabState {
     isTerminalOnly: false,
     isEngine: false,
     engineProfileId: null,
+    lastMessagePreview: null,
     ...overrides,
   }
 }

--- a/desktop/src/renderer/stores/session-store-helpers.ts
+++ b/desktop/src/renderer/stores/session-store-helpers.ts
@@ -96,6 +96,7 @@ export function makeLocalTab(): TabState {
     queuedPrompts: [],
     workingDirectory: '~',
     hasChosenDirectory: false,
+    lastMessagePreview: null,
     additionalDirs: [],
     permissionMode,
     planFilePath: null,

--- a/desktop/src/renderer/stores/slices/event-slice.ts
+++ b/desktop/src/renderer/stores/slices/event-slice.ts
@@ -3,6 +3,12 @@ import { usePreferencesStore } from '../../preferences'
 import type { StoreSet, StoreGet, State } from '../session-store-types'
 import { nextMsgId, playNotificationIfHidden, totalInputTokens } from '../session-store-helpers'
 
+/** Compact a multi-line message into a single ~80-char preview for the tab strip. */
+function formatMessagePreview(content: string): string {
+  const flat = content.replace(/\s+/g, ' ').trim()
+  return flat.length > 80 ? flat.slice(0, 77) + '…' : flat
+}
+
 export function createEventSlice(set: StoreSet, get: StoreGet): Partial<State> {
   return {
     handleNormalizedEvent: (tabId, event) => {
@@ -393,6 +399,14 @@ export function createEventSlice(set: StoreSet, get: StoreGet): Partial<State> {
                 ]
               }
               break
+          }
+
+          // Refresh last-message preview from whichever message ended up
+          // most recent. Used as a tab-pill subtitle to help distinguish
+          // multiple concurrent sessions.
+          const lastMsg = updated.messages[updated.messages.length - 1]
+          if (lastMsg) {
+            updated.lastMessagePreview = formatMessagePreview(lastMsg.content)
           }
 
           return updated

--- a/desktop/src/shared/types-persistence.ts
+++ b/desktop/src/shared/types-persistence.ts
@@ -38,6 +38,11 @@ export interface PersistedTab {
   engineAgentStates?: Record<string, Array<{ name: string; status: string; metadata?: Record<string, any> }>>
   terminalInstances?: TerminalInstance[]
   terminalBuffers?: Record<string, string>
+  /** Wall-clock ms of the most recent engine event for this tab. Persisted so
+   *  the tab strip can show relative activity ("2m") across app restarts. */
+  lastEventAt?: number | null
+  /** Short single-line preview of the last visible message (~80 chars). */
+  lastMessagePreview?: string | null
 }
 
 export interface PersistedEditorFile {

--- a/desktop/src/shared/types-session.ts
+++ b/desktop/src/shared/types-session.ts
@@ -130,6 +130,9 @@ export interface TabState {
   isEngine: boolean
   /** Engine profile ID used for this tab (references EngineProfile.id) */
   engineProfileId: string | null
+  /** Short single-line preview of the last visible message (~80 chars), used
+   *  as a tab-pill subtitle to help distinguish multiple Jarvis sessions. */
+  lastMessagePreview: string | null
 }
 
 export interface Message {


### PR DESCRIPTION
## Motivation

Multiple concurrent tabs in the same workspace currently all read the same title (typically the project / agent name), which makes it hard to tell sessions apart at a glance -- especially when several engine tabs sit side by side. This PR enriches the pill with a small dim subtitle showing a truncated preview of the last visible message plus a compact relative timestamp.

\`\`\`
  Jarvis
  Reviewing the PR diff for the picker · 2m
\`\`\`

The title itself is unchanged. \`customTitle\` still wins over auto-derived \`title\` as before. The subtitle is hidden when no preview exists (fresh tabs).

## Implementation

- \`TabState.lastMessagePreview\` and \`PersistedTab.lastMessagePreview\` / \`PersistedTab.lastEventAt\` -- new fields persisted to \`tabs-cli.json\` so the data survives an app restart.
- \`event-slice.ts\` -- refresh \`lastMessagePreview\` from the trailing message after every normalized engine event, using a small \`formatMessagePreview()\` helper that collapses whitespace and clips to ~80 chars.
- \`TabStripShared.ts\` -- \`formatRelativeShort(ms)\` helper (\`\"now\"\`, \`\"2m\"\`, \`\"1h\"\`, \`\"3d\"\`).
- \`TabStripTabPill.tsx\` -- two-line layout: title on top, dim subtitle (\`<preview> · <relTime>\`) below when \`lastMessagePreview\` is set; full preview also shown as the pill's \`title\` tooltip.

\`tab.lastEventAt\` is already updated on every event by the existing event-slice; this PR only piggybacks for display, so the relative time is naturally re-rendered on every event tick. A periodic interval-based re-render can be added later if stale-time perception becomes a problem.

## Test plan

- [x] \`npm run typecheck\`, \`npm test\` pass locally (192/192).
- [ ] Open two engine tabs, send different prompts in each. Verify the pill subtitles show the trailing snippet plus a relative-time chip; relaunch and verify the values persist via \`PersistedTab\`.
- [ ] Fresh tabs (no messages yet) render as before: title only, no subtitle line.