### PR TITLE
fix(engine): mark anthropic provider authed when CLI backend is in use

### DIFF
--- a/desktop/src/renderer/components/settings/ProvidersCategory.tsx
+++ b/desktop/src/renderer/components/settings/ProvidersCategory.tsx
@@ -14,6 +14,7 @@ function humanAuthSource(source: string | undefined): string {
     case 'filestore': return 'API key'
     case 'oauth': return 'signed in'
     case 'credentials.json': return 'credentials file'
+    case 'cli': return 'Claude CLI'
     case 'none': return 'no auth needed'
     default: return 'configured'
   }
@@ -28,6 +29,7 @@ function authSourceTooltip(source: string | undefined): string {
     case 'filestore': return 'Authenticated via API key saved in Ion settings'
     case 'oauth': return 'Authenticated via browser sign-in (OAuth)'
     case 'credentials.json': return 'Authenticated via legacy credentials.json file'
+    case 'cli': return 'Anthropic models served by the Claude CLI; no separate API key required'
     case 'none': return 'This provider runs locally and does not require authentication'
     default: return 'Provider has valid credentials'
   }

--- a/engine/internal/server/dispatch_data.go
+++ b/engine/internal/server/dispatch_data.go
@@ -165,6 +165,13 @@ func (s *Server) dispatchListModels(conn net.Conn, cmd *protocol.ClientCommand) 
 			entry.HasAuth = true
 			entry.AuthSource = "none"
 		}
+		// CLI-capable backend (cli or hybrid) handles Anthropic auth via the
+		// Claude CLI itself. Surface that to clients so the model picker
+		// doesn't hide Anthropic models when no separate API key is configured.
+		if s.cliCapable && pid == "anthropic" && !entry.HasAuth {
+			entry.HasAuth = true
+			entry.AuthSource = "cli"
+		}
 		// Populate config details (gateway URL, API key reference)
 		if s.config != nil {
 			if pc, ok := s.config.Providers[pid]; ok {

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -54,6 +54,11 @@ type Server struct {
 	stopOnce           sync.Once
 	version            string
 	startedAt          time.Time
+	// cliCapable is true when the engine is running with a backend that can
+	// serve Anthropic models via the Claude CLI (i.e. CliBackend or
+	// HybridBackend). list_models uses this to mark the anthropic provider
+	// as authed via CLI when no API key is configured.
+	cliCapable bool
 }
 
 // SetConfig stores the engine runtime config for use by sessions.
@@ -80,12 +85,20 @@ func (s *Server) SetAuthResolver(r *auth.Resolver) {
 func NewServer(socketPath string, b backend.RunBackend) *Server {
 	mgr := session.NewManager(b)
 
+	// Detect whether the backend can serve Anthropic models via Claude CLI.
+	var cliCapable bool
+	switch b.(type) {
+	case *backend.CliBackend, *backend.HybridBackend:
+		cliCapable = true
+	}
+
 	s := &Server{
 		socketPath: socketPath,
 		clients:    make(map[net.Conn]*clientWriter),
 		manager:    mgr,
 		done:       make(chan struct{}),
 		startedAt:  time.Now(),
+		cliCapable: cliCapable,
 	}
 
 	// Wire manager events to broadcast


### PR DESCRIPTION
Rebased version of #140 (from @geektechlive). Conflicts resolved — the list_models extraction commit was dropped as redundant with main's dispatch_data.go.

When the engine runs with backend=cli or backend=hybrid, Anthropic models are served via the Claude CLI — no separate API key is required. This change:

- Tracks `cliCapable` at Server construction via type-assertion on the RunBackend
- Reports anthropic as HasAuth=true with AuthSource="cli" when no API key is configured but the backend can serve those models
- Desktop: adds the new AuthSource value to the provider settings badge

Original PR: #140