### PR TITLE
feat(engine): add get_host_info and list_directory RPCs

### DIFF
--- a/engine/internal/protocol/protocol.go
+++ b/engine/internal/protocol/protocol.go
@@ -63,6 +63,12 @@ type ClientCommand struct {
 	EarlyStopOverrideThresholdPct int    `json:"earlyStopOverrideThresholdPct,omitempty"`
 	EarlyStopContinueMessage      string `json:"earlyStopContinueMessage,omitempty"`
 
+	// list_directory: absolute path to enumerate on the engine's host.
+	// Empty or "~" resolves to the engine user's home directory. ShowHidden
+	// includes dotfiles in the result.
+	Path       string `json:"path,omitempty"`
+	ShowHidden bool   `json:"showHidden,omitempty"`
+
 	// send_prompt: pre-encoded image attachments to attach to the user
 	// message as native image content blocks. The engine has no opinion on
 	// any client-side marker syntax inside Text — clients pass image bytes
@@ -140,6 +146,8 @@ var validCommands = map[string]bool{
 	"list_models":           true,
 	"store_credential":      true,
 	"refresh_models":        true,
+	"get_host_info":         true,
+	"list_directory":        true,
 	// clear_conversation_file: wipes the LLM-visible Messages (and resets
 	// LastInputTokens / LastInputTokensMsgCount) on a stored conversation
 	// file by sessionId, without requiring a live engine session. Used by
@@ -319,6 +327,11 @@ func validateRaw(cmd string, raw map[string]json.RawMessage) bool {
 		return hasNonEmptyString(raw, "provider") && hasString(raw, "credential")
 	case "refresh_models":
 		return true // optional: provider field to refresh a single provider
+	case "get_host_info":
+		return true
+	case "list_directory":
+		// path is optional ("" or "~" → engine home); no required fields
+		return true
 	case "clear_conversation_file":
 		// key carries the sessionId (conversationId) to wipe. Required and non-empty.
 		return hasNonEmptyString(raw, "key")

--- a/engine/internal/protocol/protocol_test.go
+++ b/engine/internal/protocol/protocol_test.go
@@ -672,6 +672,52 @@ func TestParseClientCommand_StoreCredentialEmptyProvider(t *testing.T) {
 	}
 }
 
+// --- get_host_info / list_directory command tests ---
+
+func TestParseClientCommand_GetHostInfo(t *testing.T) {
+	raw := `{"cmd":"get_host_info","requestId":"r5"}`
+	cmd := ParseClientCommand(raw)
+	if cmd == nil {
+		t.Fatal("expected valid command")
+	}
+	if cmd.Cmd != "get_host_info" {
+		t.Errorf("expected cmd 'get_host_info', got %q", cmd.Cmd)
+	}
+}
+
+func TestParseClientCommand_ListDirectoryWithPath(t *testing.T) {
+	raw := `{"cmd":"list_directory","requestId":"r6","path":"/Users/foo","showHidden":true}`
+	cmd := ParseClientCommand(raw)
+	if cmd == nil {
+		t.Fatal("expected valid command")
+	}
+	if cmd.Cmd != "list_directory" {
+		t.Errorf("expected cmd 'list_directory', got %q", cmd.Cmd)
+	}
+	if cmd.Path != "/Users/foo" {
+		t.Errorf("expected path '/Users/foo', got %q", cmd.Path)
+	}
+	if !cmd.ShowHidden {
+		t.Errorf("expected showHidden=true")
+	}
+}
+
+func TestParseClientCommand_ListDirectoryDefaults(t *testing.T) {
+	// path/showHidden are optional — empty payload should still parse, since
+	// "" → engine home is the documented default.
+	raw := `{"cmd":"list_directory","requestId":"r7"}`
+	cmd := ParseClientCommand(raw)
+	if cmd == nil {
+		t.Fatal("expected valid command (path is optional)")
+	}
+	if cmd.Path != "" {
+		t.Errorf("expected empty path, got %q", cmd.Path)
+	}
+	if cmd.ShowHidden {
+		t.Errorf("expected showHidden=false default")
+	}
+}
+
 func TestParseClientCommand_StoreCredentialEmptyCredential(t *testing.T) {
 	// Empty credential is valid — it means "clear this provider's key"
 	raw := `{"cmd":"store_credential","provider":"openai","credential":""}`

--- a/engine/internal/server/fs_browse.go
+++ b/engine/internal/server/fs_browse.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// hostInfoCache caches the once-computed engine host info.
+var (
+	hostInfoOnce   sync.Once
+	hostInfoCached map[string]interface{}
+)
+
+// listDirectoryMaxEntries caps the number of entries returned by a single
+// list_directory call. Beyond this, the response is truncated and the client
+// is told to narrow the path.
+const listDirectoryMaxEntries = 5000
+
+// computeHostInfo collects engine-host metadata that the desktop uses to
+// browse the engine's filesystem (home, username, hostname, os, separator).
+// The values are immutable for the lifetime of the daemon, so it caches once.
+func computeHostInfo() map[string]interface{} {
+	hostInfoOnce.Do(func() {
+		home, _ := os.UserHomeDir()
+		username := ""
+		if u, err := user.Current(); err == nil {
+			username = u.Username
+		}
+		hostname, _ := os.Hostname()
+		hostInfoCached = map[string]interface{}{
+			"home":     home,
+			"username": username,
+			"hostname": hostname,
+			"os":       runtime.GOOS,
+			"pathSep":  string(os.PathSeparator),
+		}
+	})
+	return hostInfoCached
+}
+
+// fsEntry is one row in a list_directory response.
+type fsEntry struct {
+	Name      string `json:"name"`
+	IsDir     bool   `json:"isDir"`
+	IsSymlink bool   `json:"isSymlink"`
+	Readable  bool   `json:"readable"`
+}
+
+// listDirectory enumerates a directory on the engine's host.
+//
+//   - path "" or "~" resolves to the engine user's home; "~/foo" is treated as
+//     "<home>/foo".
+//   - all other paths must be absolute; relative paths are rejected so the
+//     client can never accidentally inherit the engine's cwd.
+//   - per-entry permission errors are surfaced as readable=false rather than
+//     failing the whole call.
+//   - dotfiles are dropped unless showHidden.
+//   - entries are sorted dirs-first, case-insensitive within each group.
+//   - the response is capped at listDirectoryMaxEntries; truncated=true tells
+//     the client to narrow the path.
+//
+// Symlinks are reported but never followed; the client may pass an explicit
+// target path to navigate into one.
+func listDirectory(path string, showHidden bool) (map[string]interface{}, error) {
+	resolved, err := resolveBrowsePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	dirEntries, err := os.ReadDir(resolved)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]fsEntry, 0, len(dirEntries))
+	truncated := false
+	for _, de := range dirEntries {
+		name := de.Name()
+		if !showHidden && strings.HasPrefix(name, ".") {
+			continue
+		}
+		if len(out) >= listDirectoryMaxEntries {
+			truncated = true
+			break
+		}
+
+		entry := fsEntry{Name: name, Readable: true}
+		mode := de.Type()
+		if mode&os.ModeSymlink != 0 {
+			entry.IsSymlink = true
+			if info, statErr := os.Lstat(filepath.Join(resolved, name)); statErr == nil {
+				// dir-ness based on the symlink itself, not its target.
+				_ = info
+			}
+			// Resolve target to detect if it's a directory, but don't follow.
+			if target, statErr := os.Stat(filepath.Join(resolved, name)); statErr == nil {
+				entry.IsDir = target.IsDir()
+			} else {
+				entry.Readable = false
+			}
+		} else {
+			entry.IsDir = mode.IsDir()
+		}
+		out = append(out, entry)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].IsDir != out[j].IsDir {
+			return out[i].IsDir
+		}
+		return strings.ToLower(out[i].Name) < strings.ToLower(out[j].Name)
+	})
+
+	resp := map[string]interface{}{
+		"path":      resolved,
+		"entries":   out,
+		"truncated": truncated,
+	}
+	if parent := filepath.Dir(resolved); parent != resolved {
+		resp["parent"] = parent
+	} else {
+		resp["parent"] = nil
+	}
+	return resp, nil
+}
+
+// resolveBrowsePath converts a client-supplied path into an absolute path on
+// the engine's host. Returns an error if the path is relative.
+func resolveBrowsePath(path string) (string, error) {
+	if path == "" || path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("home directory unavailable: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("home directory unavailable: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("path must be absolute: %q", path)
+	}
+	return filepath.Clean(path), nil
+}

--- a/engine/internal/server/fs_browse_test.go
+++ b/engine/internal/server/fs_browse_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestComputeHostInfoShape(t *testing.T) {
+	info := computeHostInfo()
+	for _, key := range []string{"home", "username", "hostname", "os", "pathSep"} {
+		if _, ok := info[key]; !ok {
+			t.Errorf("expected key %q in host info", key)
+		}
+	}
+	if got := info["os"].(string); got != runtime.GOOS {
+		t.Errorf("os=%q want %q", got, runtime.GOOS)
+	}
+	if got := info["pathSep"].(string); got != string(os.PathSeparator) {
+		t.Errorf("pathSep=%q want %q", got, string(os.PathSeparator))
+	}
+}
+
+func TestResolveBrowsePath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", home, false},
+		{"~", home, false},
+		{"~/Documents", filepath.Join(home, "Documents"), false},
+		{"/tmp", "/tmp", false},
+		{"/tmp/./foo", "/tmp/foo", false},
+		{"relative/path", "", true},
+		{"./also-relative", "", true},
+	}
+	for _, tc := range tests {
+		got, err := resolveBrowsePath(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("resolveBrowsePath(%q): expected error, got %q", tc.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("resolveBrowsePath(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("resolveBrowsePath(%q) = %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestListDirectoryBasic(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, "alpha"))
+	mustMkdir(t, filepath.Join(root, "Beta"))
+	mustWrite(t, filepath.Join(root, "gamma.txt"))
+	mustWrite(t, filepath.Join(root, ".hidden"))
+
+	resp, err := listDirectory(root, false)
+	if err != nil {
+		t.Fatalf("listDirectory err: %v", err)
+	}
+	if resp["path"] != root {
+		t.Errorf("path=%v want %v", resp["path"], root)
+	}
+	if resp["parent"] != filepath.Dir(root) {
+		t.Errorf("parent=%v want %v", resp["parent"], filepath.Dir(root))
+	}
+	if resp["truncated"] != false {
+		t.Errorf("truncated=true unexpected on tiny tempdir")
+	}
+
+	entries := resp["entries"].([]fsEntry)
+	if len(entries) != 3 {
+		t.Fatalf("entries=%d want 3 (hidden excluded). got=%+v", len(entries), entries)
+	}
+	// dirs first, case-insensitive: alpha, Beta, then gamma.txt
+	if entries[0].Name != "alpha" || !entries[0].IsDir {
+		t.Errorf("entries[0]=%+v want alpha (dir)", entries[0])
+	}
+	if entries[1].Name != "Beta" || !entries[1].IsDir {
+		t.Errorf("entries[1]=%+v want Beta (dir)", entries[1])
+	}
+	if entries[2].Name != "gamma.txt" || entries[2].IsDir {
+		t.Errorf("entries[2]=%+v want gamma.txt (file)", entries[2])
+	}
+}
+
+func TestListDirectoryShowHidden(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "visible"))
+	mustWrite(t, filepath.Join(root, ".hidden"))
+
+	resp, err := listDirectory(root, true)
+	if err != nil {
+		t.Fatalf("listDirectory err: %v", err)
+	}
+	entries := resp["entries"].([]fsEntry)
+	names := entryNames(entries)
+	if !contains(names, ".hidden") {
+		t.Errorf(".hidden missing from entries with showHidden=true: %v", names)
+	}
+	if !contains(names, "visible") {
+		t.Errorf("visible missing from entries: %v", names)
+	}
+}
+
+func TestListDirectoryRejectsRelativePath(t *testing.T) {
+	if _, err := listDirectory("relative/path", false); err == nil {
+		t.Fatal("expected error for relative path")
+	}
+}
+
+func TestListDirectoryResolvesHomeShortcut(t *testing.T) {
+	resp, err := listDirectory("~", false)
+	if err != nil {
+		t.Fatalf("listDirectory(~) err: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	if resp["path"] != home {
+		t.Errorf("~ resolved to %v want %v", resp["path"], home)
+	}
+}
+
+func TestListDirectoryMissingPath(t *testing.T) {
+	// /nonexistent on every platform we ship to
+	bad := filepath.Join(t.TempDir(), "does-not-exist")
+	if _, err := listDirectory(bad, false); err == nil {
+		t.Fatal("expected error for missing directory")
+	}
+}
+
+// helpers
+
+func mustMkdir(t *testing.T, p string) {
+	t.Helper()
+	if err := os.Mkdir(p, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
+	}
+}
+
+func mustWrite(t *testing.T, p string) {
+	t.Helper()
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+func entryNames(entries []fsEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Name
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// silence unused import warnings for runtime if some test paths drop GOOS use
+var _ = strings.HasPrefix

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -513,6 +513,13 @@ func (s *Server) dispatch(conn net.Conn, cmd *protocol.ClientCommand) {
 		// Implementation in dispatch_data.go.
 		s.dispatchListModels(conn, cmd)
 
+	case "get_host_info":
+		s.sendResult(conn, cmd, nil, computeHostInfo())
+
+	case "list_directory":
+		data, err := listDirectory(cmd.Path, cmd.ShowHidden)
+		s.sendResult(conn, cmd, err, data)
+
 	case "store_credential":
 		if s.authResolver == nil {
 			s.sendResult(conn, cmd, fmt.Errorf("auth resolver not configured"), nil)


### PR DESCRIPTION
Rebased version of #138 (from @geektechlive). Conflicts with main resolved.

Two read-only RPCs that let a desktop client browse the engine's filesystem without making assumptions about the engine's host layout. Motivated by remote-engine setups where the desktop's local file picker gives the user paths that don't exist on the engine host.

- `get_host_info` -> { home, username, hostname, os, pathSep }
- `list_directory` -> { path, parent, entries[], truncated }

Original PR: #138