### PR TITLE
fix(engine): surface cache token fields on DispatchAgentResult (#146)

### DIFF
--- a/engine/internal/extension/sdk_types.go
+++ b/engine/internal/extension/sdk_types.go
@@ -185,13 +185,15 @@ type DispatchAgentOpts struct {
 
 // DispatchAgentResult holds the outcome of a dispatched agent.
 type DispatchAgentResult struct {
-	Output       string  `json:"output"`
-	ExitCode     int     `json:"exitCode"`
-	Elapsed      float64 `json:"elapsed"`
-	Cost         float64 `json:"cost"`
-	InputTokens  int     `json:"inputTokens"`
-	OutputTokens int     `json:"outputTokens"`
-	SessionID    string  `json:"sessionId,omitempty"`
+	Output                   string  `json:"output"`
+	ExitCode                 int     `json:"exitCode"`
+	Elapsed                  float64 `json:"elapsed"`
+	Cost                     float64 `json:"cost"`
+	InputTokens              int     `json:"inputTokens"`
+	OutputTokens             int     `json:"outputTokens"`
+	CacheReadInputTokens     int     `json:"cacheReadInputTokens,omitempty"`
+	CacheCreationInputTokens int     `json:"cacheCreationInputTokens,omitempty"`
+	SessionID                string  `json:"sessionId,omitempty"`
 }
 
 // DiscoverAgentsOpts configures which directories to scan for agent definitions

--- a/engine/internal/extension/sdk_types_test.go
+++ b/engine/internal/extension/sdk_types_test.go
@@ -1,0 +1,66 @@
+package extension
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDispatchAgentResult_CacheTokenFields_JSON(t *testing.T) {
+	// Round-trip: populated cache fields appear in JSON and survive unmarshal.
+	orig := DispatchAgentResult{
+		Output:                   "done",
+		ExitCode:                 0,
+		Elapsed:                  1.5,
+		Cost:                     0.003,
+		InputTokens:              100,
+		OutputTokens:             50,
+		CacheReadInputTokens:     80,
+		CacheCreationInputTokens: 20,
+		SessionID:                "sess-1",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	raw := string(data)
+	if !strings.Contains(raw, `"cacheReadInputTokens"`) {
+		t.Errorf("JSON missing cacheReadInputTokens key: %s", raw)
+	}
+	if !strings.Contains(raw, `"cacheCreationInputTokens"`) {
+		t.Errorf("JSON missing cacheCreationInputTokens key: %s", raw)
+	}
+
+	var decoded DispatchAgentResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.CacheReadInputTokens != 80 {
+		t.Errorf("CacheReadInputTokens = %d, want 80", decoded.CacheReadInputTokens)
+	}
+	if decoded.CacheCreationInputTokens != 20 {
+		t.Errorf("CacheCreationInputTokens = %d, want 20", decoded.CacheCreationInputTokens)
+	}
+
+	// Omitempty: zero-value cache fields must be absent from JSON output.
+	zero := DispatchAgentResult{
+		Output:       "done",
+		InputTokens:  100,
+		OutputTokens: 50,
+	}
+
+	zeroData, err := json.Marshal(zero)
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+
+	zeroRaw := string(zeroData)
+	if strings.Contains(zeroRaw, "cacheReadInputTokens") {
+		t.Errorf("zero-value JSON should omit cacheReadInputTokens: %s", zeroRaw)
+	}
+	if strings.Contains(zeroRaw, "cacheCreationInputTokens") {
+		t.Errorf("zero-value JSON should omit cacheCreationInputTokens: %s", zeroRaw)
+	}
+}

--- a/engine/internal/session/extcontext/dispatch_agent.go
+++ b/engine/internal/session/extcontext/dispatch_agent.go
@@ -91,6 +91,7 @@ func BuildDispatchAgentFunc(sa SessionAccessor) func(extension.DispatchAgentOpts
 		// Track child cost/tokens and forward events to extension callback.
 		var totalCost float64
 		var totalInputTokens, totalOutputTokens int
+		var totalCacheReadTokens, totalCacheCreationTokens int
 		var childSessionID string
 
 		var result string
@@ -118,6 +119,12 @@ func BuildDispatchAgentFunc(sa SessionAccessor) func(extension.DispatchAgentOpts
 				}
 				if tc.Usage.OutputTokens != nil {
 					totalOutputTokens = *tc.Usage.OutputTokens
+				}
+				if tc.Usage.CacheReadInputTokens != nil {
+					totalCacheReadTokens = *tc.Usage.CacheReadInputTokens
+				}
+				if tc.Usage.CacheCreationInputTokens != nil {
+					totalCacheCreationTokens = *tc.Usage.CacheCreationInputTokens
 				}
 				if tc.SessionID != "" {
 					childSessionID = tc.SessionID
@@ -181,24 +188,28 @@ func BuildDispatchAgentFunc(sa SessionAccessor) func(extension.DispatchAgentOpts
 
 		if childErr != nil {
 			return &extension.DispatchAgentResult{
-				Output:       childErr.Error(),
-				ExitCode:     1,
-				Elapsed:      elapsed,
-				Cost:         totalCost,
-				InputTokens:  totalInputTokens,
-				OutputTokens: totalOutputTokens,
-				SessionID:    childSessionID,
+				Output:                   childErr.Error(),
+				ExitCode:                 1,
+				Elapsed:                  elapsed,
+				Cost:                     totalCost,
+				InputTokens:              totalInputTokens,
+				OutputTokens:             totalOutputTokens,
+				CacheReadInputTokens:     totalCacheReadTokens,
+				CacheCreationInputTokens: totalCacheCreationTokens,
+				SessionID:                childSessionID,
 			}, childErr
 		}
 
 		return &extension.DispatchAgentResult{
-			Output:       result,
-			ExitCode:     0,
-			Elapsed:      elapsed,
-			Cost:         totalCost,
-			InputTokens:  totalInputTokens,
-			OutputTokens: totalOutputTokens,
-			SessionID:    childSessionID,
+			Output:                   result,
+			ExitCode:                 0,
+			Elapsed:                  elapsed,
+			Cost:                     totalCost,
+			InputTokens:              totalInputTokens,
+			OutputTokens:             totalOutputTokens,
+			CacheReadInputTokens:     totalCacheReadTokens,
+			CacheCreationInputTokens: totalCacheCreationTokens,
+			SessionID:                childSessionID,
 		}, nil
 	}
 }


### PR DESCRIPTION
DispatchAgentResult now includes CacheReadInputTokens and
CacheCreationInputTokens (omitempty), wired from TaskCompleteEvent.Usage
in dispatch_agent.go. Extensions calling ctx.dispatchAgent() can now
observe cache hit rates for child-agent dispatches.

Purely additive — no contract manifest or cross-language sync needed
since DispatchAgentResult is not in the shared contract surface.

Fixes #146
