### PR TITLE
Improve initialization UX and refine engine tool prompts

### DIFF
--- a/desktop/src/main/prompt-pipeline-prose.ts
+++ b/desktop/src/main/prompt-pipeline-prose.ts
@@ -90,5 +90,6 @@ export const PLAN_MODE_SPARSE_REMINDER =
   'Read-only except plan file. ' +
   'End turns with AskUserQuestion (for clarifications) or ExitPlanMode (for plan approval). ' +
   'Never use AskUserQuestion to ask for plan approval -- that is what ExitPlanMode is for. ' +
+  'If the plan is written and complete, call ExitPlanMode — do not delay with another question. The user has no visibility into plan content until ExitPlanMode is called. ' +
   'Forbidden as prose: "Is this plan okay?", "Should I proceed?", "Let me know if you\'d like changes", ' +
   '"How does this plan look?" -- these must use ExitPlanMode or AskUserQuestion.'

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -81,6 +81,7 @@ export default function App() {
   const isTerminalBigScreen = useSessionStore((s) => s.terminalBigScreenTabId === s.activeTabId)
   const gitPanelOpen = useSessionStore((s) => s.gitPanelOpen)
   const activeTabId = useSessionStore((s) => s.activeTabId)
+  const tabsReady = useSessionStore((s) => s.tabsReady)
   const activeTab = useSessionStore((s) => s.tabs.find((t) => t.id === s.activeTabId))
   const isTerminalOnly = activeTab?.isTerminalOnly || false
   const isEngine = activeTab?.isEngine || false
@@ -183,7 +184,7 @@ export default function App() {
           {/* ─── Terminal panel ─── */}
           {/* Normal mode: above conversation, hidden in tall/terminal-tall/big-screen view */}
           <AnimatePresence initial={false}>
-            {terminalOpen && !isTallView && !isTerminalTall && !isTerminalOnly && !isTerminalBigScreen && (
+            {tabsReady && terminalOpen && !isTallView && !isTerminalTall && !isTerminalOnly && !isTerminalBigScreen && (
               <motion.div
                 data-ion-ui
                 initial={{ opacity: 0, height: 0 }}
@@ -234,6 +235,7 @@ export default function App() {
               zIndex: isExpanded || isTerminalOnly || isTerminalTall || isEngine ? 20 : 10,
             }}
           >
+            {tabsReady && (<>
             {/* Tab strip — always mounted */}
             <div>
               <TabStrip />
@@ -287,6 +289,7 @@ export default function App() {
                 <StatusBar />
               </div>
             )}
+            </>)}
           </motion.div>
 
           {/* ─── Input row — circles float outside left ─── */}
@@ -348,7 +351,7 @@ export default function App() {
           </div>
           {/* File explorer — anchored to left edge of content column */}
           <AnimatePresence>
-            {explorerOpen && (
+            {tabsReady && explorerOpen && (
               <motion.div
                 data-ion-ui
                 initial={{ opacity: 0, x: -20 }}
@@ -370,7 +373,7 @@ export default function App() {
           </AnimatePresence>
           {/* Git side panel — anchored to right edge of content column */}
           <AnimatePresence>
-            {gitPanelOpen && (
+            {tabsReady && gitPanelOpen && (
               <motion.div
                 data-ion-ui
                 initial={{ opacity: 0, x: 20 }}
@@ -393,12 +396,12 @@ export default function App() {
         </div>
 
         {/* File editor floating panel */}
-        {editorOpen && editorDirState && editorDirState.files.length > 0 && activeTab && (
+        {tabsReady && editorOpen && editorDirState && editorDirState.files.length > 0 && activeTab && (
           <FileEditor dir={editorDirForTab(activeTab)} tabId={activeTabId} />
         )}
 
         {/* Terminal big screen overlay */}
-        {isTerminalBigScreen && (
+        {tabsReady && isTerminalBigScreen && (
           <TerminalBigScreen tabId={activeTabId} />
         )}
 

--- a/desktop/src/renderer/components/InputBar.tsx
+++ b/desktop/src/renderer/components/InputBar.tsx
@@ -61,6 +61,7 @@ export function InputBar() {
   })
   const bashExecuting = tab?.bashExecuting ?? false
   const tabsReady = useSessionStore((s) => s.tabsReady)
+  const initProgress = useSessionStore((s) => s.initProgress)
   const bashCommandEntry = usePreferencesStore((s) => s.bashCommandEntry)
   const colors = useColors()
   const isBusy = tab?.status === 'running' || tab?.status === 'connecting'
@@ -384,7 +385,7 @@ export function InputBar() {
       : bashMode
         ? bashPlaceholder
         : isConnecting
-          ? 'Initializing...'
+          ? (initProgress || 'Initializing…')
           : voiceState === 'recording'
             ? 'Recording... ✓ to confirm, ✕ to cancel'
             : voiceState === 'transcribing'

--- a/desktop/src/renderer/hooks/useTabRestoration.ts
+++ b/desktop/src/renderer/hooks/useTabRestoration.ts
@@ -23,14 +23,17 @@ export function useTabRestoration() {
     let aborted = false
     useSessionStore.getState().initStaticInfo().then(async () => {
       if (aborted) return
+      useSessionStore.setState({ initProgress: 'Loading saved tabs…' })
       const homeDir = useSessionStore.getState().staticInfo?.homePath || '~'
 
       // Try restoring saved tabs
       const saved = await window.ion.loadTabs().catch(() => null)
       if (saved && saved.tabs && saved.tabs.length > 0) {
+        useSessionStore.setState({ initProgress: `Restoring ${saved.tabs.length} tabs…` })
         // Restore each saved tab
         const restoredTabIds: Array<{ tabId: string; sessionId: string | null; index: number }> = []
         for (let i = 0; i < saved.tabs.length; i++) {
+          useSessionStore.setState({ initProgress: `Restoring tab ${i + 1} of ${saved.tabs.length}…` })
           const st = saved.tabs[i]
           if (st.conversationId && !st.isEngine) {
             // Conversation tab with a session -- resume it
@@ -277,6 +280,7 @@ export function useTabRestoration() {
           }
         }
 
+        useSessionStore.setState({ initProgress: 'Loading history…' })
         // Load historical session messages for tabs that have them
         for (const { tabId, index } of restoredTabIds) {
           const st = saved.tabs[index]
@@ -403,6 +407,7 @@ export function useTabRestoration() {
           }))
         }
 
+        useSessionStore.setState({ initProgress: 'Restoring workspace…' })
         // Restore editor states (per-directory)
         if (saved.editorStates) {
           const restoredEditorStates = new Map<string, any>()
@@ -477,7 +482,7 @@ export function useTabRestoration() {
         const restoredExpanded = typeof saved.isExpanded === 'boolean'
           ? saved.isExpanded
           : usePreferencesStore.getState().expandOnTabSwitch
-        useSessionStore.setState({ isExpanded: restoredExpanded, tabsReady: true })
+        useSessionStore.setState({ isExpanded: restoredExpanded, tabsReady: true, initProgress: null })
         return
       }
 
@@ -490,6 +495,7 @@ export function useTabRestoration() {
         useSessionStore.setState((s) => ({
           tabs: s.tabs.map((t, i) => (i === 0 ? { ...t, workingDirectory: startDir, hasChosenDirectory: hasChosen } : t)),
         }))
+        useSessionStore.setState({ initProgress: 'Creating new tab…' })
         const registerInitialTab = async (retries = 5): Promise<void> => {
           for (let i = 0; i < retries; i++) {
             try {
@@ -498,6 +504,7 @@ export function useTabRestoration() {
                 tabs: s.tabs.map((t, idx) => (idx === 0 ? { ...t, id: tabId } : t)),
                 activeTabId: tabId,
                 tabsReady: true,
+                initProgress: null,
               }))
               return
             } catch {
@@ -505,7 +512,7 @@ export function useTabRestoration() {
             }
           }
           // All retries failed — still set tabsReady so UI isn't stuck forever
-          useSessionStore.setState({ tabsReady: true })
+          useSessionStore.setState({ tabsReady: true, initProgress: null })
         }
         registerInitialTab()
       }

--- a/desktop/src/renderer/stores/session-store-types.ts
+++ b/desktop/src/renderer/stores/session-store-types.ts
@@ -43,6 +43,7 @@ export interface State {
   editorGeometry: { x: number; y: number; w: number; h: number }
   planGeometry: { x: number; y: number; w: number; h: number }
   tabsReady: boolean
+  initProgress: string | null
   backend: 'api' | 'cli'
   worktreeUncommittedMap: Map<string, boolean>
 

--- a/desktop/src/renderer/stores/sessionStore.ts
+++ b/desktop/src/renderer/stores/sessionStore.ts
@@ -45,6 +45,7 @@ const initialState = {
   editorGeometry: { x: 60, y: 80, w: 680, h: 480 },
   planGeometry: { x: 60, y: 80, w: 720, h: 420 },
   tabsReady: false,
+  initProgress: null,
   backend: 'api' as const,
   worktreeUncommittedMap: new Map(),
   engineAgentStates: new Map(),

--- a/engine/internal/backend/plan_mode_prompt.go
+++ b/engine/internal/backend/plan_mode_prompt.go
@@ -116,9 +116,12 @@ Before finishing, re-read the plan file and verify:
 ### Phase 5: Exit
 When your plan is complete and you are confident it addresses the request, call ExitPlanMode. This presents your plan for user approval. Do NOT ask "is this plan okay?" via text -- ExitPlanMode handles that. Never use AskUserQuestion to ask about plan approval -- that is what ExitPlanMode is for. AskUserQuestion is only for clarifying questions about what to put *into* the plan.
 
+Do not use AskUserQuestion as a way to delay calling ExitPlanMode. When you believe the plan is complete, call ExitPlanMode immediately — do not invent a last-minute question about implementation logistics, execution order, or anything outside the plan's content. Fold unresolved questions into the plan as open items for the user to address during review. Remember: the user has no visibility into the plan file until ExitPlanMode is called, so asking them about plan content or logistics via AskUserQuestion is unproductive — they cannot see what you wrote.
+
 ## Turn Behavior
 Each of your turns should end in one of two ways:
 1. **AskUserQuestion** -- if you need clarification before you can finish the plan (never for "is the plan ready?" or "should I proceed?" -- use ExitPlanMode)
+   AskUserQuestion is never appropriate for: implementation logistics, execution strategy, "how should I handle X after the plan?", or any question whose answer would not change what gets written in the plan file. The user has no visibility into plan content until ExitPlanMode is called — do not ask about it.
 2. **ExitPlanMode** -- if the plan is complete and ready for review
 
 Do not end a turn without one of these. Do not implement anything.
@@ -148,6 +151,7 @@ func buildPlanModeSparseReminder(planFilePath string) string {
 			"Read-only except plan file (%s).%s "+
 			"End turns with AskUserQuestion (for clarifications) or ExitPlanMode (for plan approval). "+
 			"Never use AskUserQuestion to ask for plan approval -- that is what ExitPlanMode is for. "+
+			"If the plan is written and complete, call ExitPlanMode — do not delay with another question. The user has no visibility into plan content until ExitPlanMode is called. "+
 			"Forbidden as prose: \"Is this plan okay?\", \"Should I proceed?\", \"Let me know if you'd like changes\", \"How does this plan look?\" -- these must use ExitPlanMode or AskUserQuestion.",
 		planFilePath, amendHint)
 }

--- a/engine/internal/tools/ask_user_question.go
+++ b/engine/internal/tools/ask_user_question.go
@@ -20,13 +20,15 @@ func AskUserQuestionTool() *types.ToolDef {
 		Name: AskUserQuestionName,
 		Description: `Ask the user a question to gather information, clarify ambiguity, or get a decision. The run pauses until the user responds. Use this instead of guessing when requirements are unclear.
 
-When the question has a finite set of reasonable answers, ALWAYS provide options — this is faster for the user than typing. The user can always type a custom answer even when options are provided. Only omit options for genuinely open-ended questions (e.g. "What should the project be called?").`,
+When the question has a finite set of reasonable answers, ALWAYS provide options — this is faster for the user than typing. The user can always type a custom answer even when options are provided. Only omit options for genuinely open-ended questions (e.g. "What should the project be called?").
+
+IMPORTANT: The question is displayed in a small UI card — keep it to 1-2 sentences containing only the decision point. Any necessary context, explanation, or narrative should be written as regular assistant text BEFORE calling this tool. Do not put background information, analysis, or reasoning into the question field.`,
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
 				"question": map[string]any{
 					"type":        "string",
-					"description": "The question to ask the user. Should be clear, specific, and end with a question mark.",
+					"description": "The question to ask the user. Must be 1-2 concise sentences containing only the decision point, ending with a question mark. Do not include background context, narrative, or explanation — put that in your regular message text before calling this tool.",
 				},
 				"options": map[string]any{
 					"type": "array",


### PR DESCRIPTION
## Summary

Hides UI during desktop initialization to eliminate visual churn, and refines two engine system prompts for better tool behavior.

## Changes

- **desktop:** Gate all content panes on `tabsReady` so nothing renders until tab restoration completes. The input bar shows dynamic progress text ('Loading saved tabs…', 'Restoring tab 3 of 12…', etc.) instead of a static message, and everything appears at once when ready — no flickering tabs or panel churn.
- **engine:** Improve ask-user-question tool instructions for clearer guidance on when and how to use the tool.
- **engine:** Clarify plan mode exit timing in prompts so the model understands when plan mode ends relative to tool calls.