### PR TITLE
Make engine view tabs resilient across restarts and attaches

### DIFF
--- a/desktop/src/main/__tests__/engine-bridge-start-session.test.ts
+++ b/desktop/src/main/__tests__/engine-bridge-start-session.test.ts
@@ -1,0 +1,143 @@
+/**
+ * engine-bridge-start-session — post-start reconcile handshake tests
+ *
+ * The engine's `start_session` is idempotent. When a desktop attaches
+ * to an engine that already has the session loaded (daemon reuse,
+ * desktop reinstall, reconnect after socket flap), the engine returns
+ * `{ ok: true }` immediately without re-emitting in-flight state.
+ *
+ * `EngineBridge.startSession` closes the gap by issuing a
+ * `reconcile_state` RPC right after a successful `start_session`. That
+ * triggers the engine to re-emit `engine_agent_state` + `engine_status`
+ * on the same key, including any pending AskUserQuestion / ExitPlanMode
+ * permission denials retained on the session. Without this handshake,
+ * a freshly-attached desktop would never see those denials and the
+ * AskUserQuestion card would silently fail to appear.
+ *
+ * These tests pin the wire-level behavior:
+ *   - Success path: start_session ok → reconcile_state dispatched.
+ *   - Failure path: start_session error → reconcile_state NOT dispatched
+ *     (the session isn't known to the engine; nothing to snapshot).
+ *   - Reconcile uses the same key the caller passed to startSession.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(() => ''),
+}))
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execSync: vi.fn(() => ''),
+}))
+vi.mock('../logger', () => ({
+  log: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
+import { EngineBridge } from '../engine-bridge'
+import type { EngineConfig } from '../../shared/types'
+
+function makeConfig(): EngineConfig {
+  return {
+    profileId: 'test',
+    extensions: [],
+    workingDirectory: '/tmp',
+  } as EngineConfig
+}
+
+function harness() {
+  const bridge = new EngineBridge()
+  // Stub connect — we don't want to actually open a socket.
+  ;(bridge as any).connect = vi.fn(async () => {})
+
+  // Track dispatch calls. _sendWithResult is the start_session path;
+  // sendReconcileState is the post-start reconcile path.
+  const sendWithResultCalls: any[] = []
+  const reconcileCalls: string[] = []
+  ;(bridge as any)._sendWithResult = vi.fn(async (msg: any) => {
+    sendWithResultCalls.push(msg)
+    return { ok: true }
+  })
+  const origSendReconcileState = bridge.sendReconcileState.bind(bridge)
+  bridge.sendReconcileState = (key: string) => {
+    reconcileCalls.push(key)
+    // Still exercise the underlying path to confirm it doesn't throw.
+    try { origSendReconcileState(key) } catch { /* socket not open in tests */ }
+  }
+
+  return { bridge, sendWithResultCalls, reconcileCalls }
+}
+
+describe('EngineBridge.startSession post-start reconcile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('dispatches reconcile_state after a successful start_session', async () => {
+    const { bridge, sendWithResultCalls, reconcileCalls } = harness()
+
+    const result = await bridge.startSession('tab1:inst-a', makeConfig())
+
+    expect(result.ok).toBe(true)
+    // start_session dispatched exactly once.
+    expect(sendWithResultCalls.filter((m) => m.cmd === 'start_session')).toHaveLength(1)
+    // reconcile_state dispatched exactly once, with the same key.
+    expect(reconcileCalls).toEqual(['tab1:inst-a'])
+  })
+
+  it('skips reconcile_state when start_session fails', async () => {
+    const { bridge, reconcileCalls } = harness()
+    // Override _sendWithResult to return a failure.
+    ;(bridge as any)._sendWithResult = vi.fn(async () => ({ ok: false, error: 'boom' }))
+
+    const result = await bridge.startSession('tab2:inst-b', makeConfig())
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('boom')
+    // No reconcile dispatched.
+    expect(reconcileCalls).toEqual([])
+  })
+
+  it('registers the session in activeSessions before dispatching', async () => {
+    const { bridge } = harness()
+    expect(bridge.activeSessions.has('tab3:inst-c')).toBe(false)
+
+    await bridge.startSession('tab3:inst-c', makeConfig())
+
+    expect(bridge.activeSessions.has('tab3:inst-c')).toBe(true)
+  })
+
+  it('reuses tracked conversationId from prior session lifecycle', async () => {
+    const { bridge, sendWithResultCalls } = harness()
+    // Pre-seed an entry with a conversationId (simulates a session that
+    // was started before and is being re-started after a stop).
+    bridge.activeSessions.set('tab4:inst-d', {
+      config: makeConfig(),
+      conversationId: 'conv-xyz',
+    })
+
+    await bridge.startSession('tab4:inst-d', makeConfig())
+
+    const startMsg = sendWithResultCalls.find((m) => m.cmd === 'start_session')
+    expect(startMsg).toBeDefined()
+    expect(startMsg.config.sessionId).toBe('conv-xyz')
+  })
+
+  it('honors an explicit config.sessionId over the tracked conversationId', async () => {
+    const { bridge, sendWithResultCalls } = harness()
+    bridge.activeSessions.set('tab5:inst-e', {
+      config: makeConfig(),
+      conversationId: 'conv-tracked',
+    })
+
+    const config = { ...makeConfig(), sessionId: 'conv-explicit' }
+    await bridge.startSession('tab5:inst-e', config)
+
+    const startMsg = sendWithResultCalls.find((m) => m.cmd === 'start_session')
+    expect(startMsg.config.sessionId).toBe('conv-explicit')
+  })
+})

--- a/desktop/src/main/engine-bridge-conversations.ts
+++ b/desktop/src/main/engine-bridge-conversations.ts
@@ -1,0 +1,99 @@
+import type { EngineBridge } from './engine-bridge'
+import { log as _log } from './logger'
+
+function log(msg: string): void { _log('engine-bridge', msg) }
+
+/**
+ * Conversation-data RPC helpers for the engine bridge.
+ *
+ * Extracted from engine-bridge.ts to stay under the 600-line file-size
+ * cap. These helpers wrap the engine's data-plane RPCs that load,
+ * label, migrate, and clear stored conversations — they are
+ * connection-aware (each ensures the bridge is connected before
+ * dispatching) but they do not touch any other bridge state and have
+ * no shared invariant with the streaming event subscription, so they
+ * are a natural cohesive seam.
+ *
+ * Each helper is a thin wrapper around `_sendWithData` / `_sendWithResult`
+ * with the request shape pinned to the matching `cmd:` value in
+ * engine/internal/server/server.go (and the response shape in
+ * engine/internal/server/dispatch_data.go). Keep the cmd strings in
+ * sync with the engine — they are the wire-protocol contract, not
+ * internal naming.
+ *
+ * Logging policy: every RPC logs entry at INFO with the resolved
+ * identifiers (sessionId / conversationId / provider / limit) so the
+ * data-plane traffic is reconstructable from `~/.ion/desktop.log`. The
+ * thin wrappers in engine-bridge.ts delegate here directly and do not
+ * re-log; double-logging would clutter the trace without adding signal.
+ */
+
+export async function listStoredSessions(bridge: EngineBridge, limit?: number): Promise<any[]> {
+  await bridge.connect()
+  log(`listStoredSessions: limit=${limit ?? 50}`)
+  const result = await bridge._sendWithData<any[]>({ cmd: 'list_stored_sessions', limit: limit || 50 })
+  return result.data || []
+}
+
+export async function loadSessionHistory(bridge: EngineBridge, sessionId: string): Promise<any[]> {
+  await bridge.connect()
+  log(`loadSessionHistory: sessionId=${sessionId}`)
+  const result = await bridge._sendWithData<any[]>({ cmd: 'load_session_history', key: sessionId })
+  return result.data || []
+}
+
+export async function loadChainHistory(bridge: EngineBridge, sessionIds: string[]): Promise<any[]> {
+  await bridge.connect()
+  log(`loadChainHistory: count=${sessionIds.length} first=${sessionIds[0] ?? 'none'}`)
+  const result = await bridge._sendWithData<any[]>({ cmd: 'load_session_history', sessionIds })
+  return result.data || []
+}
+
+export async function getConversation(bridge: EngineBridge, conversationId: string, offset = 0, limit = 50): Promise<any> {
+  await bridge.connect()
+  log(`getConversation: conversationId=${conversationId} offset=${offset} limit=${limit}`)
+  const result = await bridge._sendWithData<any>({ cmd: 'get_conversation', key: conversationId, offset, limit })
+  return result.data || { messages: [], total: 0, hasMore: false }
+}
+
+/**
+ * Wipes the LLM-visible message history for a stored conversation without
+ * requiring a live engine session. Called when /clear is issued on a tab
+ * that was loaded from disk but has never sent a prompt (so no engine
+ * session exists yet to receive dispatchClear). The conversationId is the
+ * session/conversation ID stored on the tab (tab.conversationId).
+ *
+ * Fields wiped (matches engine dispatchClear): Messages, LastInputTokens,
+ * LastInputTokensMsgCount. Entries, cost totals, and identity fields are
+ * preserved — /clear is a checkpoint, not a delete.
+ */
+export async function clearConversationFile(bridge: EngineBridge, conversationId: string): Promise<void> {
+  await bridge.connect()
+  log(`clearConversationFile: conversationId=${conversationId}`)
+  await bridge._sendWithResult({ cmd: 'clear_conversation_file', key: conversationId })
+}
+
+export async function saveSessionLabel(bridge: EngineBridge, sessionId: string, label: string): Promise<{ ok: boolean; error?: string }> {
+  await bridge.connect()
+  log(`saveSessionLabel: sessionId=${sessionId} labelLen=${label.length}`)
+  return bridge._sendWithResult({ cmd: 'save_session_label', key: sessionId, label })
+}
+
+export async function generateTitle(bridge: EngineBridge, text: string): Promise<string> {
+  await bridge.connect()
+  log(`generateTitle: textLen=${text.length}`)
+  const result = await bridge._sendWithData<{ title: string }>({ cmd: 'generate_title', text })
+  return result.data?.title || ''
+}
+
+export async function migrateConversation(
+  bridge: EngineBridge,
+  sessionId: string,
+  targetFormat: string,
+  targetDir: string,
+  sourceDir: string,
+): Promise<{ ok: boolean; error?: string; data?: { newSessionId: string; outputPath: string; messageCount: number; contentHash: string } }> {
+  await bridge.connect()
+  log(`migrateConversation: sessionId=${sessionId} targetFormat=${targetFormat} targetDir=${targetDir} sourceDir=${sourceDir}`)
+  return bridge._sendWithData({ cmd: 'migrate_conversation', key: sessionId, text: targetFormat, message: targetDir, args: sourceDir })
+}

--- a/desktop/src/main/engine-bridge-start-session.ts
+++ b/desktop/src/main/engine-bridge-start-session.ts
@@ -1,0 +1,92 @@
+import type { EngineBridge } from './engine-bridge'
+import { log as _log } from './logger'
+import type { EngineConfig } from '../shared/types'
+
+function log(msg: string): void { _log('engine-bridge', msg) }
+
+/**
+ * startSession — bridge attach handshake.
+ *
+ * Lives in its own file because the bridge's primary class file is at
+ * its 600-line cap and this handshake is the natural seam: it sequences
+ * three independent steps (session-id injection from prior conversation,
+ * `start_session` dispatch, post-start reconcile) that don't touch any
+ * other bridge state.
+ *
+ * Why a post-start reconcile:
+ *
+ * The engine's `start_session` is idempotent. When a desktop attaches to
+ * an engine that already has this session loaded (daemon reuse, desktop
+ * reinstall, reconnect after socket flap), the engine returns a bare
+ * `{ ok: true }` immediately — it does not re-emit the in-flight state
+ * (active agents, pending AskUserQuestion / ExitPlanMode denials, last
+ * context %, etc.). Without an explicit snapshot request, the desktop
+ * has no way to populate its renderer-side state for an
+ * already-running session.
+ *
+ * `ReconcileState` (engine/internal/session/manager.go) is the canonical
+ * reconnect handshake. It re-emits `engine_agent_state` and
+ * `engine_status` (including the pending PermissionDenials field) on
+ * the same key. The renderer's engine-event-slice already translates
+ * those snapshots into `tab.permissionDenied`, agent rows, footer
+ * values, etc. — so calling reconcile after start_session closes the
+ * "card never re-appears after desktop reinstall" gap end-to-end.
+ *
+ * Lifecycle / idempotence:
+ *
+ *   - We register the session in `activeSessions` BEFORE the dispatch
+ *     so reconnect logic (_reRegisterSessions) sees it on the next
+ *     socket recovery.
+ *   - Reconcile is fire-and-forget. The engine's `reconcile_state`
+ *     handler doesn't return a body; the snapshot arrives as ordinary
+ *     `engine_*` events on the existing event subscription. The renderer
+ *     subscribes once at bridge wireup, so it picks them up automatically.
+ *   - On a start_session failure we skip reconcile — the session isn't
+ *     known to the engine yet, so there's nothing to snapshot. Logged so
+ *     the failure-then-no-reconcile path is reconstructable from logs.
+ *
+ * Logging:
+ *
+ * Every step is logged at INFO with the session key and resolved config
+ * highlights so the attach cycle is reconstructable from `~/.ion/desktop.log`
+ * without a debugger. Both branches of the post-start conditional log —
+ * "requesting reconcile_state post-start" or "skipping reconcile (start
+ * failed: ...)" — so a grep for `reconcile_state` covers every attach.
+ */
+export async function startSession(
+  bridge: EngineBridge,
+  key: string,
+  config: EngineConfig,
+): Promise<{ ok: boolean; error?: string }> {
+  const entry = bridge.activeSessions.get(key)
+  // If we have a tracked conversationId from a previous session lifecycle,
+  // inject it into the config so the engine can resume the conversation.
+  // This is the same idempotence affordance the engine relies on: a fresh
+  // start_session call with a prior sessionId is a resume, not a new
+  // conversation.
+  if (entry?.conversationId && !config.sessionId) {
+    config = { ...config, sessionId: entry.conversationId }
+  }
+  log(`startSession: key=${key} model=${config.model} sessionId=${config.sessionId ?? 'none'}`)
+
+  // Register BEFORE dispatch so _reRegisterSessions on socket recovery
+  // sees this session even if start_session is still in flight at the
+  // moment of a reconnect.
+  bridge.activeSessions.set(key, { config, conversationId: entry?.conversationId })
+
+  await bridge.connect()
+  const result = await bridge._sendWithResult({ cmd: 'start_session', key, config })
+
+  // Post-start reconcile handshake. See the docblock at the top of this
+  // file for the full rationale — the short version is "tell the engine
+  // to re-emit its current snapshot so a freshly-attached desktop
+  // populates state for an already-running session, including pending
+  // AskUserQuestion / ExitPlanMode denials."
+  if (result.ok) {
+    log(`startSession: key=${key} requesting reconcile_state post-start`)
+    bridge.sendReconcileState(key)
+  } else {
+    log(`startSession: key=${key} skipping reconcile (start failed: ${result.error ?? 'unknown'})`)
+  }
+  return result
+}

--- a/desktop/src/main/engine-bridge.ts
+++ b/desktop/src/main/engine-bridge.ts
@@ -5,6 +5,8 @@ import { join } from 'path'
 import { homedir } from 'os'
 import { log as _log, debug as _debug, warn as _warn, error as _error } from './logger'
 import { spawnEngineServer } from './engine-bridge-spawn'
+import { startSession as startSessionImpl } from './engine-bridge-start-session'
+import * as conv from './engine-bridge-conversations'
 import type { EngineConfig, EngineEvent, ImageAttachmentPayload } from '../shared/types'
 
 const TAG = 'EngineBridge'
@@ -42,7 +44,11 @@ export class EngineBridge extends EventEmitter {
   private requestCounter = 0
   private connectPromise: Promise<void> | null = null
   private reconnectDisabled = false
-  private activeSessions = new Map<string, { config: EngineConfig; conversationId?: string }>()
+  // Treated as internal to the engine-bridge.* module group (used by
+  // engine-bridge-start-session.ts). Not `private` so sibling files in
+  // the same module group can read/write the registry without forcing
+  // every helper back into this already-cap-bound file.
+  activeSessions = new Map<string, { config: EngineConfig; conversationId?: string }>()
   /** Client-side key aliases: oldKey → newKey. Rewrites incoming event keys. */
   private keyAliases = new Map<string, string>()
 
@@ -281,7 +287,18 @@ export class EngineBridge extends EventEmitter {
     }
   }
 
-  private _sendWithResult(msg: any): Promise<{ ok: boolean; error?: string }> {
+  /**
+   * Internal command dispatch with typed { ok, error } response.
+   *
+   * Marked with a leading underscore to signal "treat as internal to the
+   * engine-bridge.* module group" — TypeScript's `private` keyword would
+   * be stricter but would also prevent sibling files like
+   * engine-bridge-start-session.ts from calling it, which is the
+   * extraction-driven seam we need to stay under the file-size cap.
+   * Treat external callers as a code-review concern, not a compile-time
+   * one.
+   */
+  _sendWithResult(msg: any): Promise<{ ok: boolean; error?: string }> {
     const requestId = `bridge-${++this.requestCounter}-${Date.now()}`
     msg.requestId = requestId
 
@@ -301,7 +318,9 @@ export class EngineBridge extends EventEmitter {
     })
   }
 
-  private _sendWithData<T>(msg: any): Promise<{ ok: boolean; error?: string; data?: T }> {
+  // Internal to the engine-bridge.* module group. See _sendWithResult
+  // for the rationale on widening from `private` to module-package scope.
+  _sendWithData<T>(msg: any): Promise<{ ok: boolean; error?: string; data?: T }> {
     const requestId = `bridge-${++this.requestCounter}-${Date.now()}`
     msg.requestId = requestId
 
@@ -323,16 +342,7 @@ export class EngineBridge extends EventEmitter {
   // ─── Public API ───
 
   async startSession(key: string, config: EngineConfig): Promise<{ ok: boolean; error?: string }> {
-    const entry = this.activeSessions.get(key)
-    // If we have a tracked conversationId from a previous session lifecycle,
-    // inject it into the config so the engine can resume the conversation.
-    if (entry?.conversationId && !config.sessionId) {
-      config = { ...config, sessionId: entry.conversationId }
-    }
-    log(`startSession: key=${key} model=${config.model} sessionId=${config.sessionId ?? 'none'}`)
-    this.activeSessions.set(key, { config, conversationId: entry?.conversationId })
-    await this.connect()
-    return this._sendWithResult({ cmd: 'start_session', key, config })
+    return startSessionImpl(this, key, config)
   }
 
   /** Send a typed-response command. Sibling helpers (e.g. engine-bridge-fs.ts) layer on top of the bridge via this. */
@@ -441,56 +451,40 @@ export class EngineBridge extends EventEmitter {
     this._send({ cmd: 'set_plan_mode', key, enabled, allowedTools, source })
   }
 
+  // ─── Conversation-data RPCs ───
+  //
+  // Bodies live in engine-bridge-conversations.ts. The methods stay on
+  // the bridge so external callers (renderer IPC, control plane, OAuth
+  // token store) keep their existing surface area. Each wrapper is a
+  // single-line delegate — see the sibling file for behavior, logging,
+  // and wire-protocol contract notes.
+
   async listStoredSessions(limit?: number): Promise<any[]> {
-    await this.connect()
-    const result = await this._sendWithData<any[]>({ cmd: 'list_stored_sessions', limit: limit || 50 })
-    return result.data || []
+    return conv.listStoredSessions(this, limit)
   }
 
   async loadSessionHistory(sessionId: string): Promise<any[]> {
-    await this.connect()
-    const result = await this._sendWithData<any[]>({ cmd: 'load_session_history', key: sessionId })
-    return result.data || []
+    return conv.loadSessionHistory(this, sessionId)
   }
 
   async loadChainHistory(sessionIds: string[]): Promise<any[]> {
-    await this.connect()
-    const result = await this._sendWithData<any[]>({ cmd: 'load_session_history', sessionIds })
-    return result.data || []
+    return conv.loadChainHistory(this, sessionIds)
   }
 
   async getConversation(conversationId: string, offset = 0, limit = 50): Promise<any> {
-    await this.connect()
-    const result = await this._sendWithData<any>({ cmd: 'get_conversation', key: conversationId, offset, limit })
-    return result.data || { messages: [], total: 0, hasMore: false }
+    return conv.getConversation(this, conversationId, offset, limit)
   }
 
-  /**
-   * Wipes the LLM-visible message history for a stored conversation without
-   * requiring a live engine session. Called when /clear is issued on a tab
-   * that was loaded from disk but has never sent a prompt (so no engine
-   * session exists yet to receive dispatchClear). The conversationId is the
-   * session/conversation ID stored on the tab (tab.conversationId).
-   *
-   * Fields wiped (matches engine dispatchClear): Messages, LastInputTokens,
-   * LastInputTokensMsgCount. Entries, cost totals, and identity fields are
-   * preserved — /clear is a checkpoint, not a delete.
-   */
   async clearConversationFile(conversationId: string): Promise<void> {
-    await this.connect()
-    log(`clearConversationFile: conversationId=${conversationId}`)
-    await this._sendWithResult({ cmd: 'clear_conversation_file', key: conversationId })
+    return conv.clearConversationFile(this, conversationId)
   }
 
   async saveSessionLabel(sessionId: string, label: string): Promise<{ ok: boolean; error?: string }> {
-    await this.connect()
-    return this._sendWithResult({ cmd: 'save_session_label', key: sessionId, label })
+    return conv.saveSessionLabel(this, sessionId, label)
   }
 
   async generateTitle(text: string): Promise<string> {
-    await this.connect()
-    const result = await this._sendWithData<{ title: string }>({ cmd: 'generate_title', text })
-    return result.data?.title || ''
+    return conv.generateTitle(this, text)
   }
 
   async migrateConversation(
@@ -499,8 +493,7 @@ export class EngineBridge extends EventEmitter {
     targetDir: string,
     sourceDir: string,
   ): Promise<{ ok: boolean; error?: string; data?: { newSessionId: string; outputPath: string; messageCount: number; contentHash: string } }> {
-    await this.connect()
-    return this._sendWithData({ cmd: 'migrate_conversation', key: sessionId, text: targetFormat, message: targetDir, args: sourceDir })
+    return conv.migrateConversation(this, sessionId, targetFormat, targetDir, sourceDir)
   }
 
   async listModels(): Promise<{ models: any[]; providers: any[] }> {

--- a/desktop/src/main/event-wiring.ts
+++ b/desktop/src/main/event-wiring.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs'
 import { IPC } from '../shared/types'
 import type { NormalizedEvent, EnrichedError } from '../shared/types'
 import { log as _log } from './logger'
-import { state, sessionPlane, engineBridge, activeAssistantMessages, activeToolInputs, lastMessagePreview, extensionCommandRegistry } from './state'
+import { state, sessionPlane, engineBridge, activeAssistantMessages, activeToolInputs, lastMessagePreview, extensionCommandRegistry, forwardedEnginePermissionDenials } from './state'
 import { broadcast } from './broadcast'
 import { currentBackend } from './settings-store'
 import { normalizedToRemote } from './remote/protocol'
@@ -77,6 +77,47 @@ export function wireEngineBridgeEvents(): void {
         log(`engineBridge: agent_state forwarded key=${key} count=${agents.length} statuses=[${statuses}]`)
       }
       state.remoteTransport.send({ type: `engine_${event.type.replace('engine_', '')}`, tabId, instanceId, ...event })
+
+      // Synthesize a `permission_request` envelope for iOS when an
+      // engine-view `engine_status` event carries AskUserQuestion or
+      // ExitPlanMode denials. The CLI/sessionPlane path forwards these
+      // from `task_complete` in wireRemoteSessionPlaneForwarding above,
+      // but engine-view events never reach sessionPlane (key mismatch:
+      // EngineControlPlane is keyed by bare tabId, engine events arrive
+      // with `tabId:instanceId`). Without this block, iOS receives the
+      // engine_status itself (forwarded above) but has no decoder for
+      // `permissionDenials` inside it — the card-rendering path on iOS
+      // is keyed off `permission_request`. See plan-section "Files to
+      // modify → event-wiring.ts" for the cross-reference.
+      //
+      // Dedupe via forwardedEnginePermissionDenials: engine_status fires
+      // repeatedly, so without a guard every cost-only tick would re-push
+      // the same envelope and re-fire the iOS push notification.
+      if (event.type === 'engine_status' && Array.isArray(event.fields?.permissionDenials) && event.fields.permissionDenials.length > 0 && instanceId) {
+        for (const denial of event.fields.permissionDenials) {
+          if (denial.toolName !== 'AskUserQuestion' && denial.toolName !== 'ExitPlanMode') continue
+          const questionId = `denied-${denial.toolUseId}`
+          if (forwardedEnginePermissionDenials.has(questionId)) {
+            // Already pushed for this toolUseId — skip silently. We hit
+            // this path on every cost-only engine_status tick after the
+            // initial denial-carrying tick.
+            continue
+          }
+          forwardedEnginePermissionDenials.add(questionId)
+          const pushBody = denial.toolName === 'AskUserQuestion'
+            ? 'Question waiting for your answer'
+            : 'Plan ready for your review'
+          log(`engine_status: forwarding ${denial.toolName} denial to remote key=${key} questionId=${questionId}`)
+          state.remoteTransport.send({
+            type: 'permission_request',
+            tabId,
+            questionId,
+            toolName: denial.toolName,
+            toolInput: denial.toolInput,
+            options: [],
+          }, true, { title: 'Ion needs your attention', body: pushBody })
+        }
+      }
 
       // /clear success → relay an iOS-renderable divider so the mobile
       // client sees the checkpoint immediately. We piggy-back on the

--- a/desktop/src/main/remote/protocol.ts
+++ b/desktop/src/main/remote/protocol.ts
@@ -26,7 +26,7 @@ export interface RemoteTabState {
   isTerminalOnly?: boolean
   isEngine?: boolean
   engineProfileId?: string | null
-  engineInstances?: Array<{ id: string; label: string }>
+  engineInstances?: Array<{ id: string; label: string; waitingState?: 'plan-ready' | 'question' | null }>
   activeEngineInstanceId?: string | null
   terminalInstances?: TerminalInstanceInfo[]
   activeTerminalInstanceId?: string | null

--- a/desktop/src/main/remote/snapshot.ts
+++ b/desktop/src/main/remote/snapshot.ts
@@ -42,7 +42,44 @@ export async function getRemoteTabStates(): Promise<RemoteTabState[]> {
               }
             }
             var queue = (t.permissionQueue || []).slice();
-            if (t.status !== 'failed' && t.status !== 'dead') {
+            // Promote PER-ENGINE-INSTANCE denials into the parent tab's
+            // permissionQueue so the iOS card path (which keys off the
+            // tab-level queue) continues to work unchanged at the
+            // conversation level. We pick the *active* instance's
+            // denial — sibling instances under the same tab are
+            // independent sub-conversations and iOS only navigates one
+            // engine sub-tab at a time.
+            //
+            // NB: iOS does NOT consume per-instance waitingState into
+            // any parent-tab field; the parent pill glows because the
+            // promoted denial is in permissionQueue. The per-instance
+            // waitingState (set below on engineInstances[i]) drives the
+            // iOS sub-tab pill dot in EngineInstanceBar, not the
+            // parent-tab pill. If you ever want to bubble per-instance
+            // state into the parent tab fields directly (separate from
+            // queue promotion), do it here — not by piping waitingState
+            // through to RemoteTabState top-level.
+            if (t.isEngine === true && s.enginePermissionDenied && s.enginePermissionDenied.get) {
+              var ePane = s.enginePanes && s.enginePanes.get ? s.enginePanes.get(t.id) : null;
+              var activeInst = ePane ? (ePane.activeInstanceId || (ePane.instances && ePane.instances[0] && ePane.instances[0].id)) : null;
+              if (activeInst) {
+                var pdEntry = s.enginePermissionDenied.get(t.id + ':' + activeInst);
+                var pdTools = pdEntry && pdEntry.tools;
+                if (pdTools && pdTools.length > 0) {
+                  for (var pdi = 0; pdi < pdTools.length; pdi++) {
+                    queue.push({
+                      questionId: 'denied-' + pdTools[pdi].toolUseId,
+                      toolName: pdTools[pdi].toolName,
+                      toolTitle: pdTools[pdi].toolName,
+                      toolInput: pdTools[pdi].toolInput,
+                      options: [],
+                    });
+                  }
+                }
+              }
+            } else if (t.status !== 'failed' && t.status !== 'dead') {
+              // CLI tabs: unchanged path. permissionDenied lives on the
+              // tab itself.
               var denied = t.permissionDenied && t.permissionDenied.tools;
               if (denied && denied.length > 0) {
                 for (var d = 0; d < denied.length; d++) {
@@ -69,14 +106,31 @@ export async function getRemoteTabStates(): Promise<RemoteTabState[]> {
               activeTerminalInstanceId = pane.activeInstanceId || pane.instances[0].id;
             }
             var ePanes = s.enginePanes;
-            var ePane = ePanes && ePanes.get ? ePanes.get(t.id) : null;
+            var ePaneForList = ePanes && ePanes.get ? ePanes.get(t.id) : null;
             var engineInstances = undefined;
             var activeEngineInstanceId = undefined;
-            if (ePane && ePane.instances && ePane.instances.length > 0) {
-              engineInstances = ePane.instances.map(function(inst) {
-                return { id: inst.id, label: inst.label };
+            if (ePaneForList && ePaneForList.instances && ePaneForList.instances.length > 0) {
+              // For each instance, derive its individual waitingState
+              // from enginePermissionDenied so iOS can show a per-sub-tab
+              // status dot in EngineInstanceBar. 'question' outranks
+              // 'plan-ready' (matches desktop's getWaitingState helper).
+              engineInstances = ePaneForList.instances.map(function(inst) {
+                var ws = null;
+                if (s.enginePermissionDenied && s.enginePermissionDenied.get) {
+                  var pdEntry = s.enginePermissionDenied.get(t.id + ':' + inst.id);
+                  var pdTools = pdEntry && pdEntry.tools;
+                  if (pdTools && pdTools.length > 0) {
+                    var hasPlanReady = false;
+                    for (var k = 0; k < pdTools.length; k++) {
+                      if (pdTools[k].toolName === 'AskUserQuestion') { ws = 'question'; break; }
+                      if (pdTools[k].toolName === 'ExitPlanMode') hasPlanReady = true;
+                    }
+                    if (ws === null && hasPlanReady) ws = 'plan-ready';
+                  }
+                }
+                return { id: inst.id, label: inst.label, waitingState: ws };
               });
-              activeEngineInstanceId = ePane.activeInstanceId || ePane.instances[0].id;
+              activeEngineInstanceId = ePaneForList.activeInstanceId || ePaneForList.instances[0].id;
             }
             return {
               id: t.id,

--- a/desktop/src/main/state.ts
+++ b/desktop/src/main/state.ts
@@ -109,3 +109,26 @@ export const modelCache = {
  */
 export const extensionCommandRegistry = new Map<string, Set<string>>()
 
+/**
+ * Dedupe set for AskUserQuestion / ExitPlanMode `permission_request`
+ * envelopes synthesized from engine-view `engine_status.permissionDenials`
+ * and forwarded to iOS. The engine emits engine_status repeatedly
+ * (cost-only ticks fire ~1ms after the denial-carrying tick), so we'd
+ * otherwise re-push the same `denied-<toolUseId>` question over and over
+ * — each one fires a push notification, which is the visible spam.
+ *
+ * Keyed by the synthetic `questionId` (`denied-<toolUseId>`). The toolUseId
+ * is engine-assigned and unique per call, so a fresh question always
+ * misses the set. Entries are cleared:
+ *   - When the user answers (renderer clears tab.permissionDenied → next
+ *     engine_status sees no denials → nothing to forward; the answered
+ *     toolUseId is never seen again because the engine doesn't re-emit it).
+ *   - When the engine tab is closed (closeTab; see wiring below).
+ *
+ * Memory bound: ~one entry per AskUserQuestion ever asked on this desktop
+ * process. Acceptable — toolUseId is a short string and the process is
+ * already long-lived; if it becomes a leak we can prune on engine_dead
+ * or on snapshot reconcile.
+ */
+export const forwardedEnginePermissionDenials = new Set<string>()
+

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -24,6 +24,7 @@ import { useHealthReconciliation } from './hooks/useHealthReconciliation'
 import { useThemeSync } from './hooks/useThemeSync'
 import { useTrayMenuListeners } from './hooks/useTrayMenuListeners'
 import { useTabRestoration } from './hooks/useTabRestoration'
+import { useEnginePermissionDenialBackfill } from './hooks/useEnginePermissionDenialBackfill'
 import { useClickThrough } from './hooks/useClickThrough'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useWindowHeight, useInputRowHeight } from './hooks/useWindowGeometry'
@@ -41,6 +42,7 @@ export default function App() {
   useThemeSync()
   useTrayMenuListeners()
   useTabRestoration()
+  useEnginePermissionDenialBackfill()
   useClickThrough()
 
   // Listen for auto-update download notifications from the main process

--- a/desktop/src/renderer/components/EngineStatusBar.tsx
+++ b/desktop/src/renderer/components/EngineStatusBar.tsx
@@ -4,6 +4,7 @@ import { Reorder } from 'framer-motion'
 import { useColors } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
 import type { EngineInstance } from '../../shared/types'
+import { getEngineInstanceWaitingState } from './TabStripShared'
 
 interface Props {
   tabId: string
@@ -15,6 +16,11 @@ export function EngineStatusBar({ tabId }: Props) {
   const instances = pane?.instances || []
   const activeId = pane?.activeInstanceId || null
   const tabs = useSessionStore((s) => s.tabs)
+  // Subscribe to enginePermissionDenied so the per-instance status dot
+  // re-renders when this tab's instances acquire or clear a pending
+  // AskUserQuestion / ExitPlanMode denial. The map identity changes on
+  // every write in engine-event-slice.ts.
+  useSessionStore((s) => s.enginePermissionDenied)
   // Other engine tabs this instance can be moved to
   const engineTargetTabs = tabs.filter((t) => t.isEngine && t.id !== tabId)
 
@@ -59,6 +65,21 @@ export function EngineStatusBar({ tabId }: Props) {
 
   const renderTab = (inst: EngineInstance) => {
     const isActive = inst.id === activeId
+    // Per-instance waiting-state dot. 'question' (yellow/orange) and
+    // 'plan-ready' (green) mirror the parent-tab pill glow palette in
+    // TabStripStatusDot.tsx. Null = no dot. Engine sub-tabs are
+    // independent sub-conversations, so the dot is scoped to whichever
+    // instance has the pending denial. The parent-tab pill in TabStrip
+    // bubbles "any instance waiting" via getWaitingState().
+    const waitingState = getEngineInstanceWaitingState(`${tabId}:${inst.id}`)
+    const dotColor =
+      waitingState === 'question' ? colors.infoText :
+        waitingState === 'plan-ready' ? colors.statusComplete :
+          null
+    const dotGlow =
+      waitingState === 'question' ? colors.tabGlowQuestion :
+        waitingState === 'plan-ready' ? colors.tabGlowPlanReady :
+          null
     return (
       <Reorder.Item
         key={inst.id}
@@ -88,6 +109,18 @@ export function EngineStatusBar({ tabId }: Props) {
           flexShrink: 0,
         }}
       >
+        {dotColor && (
+          <span
+            className="flex-shrink-0"
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: dotColor,
+              ...(dotGlow ? { boxShadow: `0 0 6px 2px ${dotGlow}` } : {}),
+            }}
+          />
+        )}
         {editingId === inst.id ? (
           <input
             data-ion-ui

--- a/desktop/src/renderer/components/EngineView.tsx
+++ b/desktop/src/renderer/components/EngineView.tsx
@@ -6,6 +6,7 @@ import { EngineDialog } from './EngineDialog'
 import { EngineStatusBar } from './EngineStatusBar'
 import { AgentPanel } from './AgentPanel'
 import { EngineFooter } from './EngineFooter'
+import { PermissionDeniedCard } from './PermissionDeniedCard'
 import { ArrowDown } from '@phosphor-icons/react'
 import {
   groupMessages,
@@ -64,6 +65,20 @@ export function EngineView({ tabId }: EngineViewProps) {
     return k ? (s.engineWorkingMessages.get(k) || '') : ''
   })
   const tabStatus = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.status)
+  // PermissionDenied is set on the parent tab by engine-event-slice when
+  // engine_status carries AskUserQuestion / ExitPlanMode denials. It is
+  // tab-scoped (not engine-instance-scoped) — see plan comment in
+  // engine-event-slice.ts case 'engine_status'. If a tab hosts multiple
+  // engine instances and two post denials concurrently, the last writer
+  // wins. That matches the existing single-card-per-tab UX in
+  // ConversationView; revisit if per-instance cards are wanted.
+  const permissionDenied = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.permissionDenied)
+  const tabMessages = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.messages || EMPTY_MESSAGES)
+  const tabPlanFilePath = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.planFilePath)
+  const tabGroupPinned = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.groupPinned)
+  const tabConversationId = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.conversationId)
+  const staticInfo = useSessionStore(s => s.staticInfo)
+  const submitEnginePrompt = useSessionStore(s => s.submitEnginePrompt)
   const isTall = useSessionStore(s => s.tallViewTabId === tabId)
   const toggleTallView = useSessionStore(s => s.toggleTallView)
   const engineModelOverride = useSessionStore(s => {
@@ -170,6 +185,35 @@ export function EngineView({ tabId }: EngineViewProps) {
       }
     }, 5_000)
   }
+
+  // ─── Permission-denied card handlers ───
+  //
+  // EngineView's variant of usePermissionDeniedHandlers. The conversation
+  // hook calls `sendMessage` (CLI/sessionPlane path); the engine variant
+  // calls `submitEnginePrompt` for the active engine instance so the
+  // answer is delivered as a new engine prompt on the same key.
+  //
+  // We deliberately do NOT reuse the conversation hook directly — that
+  // hook also implements the Plan-Mode → Implement flow which depends on
+  // CLI-specific machinery (resetTabSession, sendMessage signature with
+  // an implementationPhase flag). The engine variant currently supports
+  // only the AskUserQuestion path; ExitPlanMode on engine tabs is still
+  // an open item flagged in the plan.
+  const clearPermissionDenied = useCallback(() => {
+    useSessionStore.setState((s) => ({
+      tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, permissionDenied: null } : t)),
+    }))
+  }, [tabId])
+
+  const handleAnswerDenial = useCallback((answer: string) => {
+    console.log(`[EngineView] handleAnswerDenial: tab=${tabId.slice(0, 8)} key=${key} answerLen=${answer.length}`)
+    clearPermissionDenied()
+    if (!key) {
+      console.warn(`[EngineView] handleAnswerDenial: no active engine instance for tab=${tabId.slice(0, 8)} — dropping answer`)
+      return
+    }
+    submitEnginePrompt(tabId, answer, undefined, undefined)
+  }, [tabId, key, clearPermissionDenied, submitEnginePrompt])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%', position: 'relative' }}>
@@ -322,6 +366,27 @@ export function EngineView({ tabId }: EngineViewProps) {
           )}
         </AnimatePresence>
       </div>
+
+      {/* Permission-denied / AskUserQuestion card.
+          Rendered between the scrollable conversation area and the agent
+          panel so the question sits directly above the input where users
+          expect it. Wired to the engine's submitEnginePrompt so the answer
+          becomes a new prompt on the active engine instance. */}
+      <AnimatePresence>
+        {permissionDenied && (
+          <PermissionDeniedCard
+            tools={permissionDenied.tools}
+            tabId={tabId}
+            sessionId={tabConversationId ?? null}
+            projectPath={staticInfo?.projectPath || ''}
+            messages={tabMessages}
+            tabPlanFilePath={tabPlanFilePath}
+            tabGroupPinned={tabGroupPinned}
+            onDismiss={clearPermissionDenied}
+            onAnswer={handleAnswerDenial}
+          />
+        )}
+      </AnimatePresence>
 
       {/* Agent bars */}
       <div style={{ flex: agentPanelFullscreen ? 1 : undefined, overflow: agentPanelFullscreen ? 'auto' : undefined, minHeight: 0 }}>

--- a/desktop/src/renderer/components/EngineView.tsx
+++ b/desktop/src/renderer/components/EngineView.tsx
@@ -65,14 +65,18 @@ export function EngineView({ tabId }: EngineViewProps) {
     return k ? (s.engineWorkingMessages.get(k) || '') : ''
   })
   const tabStatus = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.status)
-  // PermissionDenied is set on the parent tab by engine-event-slice when
-  // engine_status carries AskUserQuestion / ExitPlanMode denials. It is
-  // tab-scoped (not engine-instance-scoped) — see plan comment in
-  // engine-event-slice.ts case 'engine_status'. If a tab hosts multiple
-  // engine instances and two post denials concurrently, the last writer
-  // wins. That matches the existing single-card-per-tab UX in
-  // ConversationView; revisit if per-instance cards are wanted.
-  const permissionDenied = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.permissionDenied)
+  // PermissionDenied is stored PER ENGINE INSTANCE in
+  // `enginePermissionDenied`, keyed by `${tabId}:${instanceId}`. Engine
+  // sub-tabs (instances) are independent sub-conversations, so storing
+  // the denial on the parent tab would show the same card on every
+  // sibling sub-tab. The card is scoped to whichever instance produced
+  // it; switching to a sibling without a pending denial shows no card.
+  //
+  // Parent-tab pill bubbling: getWaitingState() in TabStripShared.ts
+  // folds across this map for engine tabs, so the strip pill still
+  // glows when any sub-tab is blocked. iOS receives the active
+  // instance's denial via the snapshot path (see main/remote/snapshot.ts).
+  const permissionDenied = useSessionStore(s => key ? (s.enginePermissionDenied.get(key) || null) : null)
   const tabMessages = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.messages || EMPTY_MESSAGES)
   const tabPlanFilePath = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.planFilePath)
   const tabGroupPinned = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.groupPinned)
@@ -200,10 +204,13 @@ export function EngineView({ tabId }: EngineViewProps) {
   // only the AskUserQuestion path; ExitPlanMode on engine tabs is still
   // an open item flagged in the plan.
   const clearPermissionDenied = useCallback(() => {
-    useSessionStore.setState((s) => ({
-      tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, permissionDenied: null } : t)),
-    }))
-  }, [tabId])
+    if (!key) return
+    useSessionStore.setState((s) => {
+      const next = new Map(s.enginePermissionDenied)
+      next.set(key, null)
+      return { enginePermissionDenied: next }
+    })
+  }, [key])
 
   const handleAnswerDenial = useCallback((answer: string) => {
     console.log(`[EngineView] handleAnswerDenial: tab=${tabId.slice(0, 8)} key=${key} answerLen=${answer.length}`)

--- a/desktop/src/renderer/components/EngineView.tsx
+++ b/desktop/src/renderer/components/EngineView.tsx
@@ -77,7 +77,6 @@ export function EngineView({ tabId }: EngineViewProps) {
   // glows when any sub-tab is blocked. iOS receives the active
   // instance's denial via the snapshot path (see main/remote/snapshot.ts).
   const permissionDenied = useSessionStore(s => key ? (s.enginePermissionDenied.get(key) || null) : null)
-  const tabMessages = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.messages || EMPTY_MESSAGES)
   const tabPlanFilePath = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.planFilePath)
   const tabGroupPinned = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.groupPinned)
   const tabConversationId = useSessionStore(s => s.tabs.find(t => t.id === tabId)?.conversationId)
@@ -386,7 +385,7 @@ export function EngineView({ tabId }: EngineViewProps) {
             tabId={tabId}
             sessionId={tabConversationId ?? null}
             projectPath={staticInfo?.projectPath || ''}
-            messages={tabMessages}
+            messages={messages}
             tabPlanFilePath={tabPlanFilePath}
             tabGroupPinned={tabGroupPinned}
             onDismiss={clearPermissionDenied}

--- a/desktop/src/renderer/components/TabStrip.tsx
+++ b/desktop/src/renderer/components/TabStrip.tsx
@@ -23,6 +23,16 @@ import { TabPill } from './TabStripTabPill'
 
 export function TabStrip() {
   const tabs = useSessionStore((s) => s.tabs)
+  // Subscribe to engine state so the waiting-state border on an engine
+  // tab's pill re-renders when any of its sub-instances gets/clears a
+  // pending AskUserQuestion / ExitPlanMode denial. getWaitingState()
+  // reads these maps via useSessionStore.getState() at render time;
+  // these subscriptions trigger the re-render when the map identity
+  // changes. Without them, pills don't update on instance-scoped
+  // denial changes because tab.permissionDenied is no longer the
+  // engine source of truth.
+  useSessionStore((s) => s.enginePermissionDenied)
+  useSessionStore((s) => s.enginePanes)
   const activeTabId = useSessionStore((s) => s.activeTabId)
   const selectTab = useSessionStore((s) => s.selectTab)
   const closeTab = useSessionStore((s) => s.closeTab)

--- a/desktop/src/renderer/components/TabStripGroupPill.tsx
+++ b/desktop/src/renderer/components/TabStripGroupPill.tsx
@@ -5,7 +5,7 @@ import { useSessionStore } from '../stores/sessionStore'
 import { useColors } from '../theme'
 import { usePreferencesStore } from '../preferences'
 import type { TabGroupView } from '../hooks/useTabGroups'
-import { checkWorktreeUncommitted, shouldUseWorktree, zoomRect } from './TabStripShared'
+import { checkWorktreeUncommitted, getWaitingState, shouldUseWorktree, zoomRect } from './TabStripShared'
 import { StackedStatusDots } from './TabStripStatusDot'
 import { InlineRenameInput } from './TabStripInlineRenameInput'
 import { PillColorPicker } from './TabStripPillColorPicker'
@@ -56,15 +56,25 @@ export function GroupPill({
 
   const displayTitle = selectedTab ? (selectedTab.customTitle || selectedTab.title) : ''
 
-  // Derive aggregate waiting state: if ANY tab in the group is waiting on the user
-  // Question takes priority over plan-ready across all tabs in the group
+  // Subscribe to the engine-instance denial map so the group pill border
+  // re-renders when any engine sub-tab gets/clears a pending denial.
+  // `getWaitingState()` reads this map for engine tabs; without the
+  // subscription the group pill would stall on stale data.
+  useSessionStore((s) => s.enginePermissionDenied)
+  useSessionStore((s) => s.enginePanes)
+
+  // Derive aggregate waiting state: if ANY tab in the group is waiting on the user.
+  // Question takes priority over plan-ready across all tabs in the group.
+  // We delegate to getWaitingState() so the engine-tab branch (folding
+  // across per-instance denials in `enginePermissionDenied`) is honored
+  // here too. For CLI tabs the helper reads `tab.permissionDenied` as
+  // before.
   const groupWaitingState: 'plan-ready' | 'question' | null = (() => {
     let hasPlanReady = false
     for (const t of group.tabs) {
-      const tools = t.permissionDenied?.tools
-      if (!tools?.length) continue
-      if (tools.some((x) => x.toolName === 'AskUserQuestion')) return 'question'
-      if (tools.some((x) => x.toolName === 'ExitPlanMode')) hasPlanReady = true
+      const ws = getWaitingState(t)
+      if (ws === 'question') return 'question'
+      if (ws === 'plan-ready') hasPlanReady = true
     }
     return hasPlanReady ? 'plan-ready' : null
   })()

--- a/desktop/src/renderer/components/TabStripShared.ts
+++ b/desktop/src/renderer/components/TabStripShared.ts
@@ -84,13 +84,59 @@ export function formatRelativeShort(ms: number): string {
 /** Tristate "waiting for the user" derived from queued permission denials. */
 export type WaitingState = 'plan-ready' | 'question' | null
 
-/** Derive the waiting state from a tab's permission-denied tools. */
-export function getWaitingState(tab: TabState): WaitingState {
-  const tools = tab.permissionDenied?.tools
+/** Derive the waiting state from a denial-tools array. Returns 'question'
+ *  if any tool is AskUserQuestion, else 'plan-ready' if any is
+ *  ExitPlanMode, else null. Shared by both CLI and engine paths. */
+function waitingStateFromTools(
+  tools: ReadonlyArray<{ toolName: string }> | undefined | null,
+): WaitingState {
   if (!tools?.length) return null
   if (tools.some((t) => t.toolName === 'AskUserQuestion')) return 'question'
   if (tools.some((t) => t.toolName === 'ExitPlanMode')) return 'plan-ready'
   return null
+}
+
+/**
+ * Derive the waiting state from a tab's pending denials.
+ *
+ * - CLI tabs: read from `tab.permissionDenied`.
+ * - Engine tabs (`tab.isEngine === true`): fold across every engine
+ *   instance under this tab in `state.enginePermissionDenied`, returning
+ *   the worst-priority waiting state ('question' > 'plan-ready' > null).
+ *
+ * Engine sub-tabs (instances) are independent sub-conversations and
+ * each may have its own pending question or plan card. Parent-pill
+ * glow must surface "any sub-tab is blocked," so we walk the per-
+ * instance map keyed by `${tabId}:${instanceId}`.
+ */
+export function getWaitingState(tab: TabState): WaitingState {
+  if (tab.isEngine) {
+    // Read the store directly. This is invoked from render callsites
+    // that already subscribe to the parts of state that change the
+    // map's identity (enginePermissionDenied / enginePanes), so this
+    // is consistent at render time.
+    const s = useSessionStore.getState()
+    const pane = s.enginePanes.get(tab.id)
+    if (!pane || pane.instances.length === 0) return null
+    let hasPlanReady = false
+    for (const inst of pane.instances) {
+      const entry = s.enginePermissionDenied.get(`${tab.id}:${inst.id}`)
+      const ws = waitingStateFromTools(entry?.tools)
+      if (ws === 'question') return 'question'
+      if (ws === 'plan-ready') hasPlanReady = true
+    }
+    return hasPlanReady ? 'plan-ready' : null
+  }
+  return waitingStateFromTools(tab.permissionDenied?.tools)
+}
+
+/** Same tristate logic as `getWaitingState`, but for a single engine
+ *  instance identified by its compound `${tabId}:${instanceId}` key.
+ *  Used by the engine sub-tab pill renderer to draw a per-instance
+ *  status dot. */
+export function getEngineInstanceWaitingState(key: string): WaitingState {
+  const entry = useSessionStore.getState().enginePermissionDenied.get(key)
+  return waitingStateFromTools(entry?.tools)
 }
 
 /** Status-dot color/pulse/glow derived from a tab's runtime state. Used by both single dots and stacked group dots. */

--- a/desktop/src/renderer/hooks/useEnginePermissionDenialBackfill.ts
+++ b/desktop/src/renderer/hooks/useEnginePermissionDenialBackfill.ts
@@ -1,0 +1,221 @@
+import { useEffect } from 'react'
+import { useSessionStore } from '../stores/sessionStore'
+
+/**
+ * Backfill pending AskUserQuestion / ExitPlanMode denials for engine
+ * instances from their on-disk conversation files.
+ *
+ * Why this exists:
+ *   Across desktop restarts (and especially upgrades) the engine's
+ *   in-memory `lastPermissionDenials` is lost. When the desktop
+ *   reattaches and triggers `reconcile_state`, the engine emits
+ *   `engine_status` with `pendingDenials=0`. The desktop's persisted
+ *   `engineDenials` field is only as fresh as the last successful
+ *   serialization; if the previous build hadn't yet written that
+ *   field (e.g. immediately after this feature was introduced), the
+ *   denial state is gone.
+ *
+ *   But the assistant's tool_use call IS recorded in the engine
+ *   conversation file (`~/.ion/conversations/<sessionId>.jsonl`).
+ *   Loading the file and inspecting the last tool_use lets us
+ *   reconstruct the denial — including its full `toolInput` (so the
+ *   card can render question text and plan content).
+ *
+ * Trigger:
+ *   This effect watches `engineConversationIds`. Each entry appears
+ *   when the engine emits `engine_status` carrying a `sessionId` for
+ *   that instance — i.e. after `start_session` + `reconcile_state`
+ *   complete. At that point we know:
+ *     - the compound key (`${tabId}:${instanceId}`)
+ *     - the latest sessionId for this instance
+ *     - whether `enginePermissionDenied.get(key)` already has live
+ *       data (engine emitted denials directly, no backfill needed)
+ *     - whether the existing entry is missing `toolInput` (synthesized
+ *       from history during restoration, needs enrichment)
+ *
+ *   For each key with a sessionId where backfill is needed, we issue
+ *   a single async `loadSession` call. To avoid repeated work, we
+ *   track keys we've already processed in a module-local Set; the
+ *   Set is cleared only on unmount (full desktop teardown), which is
+ *   the right scope — the engine doesn't change its conversation
+ *   file mid-session.
+ *
+ * What we read:
+ *   `window.ion.loadSession(sessionId)` returns engine messages from
+ *   `loadEngineConversationMessages` (see main/session-meta.ts). Each
+ *   `role: 'tool'` entry carries `toolName`, `toolId`, and `toolInput`
+ *   (JSON string of the tool_use input). We scan from the end and
+ *   pick the most recent tool whose `toolName` is AskUserQuestion or
+ *   ExitPlanMode that does NOT have a populated `content` (which
+ *   would indicate a `tool_result` was already recorded — meaning the
+ *   user already answered).
+ *
+ *   We only WRITE to `enginePermissionDenied` when:
+ *     - no entry exists for the key, OR
+ *     - the existing entry's first tool has `toolInput == null/undefined`
+ *       (synthesis from restoration that needs enrichment).
+ *
+ *   If the backfill finds nothing, we still mark the key as
+ *   processed so we don't repeatedly load the same file.
+ */
+export function useEnginePermissionDenialBackfill(): void {
+  useEffect(() => {
+    const processedKeys = new Set<string>()
+
+    // Subscribe to engineConversationIds. The selector returns the map
+    // identity itself — Zustand re-runs the callback when the map is
+    // replaced (which happens on every new sessionId assignment in
+    // engine-event-slice.ts:case 'engine_status').
+    const unsubscribe = useSessionStore.subscribe((state, prev) => {
+      const ids = state.engineConversationIds
+      if (ids === prev.engineConversationIds) return
+
+      // For each key with a sessionId, decide whether we need to
+      // backfill. We process newly-known keys; entries that haven't
+      // changed don't need re-processing.
+      for (const [key, sessionIds] of ids) {
+        if (processedKeys.has(key)) continue
+        const sessionId = sessionIds[sessionIds.length - 1]
+        if (!sessionId) continue
+
+        const existing = state.enginePermissionDenied.get(key)
+        // We only enrich EXISTING synthesized entries. If no entry
+        // exists, we don't create one from the conversation file —
+        // that risks cross-instance contamination when multiple
+        // instances share a single legacy parent-tab conversationId
+        // (a pre-existing structural bug; see
+        // useTabRestoration.ts:engineSessionIds comment).
+        //
+        // A synthesized entry has `toolInput === undefined` because
+        // the engineMessages persistence didn't capture toolInput
+        // before this change. A live denial that arrived via
+        // engine_status has full toolInput. We only act on the
+        // former.
+        if (!existing || !existing.tools || existing.tools.length === 0) {
+          processedKeys.add(key)
+          continue
+        }
+        if (existing.tools[0]?.toolInput) {
+          processedKeys.add(key)
+          continue
+        }
+
+        // Mark processed BEFORE the async call to prevent re-entry
+        // during the await. If the load fails or returns empty, we
+        // accept the loss; we won't infinitely retry.
+        processedKeys.add(key)
+        void backfillForKey(key, sessionId, existing.tools[0].toolName, existing.tools[0].toolUseId)
+      }
+    })
+
+    return () => {
+      unsubscribe()
+      processedKeys.clear()
+    }
+  }, [])
+}
+
+/**
+ * Load `sessionId`'s conversation file and, if its tail shows an
+ * unresolved tool_use matching the synthesized entry's toolName and
+ * toolUseId, enrich the denial entry for `key` with the file's
+ * toolInput. Logs both branches so an operator can confirm which keys
+ * got backfilled and which didn't via a single grep over
+ * `~/.ion/desktop.log`.
+ *
+ * The `expectedToolName` / `expectedToolUseId` parameters anchor the
+ * lookup: when multiple instances share a single conversation file
+ * (legacy parent-tab.conversationId leak), we only enrich the key
+ * whose synthesized tool_use ID matches the file's tail. Other
+ * instances pointing at the same file won't get a stray denial.
+ */
+async function backfillForKey(
+  key: string,
+  sessionId: string,
+  expectedToolName: string,
+  expectedToolUseId: string,
+): Promise<void> {
+  try {
+    const msgs = await window.ion.loadSession(sessionId)
+    if (!Array.isArray(msgs) || msgs.length === 0) {
+      console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=empty no messages in conversation file`)
+      return
+    }
+
+    // Walk from the end to find the most recent tool_use of interest.
+    // An "unresolved" tool_use is one without a matching tool_result —
+    // loadEngineConversationMessages writes the result content into
+    // `m.content` when a tool_result is paired up. An empty content
+    // string means no result, hence pending.
+    //
+    // To prevent cross-instance contamination we anchor on the
+    // synthesized entry's expectedToolUseId — only enrich when the
+    // file's tail matches.
+    let candidate: { toolName: string; toolId: string; toolInput: string } | null = null
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i] as { role?: string; toolName?: string; toolId?: string; toolInput?: string; content?: string }
+      if (m.role !== 'tool' || !m.toolName) continue
+      // The first tool we encounter walking backward is the last one.
+      if (m.toolName !== 'AskUserQuestion' && m.toolName !== 'ExitPlanMode') {
+        console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=otherTool last tool was ${m.toolName} — no card to restore`)
+        return
+      }
+      if (m.content && m.content.length > 0) {
+        console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=resolved last tool ${m.toolName} already has a result — nothing pending`)
+        return
+      }
+      // Match anchor: tool name OR toolId must agree with the
+      // synthesized entry to be sure this file's tail belongs to
+      // this instance.
+      const idMatch = m.toolId && expectedToolUseId !== 'restored' && m.toolId === expectedToolUseId
+      const nameMatch = m.toolName === expectedToolName
+      if (!idMatch && !nameMatch) {
+        console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=mismatch file tail tool=${m.toolName} toolId=${(m.toolId || '').slice(0, 16)} but expected ${expectedToolName} toolId=${expectedToolUseId.slice(0, 16)}`)
+        return
+      }
+      candidate = {
+        toolName: m.toolName,
+        toolId: m.toolId || expectedToolUseId,
+        toolInput: m.toolInput || '',
+      }
+      break
+    }
+
+    if (!candidate) {
+      console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=noToolMessages no tool messages found`)
+      return
+    }
+
+    // Parse the JSON-string toolInput into a Record for the denial entry.
+    // PermissionDeniedCard reads `denial.toolInput` as an object, not a
+    // string. parseToolInput in useTabRestoration.ts does the same.
+    let parsedInput: Record<string, unknown> | undefined = undefined
+    if (candidate.toolInput) {
+      try { parsedInput = JSON.parse(candidate.toolInput) } catch { parsedInput = undefined }
+    }
+    if (!parsedInput) {
+      console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=noInput file has tool but no parseable input`)
+      return
+    }
+
+    useSessionStore.setState((state) => {
+      const existing = state.enginePermissionDenied.get(key)
+      // Final guard: don't overwrite a live denial that arrived between
+      // when we decided to backfill and when the load returned.
+      if (!existing || !existing.tools || existing.tools.length === 0) return {}
+      if (existing.tools[0]?.toolInput) return {}
+      const next = new Map(state.enginePermissionDenied)
+      next.set(key, {
+        tools: [{
+          toolName: candidate.toolName,
+          toolUseId: candidate.toolId,
+          toolInput: parsedInput,
+        }],
+      })
+      console.log(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=enriched tool=${candidate.toolName} toolId=${candidate.toolId.slice(0, 16)} inputKeys=${Object.keys(parsedInput).join(',')}`)
+      return { enginePermissionDenied: next }
+    })
+  } catch (err) {
+    console.warn(`[denial-backfill] key=${key} sessionId=${sessionId.slice(0, 20)} branch=error ${err instanceof Error ? err.message : String(err)}`)
+  }
+}

--- a/desktop/src/renderer/hooks/useTabRestoration-engine.ts
+++ b/desktop/src/renderer/hooks/useTabRestoration-engine.ts
@@ -1,0 +1,246 @@
+import type { Message, AgentStateUpdate } from '../../shared/types'
+import type { PersistedTab } from '../../shared/types-persistence'
+import { useSessionStore } from '../stores/sessionStore'
+import { usePreferencesStore } from '../preferences'
+
+/** Parse a JSON toolInput string into a Record, or undefined on failure. */
+function parseToolInput(raw?: string): Record<string, unknown> | undefined {
+  if (!raw) return undefined
+  try { return JSON.parse(raw) } catch { return undefined }
+}
+
+/**
+ * Restore an engine tab and all its per-instance state from a persisted
+ * `PersistedTab` snapshot. Extracted from `useTabRestoration.ts` to
+ * keep that file under the 600-line cap.
+ *
+ * Inputs:
+ *   - `st`: the persisted tab record
+ *   - `restoredTabIds`: the accumulator used by the caller to track
+ *     which tabs were created so historical-message loading can
+ *     iterate them later. Updated in-place.
+ *   - `tabIndex`: the index of this tab in the persisted array (the
+ *     caller uses this to associate the new tabId back to the
+ *     original position so `saved.activeTabIndex` works).
+ *
+ * Side effects:
+ *   - Calls `createEngineTab` on the session store (synchronous).
+ *   - Performs a single atomic `setState` to seed engine state maps.
+ *   - Issues async `window.ion.engineStart` calls per instance (the
+ *     returned promises are not awaited — engines start in parallel).
+ *
+ * Returns the newly-created `tabId` so callers can link it.
+ */
+export function restoreEngineTab(st: PersistedTab, restoredTabIds: Array<{ tabId: string; sessionId: string | null; index: number }>, tabIndex: number): string {
+  const tabId = useSessionStore.getState().createEngineTab(st.workingDirectory, st.engineProfileId || undefined)
+  restoredTabIds.push({ tabId, sessionId: null, index: tabIndex })
+
+  // Build all engine state before any setState call to avoid
+  // intermediate renders where EngineView sees no instances
+  // (its auto-create effect would fire, causing duplicate sessions
+  // and cascading re-renders → React error #310).
+  const restoredPanes = new Map(useSessionStore.getState().enginePanes)
+  const restoredEngineMessages = new Map(useSessionStore.getState().engineMessages)
+  const restoredEngineAgentStates = new Map(useSessionStore.getState().engineAgentStates)
+  const restoredEngineDraftInputs = new Map(useSessionStore.getState().engineDraftInputs)
+  // Per-engine-instance pending denials. We deliberately do NOT
+  // carry the legacy parent-level `st.permissionDenied` forward
+  // for engine tabs — that field was written by the old slice
+  // and would show a stale parent-card on every sibling. The
+  // engine's reconcile handshake will repopulate the
+  // per-instance map authoritatively on the next engine_status.
+  const restoredEnginePermissionDenied = new Map(useSessionStore.getState().enginePermissionDenied)
+  // Per-engine-instance conversation IDs. Seeded from the
+  // persisted `engineSessionIds` so the engine restart can
+  // pass the correct sessionId per instance (otherwise three
+  // instances under the same tab all try to resume
+  // `st.conversationId`, which is the parent tab's single ID
+  // — a pre-existing bug). Also makes
+  // useEnginePermissionDenialBackfill able to find the right
+  // conversation file immediately at startup instead of
+  // waiting for engine_status to populate the map.
+  const restoredEngineConversationIds = new Map(useSessionStore.getState().engineConversationIds)
+
+  if (st.engineInstances && st.engineInstances.length > 0) {
+    restoredPanes.set(tabId, {
+      instances: st.engineInstances,
+      activeInstanceId: st.engineInstances[0].id,
+    })
+
+    if (st.engineMessages) {
+      for (const inst of st.engineInstances) {
+        const saved = st.engineMessages[inst.id]
+        if (saved && saved.length > 0) {
+          const key = `${tabId}:${inst.id}`
+          restoredEngineMessages.set(key, saved.map((m) => ({
+            id: crypto.randomUUID(),
+            role: m.role as Message['role'],
+            content: m.content || '',
+            toolName: m.toolName,
+            toolId: m.toolId,
+            toolInput: m.toolInput,
+            toolStatus: m.toolStatus as Message['toolStatus'],
+            timestamp: m.timestamp,
+          })))
+        }
+      }
+    }
+
+    if (st.engineAgentStates) {
+      for (const inst of st.engineInstances) {
+        const saved = st.engineAgentStates[inst.id]
+        if (saved && saved.length > 0) {
+          const key = `${tabId}:${inst.id}`
+          restoredEngineAgentStates.set(key, saved.map((a) => ({
+            name: a.name,
+            status: (a.status === 'running' ? 'done' : a.status) as AgentStateUpdate['status'],
+            metadata: a.metadata,
+          })))
+        }
+      }
+    }
+
+    if (st.engineDrafts) {
+      for (const inst of st.engineInstances) {
+        const d = st.engineDrafts[inst.id]
+        if (d && d.length > 0) {
+          const key = `${tabId}:${inst.id}`
+          restoredEngineDraftInputs.set(key, d)
+          console.log(`[restore] engine draft for ${tabId.slice(0, 8)}:${inst.id.slice(0, 8)} len=${d.length}`)
+        }
+      }
+    }
+
+    if (st.engineDenials) {
+      for (const inst of st.engineInstances) {
+        const d = st.engineDenials[inst.id]
+        if (d && d.tools && d.tools.length > 0) {
+          const key = `${tabId}:${inst.id}`
+          restoredEnginePermissionDenied.set(key, { tools: d.tools })
+          console.log(`[restore] engine denial for ${tabId.slice(0, 8)}:${inst.id.slice(0, 8)} tools=${d.tools.map((t) => t.toolName).join(',')}`)
+        }
+      }
+    }
+
+    // Seed per-instance conversation IDs from persistence.
+    // engine_status will append additional IDs as the session
+    // runs; we only need the most recent one here so backfill
+    // can locate the conversation file.
+    if (st.engineSessionIds) {
+      for (const inst of st.engineInstances) {
+        const sid = st.engineSessionIds[inst.id]
+        if (sid) {
+          restoredEngineConversationIds.set(`${tabId}:${inst.id}`, [sid])
+        }
+      }
+    }
+
+    // Fallback: synthesize a denial from the last tool message in
+    // each instance's persisted engineMessages when the engine
+    // hasn't yet replayed a permissionDenials entry for it.
+    //
+    // Why this matters: the engine's reconcile_state only re-emits
+    // `pendingDenials` from `lastPermissionDenials` in memory. When
+    // the engine restarts (or never had the denial recorded), that
+    // slice is empty and the desktop loses the card even though
+    // the conversation file shows the assistant's final
+    // AskUserQuestion / ExitPlanMode call. Mirrors the CLI path
+    // (in useTabRestoration.ts) which does the same scan over
+    // historical messages — engine tabs need this too because they
+    // don't route through the CLI's historicalSessionIds replay.
+    //
+    // We only synthesize when:
+    //   - the instance has no entry in restoredEnginePermissionDenied
+    //     (engineDenials already authoritative if present), AND
+    //   - the last persisted message with a toolName is
+    //     AskUserQuestion or ExitPlanMode.
+    //
+    // The synthetic entry's toolInput is parsed from the persisted
+    // message's `toolInput` (a JSON string captured by the engine_tool_update
+    // slice handler). For pre-feature persisted data that lacks
+    // toolInput, the entry is created with toolInput=undefined; the
+    // useEnginePermissionDenialBackfill hook then loads the matching
+    // conversation file to enrich the toolInput from disk.
+    if (st.engineMessages) {
+      for (const inst of st.engineInstances) {
+        const key = `${tabId}:${inst.id}`
+        if (restoredEnginePermissionDenied.get(key)) continue
+        const msgs = st.engineMessages[inst.id]
+        if (!msgs || msgs.length === 0) continue
+        // Find the most recent tool message.
+        const lastTool = [...msgs].reverse().find((m) => m.toolName)
+        if (!lastTool) continue
+        if (lastTool.toolName !== 'AskUserQuestion' && lastTool.toolName !== 'ExitPlanMode') continue
+        restoredEnginePermissionDenied.set(key, {
+          tools: [{
+            toolName: lastTool.toolName,
+            toolUseId: lastTool.toolId || 'restored',
+            toolInput: parseToolInput(lastTool.toolInput),
+          }],
+        })
+        console.log(`[restore] engine denial synthesized from history for ${tabId.slice(0, 8)}:${inst.id.slice(0, 8)} tool=${lastTool.toolName} toolId=${(lastTool.toolId || 'none').slice(0, 16)} hasInput=${lastTool.toolInput ? 'yes' : 'no'}`)
+      }
+    }
+  }
+
+  // Single atomic setState: tab metadata + panes + messages + agent states + drafts + denials + sessionIds
+  useSessionStore.setState((s) => ({
+    tabs: s.tabs.map((t) =>
+      t.id === tabId
+        ? {
+            ...t,
+            customTitle: st.customTitle || null,
+            pillColor: st.pillColor || null,
+            groupId: st.groupId || null,
+            groupPinned: st.groupPinned ?? false,
+            modelOverride: st.modelOverride || null,
+            conversationId: st.conversationId || null,
+            draftInput: st.draftInput ?? '',
+            lastMessagePreview: st.lastMessagePreview || null,
+            lastEventAt: st.lastEventAt ?? null,
+            // NB: deliberately NOT restoring st.permissionDenied
+            // for engine tabs — legacy field, now superseded by
+            // enginePermissionDenied (per-instance). See the
+            // restoredEnginePermissionDenied comment above.
+          }
+        : t
+    ),
+    enginePanes: restoredPanes,
+    engineMessages: restoredEngineMessages,
+    engineAgentStates: restoredEngineAgentStates,
+    engineDraftInputs: restoredEngineDraftInputs,
+    enginePermissionDenied: restoredEnginePermissionDenied,
+    engineConversationIds: restoredEngineConversationIds,
+  }))
+  if (st.draftInput) console.log(`[restore] draft for engine tab ${tabId.slice(0, 8)} len=${st.draftInput.length}`)
+
+  // Start engine processes (state is fully set up)
+  if (st.engineInstances && st.engineInstances.length > 0) {
+    const { engineProfiles } = usePreferencesStore.getState()
+    const profile = st.engineProfileId ? engineProfiles.find((p) => p.id === st.engineProfileId) : null
+    if (profile) {
+      for (const inst of st.engineInstances) {
+        const key = `${tabId}:${inst.id}`
+        // Prefer the per-instance sessionId from
+        // engineSessionIds (most recent conversation file for
+        // this instance). Fall back to the parent
+        // tab.conversationId only for back-compat with old
+        // persisted states that pre-date the per-instance
+        // serialization — in that case all instances will try
+        // to share one conversation, which is the legacy
+        // behavior; new persisted states avoid this collision.
+        const instSessionId = st.engineSessionIds?.[inst.id] || st.conversationId || ''
+        window.ion.engineStart(key, {
+          profileId: profile.id,
+          extensions: profile.extensions,
+          workingDirectory: st.workingDirectory,
+          ...(instSessionId ? { sessionId: instSessionId } : {}),
+        }).catch((err: { message?: string }) => {
+          console.error(`[restore] engine start failed for ${key}: ${err.message}`)
+        })
+      }
+    }
+  }
+
+  return tabId
+}

--- a/desktop/src/renderer/hooks/useTabRestoration.ts
+++ b/desktop/src/renderer/hooks/useTabRestoration.ts
@@ -107,6 +107,13 @@ export function useTabRestoration() {
             const restoredEngineMessages = new Map(useSessionStore.getState().engineMessages)
             const restoredEngineAgentStates = new Map(useSessionStore.getState().engineAgentStates)
             const restoredEngineDraftInputs = new Map(useSessionStore.getState().engineDraftInputs)
+            // Per-engine-instance pending denials. We deliberately do NOT
+            // carry the legacy parent-level `st.permissionDenied` forward
+            // for engine tabs — that field was written by the old slice
+            // and would show a stale parent-card on every sibling. The
+            // engine's reconcile handshake will repopulate the
+            // per-instance map authoritatively on the next engine_status.
+            const restoredEnginePermissionDenied = new Map(useSessionStore.getState().enginePermissionDenied)
 
             if (st.engineInstances && st.engineInstances.length > 0) {
               restoredPanes.set(tabId, {
@@ -156,9 +163,20 @@ export function useTabRestoration() {
                   }
                 }
               }
+
+              if (st.engineDenials) {
+                for (const inst of st.engineInstances) {
+                  const d = st.engineDenials[inst.id]
+                  if (d && d.tools && d.tools.length > 0) {
+                    const key = `${tabId}:${inst.id}`
+                    restoredEnginePermissionDenied.set(key, { tools: d.tools })
+                    console.log(`[restore] engine denial for ${tabId.slice(0, 8)}:${inst.id.slice(0, 8)} tools=${d.tools.map((t) => t.toolName).join(',')}`)
+                  }
+                }
+              }
             }
 
-            // Single atomic setState: tab metadata + panes + messages + agent states + drafts
+            // Single atomic setState: tab metadata + panes + messages + agent states + drafts + denials
             useSessionStore.setState((s) => ({
               tabs: s.tabs.map((t) =>
                 t.id === tabId
@@ -173,6 +191,10 @@ export function useTabRestoration() {
                       draftInput: st.draftInput ?? '',
                       lastMessagePreview: st.lastMessagePreview || null,
                       lastEventAt: st.lastEventAt ?? null,
+                      // NB: deliberately NOT restoring st.permissionDenied
+                      // for engine tabs — legacy field, now superseded by
+                      // enginePermissionDenied (per-instance). See the
+                      // restoredEnginePermissionDenied comment above.
                     }
                   : t
               ),
@@ -180,6 +202,7 @@ export function useTabRestoration() {
               engineMessages: restoredEngineMessages,
               engineAgentStates: restoredEngineAgentStates,
               engineDraftInputs: restoredEngineDraftInputs,
+              enginePermissionDenied: restoredEnginePermissionDenied,
             }))
             if (st.draftInput) console.log(`[restore] draft for engine tab ${tabId.slice(0, 8)} len=${st.draftInput.length}`)
 

--- a/desktop/src/renderer/hooks/useTabRestoration.ts
+++ b/desktop/src/renderer/hooks/useTabRestoration.ts
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
-import type { Message, AgentStateUpdate } from '../../shared/types'
+import type { Message } from '../../shared/types'
 import { useSessionStore } from '../stores/sessionStore'
 import { usePreferencesStore } from '../preferences'
 import { setSavedBuffer } from '../components/TerminalInstance'
+import { restoreEngineTab } from './useTabRestoration-engine'
 
 /** Parse a JSON toolInput string into a Record, or undefined on failure. */
 function parseToolInput(raw?: string): Record<string, unknown> | undefined {
@@ -95,135 +96,14 @@ export function useTabRestoration() {
             window.ion.setPermissionMode(tabId, st.permissionMode, 'tab_restore')
             if (st.draftInput) console.log(`[restore] draft for tab ${tabId.slice(0, 8)} len=${st.draftInput.length}`)
           } else if (st.isEngine) {
-            // Engine tab
-            const tabId = useSessionStore.getState().createEngineTab(st.workingDirectory, st.engineProfileId || undefined)
-            restoredTabIds.push({ tabId, sessionId: null, index: i })
-
-            // Build all engine state before any setState call to avoid
-            // intermediate renders where EngineView sees no instances
-            // (its auto-create effect would fire, causing duplicate sessions
-            // and cascading re-renders → React error #310).
-            const restoredPanes = new Map(useSessionStore.getState().enginePanes)
-            const restoredEngineMessages = new Map(useSessionStore.getState().engineMessages)
-            const restoredEngineAgentStates = new Map(useSessionStore.getState().engineAgentStates)
-            const restoredEngineDraftInputs = new Map(useSessionStore.getState().engineDraftInputs)
-            // Per-engine-instance pending denials. We deliberately do NOT
-            // carry the legacy parent-level `st.permissionDenied` forward
-            // for engine tabs — that field was written by the old slice
-            // and would show a stale parent-card on every sibling. The
-            // engine's reconcile handshake will repopulate the
-            // per-instance map authoritatively on the next engine_status.
-            const restoredEnginePermissionDenied = new Map(useSessionStore.getState().enginePermissionDenied)
-
-            if (st.engineInstances && st.engineInstances.length > 0) {
-              restoredPanes.set(tabId, {
-                instances: st.engineInstances,
-                activeInstanceId: st.engineInstances[0].id,
-              })
-
-              if (st.engineMessages) {
-                for (const inst of st.engineInstances) {
-                  const saved = st.engineMessages[inst.id]
-                  if (saved && saved.length > 0) {
-                    const key = `${tabId}:${inst.id}`
-                    restoredEngineMessages.set(key, saved.map((m) => ({
-                      id: crypto.randomUUID(),
-                      role: m.role as Message['role'],
-                      content: m.content || '',
-                      toolName: m.toolName,
-                      toolId: m.toolId,
-                      toolStatus: m.toolStatus as Message['toolStatus'],
-                      timestamp: m.timestamp,
-                    })))
-                  }
-                }
-              }
-
-              if (st.engineAgentStates) {
-                for (const inst of st.engineInstances) {
-                  const saved = st.engineAgentStates[inst.id]
-                  if (saved && saved.length > 0) {
-                    const key = `${tabId}:${inst.id}`
-                    restoredEngineAgentStates.set(key, saved.map((a) => ({
-                      name: a.name,
-                      status: (a.status === 'running' ? 'done' : a.status) as AgentStateUpdate['status'],
-                      metadata: a.metadata,
-                    })))
-                  }
-                }
-              }
-
-              if (st.engineDrafts) {
-                for (const inst of st.engineInstances) {
-                  const d = st.engineDrafts[inst.id]
-                  if (d && d.length > 0) {
-                    const key = `${tabId}:${inst.id}`
-                    restoredEngineDraftInputs.set(key, d)
-                    console.log(`[restore] engine draft for ${tabId.slice(0, 8)}:${inst.id.slice(0, 8)} len=${d.length}`)
-                  }
-                }
-              }
-
-              if (st.engineDenials) {
-                for (const inst of st.engineInstances) {
-                  const d = st.engineDenials[inst.id]
-                  if (d && d.tools && d.tools.length > 0) {
-                    const key = `${tabId}:${inst.id}`
-                    restoredEnginePermissionDenied.set(key, { tools: d.tools })
-                    console.log(`[restore] engine denial for ${tabId.slice(0, 8)}:${inst.id.slice(0, 8)} tools=${d.tools.map((t) => t.toolName).join(',')}`)
-                  }
-                }
-              }
-            }
-
-            // Single atomic setState: tab metadata + panes + messages + agent states + drafts + denials
-            useSessionStore.setState((s) => ({
-              tabs: s.tabs.map((t) =>
-                t.id === tabId
-                  ? {
-                      ...t,
-                      customTitle: st.customTitle || null,
-                      pillColor: st.pillColor || null,
-                      groupId: st.groupId || null,
-                      groupPinned: st.groupPinned ?? false,
-                      modelOverride: st.modelOverride || null,
-                      conversationId: st.conversationId || null,
-                      draftInput: st.draftInput ?? '',
-                      lastMessagePreview: st.lastMessagePreview || null,
-                      lastEventAt: st.lastEventAt ?? null,
-                      // NB: deliberately NOT restoring st.permissionDenied
-                      // for engine tabs — legacy field, now superseded by
-                      // enginePermissionDenied (per-instance). See the
-                      // restoredEnginePermissionDenied comment above.
-                    }
-                  : t
-              ),
-              enginePanes: restoredPanes,
-              engineMessages: restoredEngineMessages,
-              engineAgentStates: restoredEngineAgentStates,
-              engineDraftInputs: restoredEngineDraftInputs,
-              enginePermissionDenied: restoredEnginePermissionDenied,
-            }))
-            if (st.draftInput) console.log(`[restore] draft for engine tab ${tabId.slice(0, 8)} len=${st.draftInput.length}`)
-
-            // Start engine processes (state is fully set up)
-            if (st.engineInstances && st.engineInstances.length > 0) {
-              const { engineProfiles } = usePreferencesStore.getState()
-              const profile = st.engineProfileId ? engineProfiles.find((p) => p.id === st.engineProfileId) : null
-              if (profile) {
-                for (const inst of st.engineInstances) {
-                  const key = `${tabId}:${inst.id}`
-                  window.ion.engineStart(key, {
-                    profileId: profile.id,
-                    extensions: profile.extensions,
-                    workingDirectory: st.workingDirectory,
-                    ...(st.conversationId ? { sessionId: st.conversationId } : {}),
-                  }).catch((err: any) => {
-                    console.error(`[restore] engine start failed for ${key}: ${err.message}`)
-                  })
-                }
-              }
-            }
+            // Engine tab — full restoration logic is extracted to
+            // useTabRestoration-engine.ts to keep this file under the
+            // 600-line cap. Returns the new tabId (used by the
+            // historical-message loop below; engine tabs don't have
+            // historicalSessionIds so the new id appears in
+            // restoredTabIds but gets skipped by the loop's
+            // `historicalIds.length > 0` guard).
+            restoreEngineTab(st, restoredTabIds, i)
           } else if (st.isTerminalOnly) {
             // Terminal-only tab
             const tabId = await useSessionStore.getState().createTerminalTab()

--- a/desktop/src/renderer/stores/__tests__/engine-event-slice-agent-state.test.ts
+++ b/desktop/src/renderer/stores/__tests__/engine-event-slice-agent-state.test.ts
@@ -41,6 +41,7 @@ function buildHarness() {
     engineModelOverrides: new Map(),
     engineConversationIds: new Map(),
     enginePanes: new Map(),
+    enginePermissionDenied: new Map(),
   }
   const set = (partial: any) => {
     const patch = typeof partial === 'function' ? partial(state) : partial

--- a/desktop/src/renderer/stores/__tests__/engine-event-slice-permission-denials.test.ts
+++ b/desktop/src/renderer/stores/__tests__/engine-event-slice-permission-denials.test.ts
@@ -1,0 +1,222 @@
+/**
+ * engine-event-slice — engine_status.permissionDenials → tab.permissionDenied
+ *
+ * The engine intercepts AskUserQuestion and ExitPlanMode and emits the
+ * denial on the next engine_status event under `fields.permissionDenials`.
+ * For engine-view tabs (compound `tabId:instanceId` key), the slice is the
+ * only place that translates this signal into the renderer's
+ * `tab.permissionDenied` shape — the CLI synthesis path in
+ * engine-control-plane-events.ts:handleStatusEvent is bypassed for these
+ * tabs because EngineControlPlane is keyed by bare tabId only.
+ *
+ * Contract pinned here:
+ *   1. AskUserQuestion / ExitPlanMode denials populate tab.permissionDenied.
+ *   2. Other denial tool names are ignored.
+ *   3. Cost-only follow-up status (no denials) preserves the existing
+ *      permissionDenied — it does NOT clobber.
+ *   4. The parent tabId (key.split(':')[0]) is updated, even when the
+ *      event arrives on a compound key.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../session-store-helpers', () => ({
+  makeLocalTab: vi.fn(),
+  nextMsgId: vi.fn(() => 'mock-msg-id'),
+  playNotificationIfHidden: vi.fn(async () => {}),
+}))
+
+import { createEngineEventSlice } from '../slices/engine-event-slice'
+import type { State } from '../session-store-types'
+
+function buildHarness() {
+  const state: any = {
+    tabs: [{ id: 'tab1', isEngine: true, lastEventAt: 0, status: 'running', permissionDenied: null }],
+    engineAgentStates: new Map(),
+    engineStatusFields: new Map(),
+    engineWorkingMessages: new Map(),
+    engineNotifications: new Map(),
+    engineDialogs: new Map(),
+    enginePinnedPrompt: new Map(),
+    engineUsage: new Map(),
+    engineMessages: new Map(),
+    engineDraftInputs: new Map(),
+    engineModelOverrides: new Map(),
+    engineConversationIds: new Map(),
+    enginePanes: new Map(),
+  }
+  const set = (partial: any) => {
+    const patch = typeof partial === 'function' ? partial(state) : partial
+    Object.assign(state, patch)
+  }
+  const get = () => state as State
+  const slice = createEngineEventSlice(set, get) as State
+  return { state, slice }
+}
+
+describe('engine_status.permissionDenials → tab.permissionDenied', () => {
+  it('sets tab.permissionDenied for AskUserQuestion denial on compound key', () => {
+    const { state, slice } = buildHarness()
+    const key = 'tab1:inst-a'
+
+    slice.handleEngineEvent(key, {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 12,
+        contextWindow: 200000,
+        permissionDenials: [
+          {
+            toolName: 'AskUserQuestion',
+            toolUseId: 'tu-1',
+            toolInput: { question: 'Pick one', options: ['A', 'B'] },
+          },
+        ],
+      },
+    } as any)
+
+    const tab = state.tabs.find((t: any) => t.id === 'tab1')
+    expect(tab.permissionDenied).not.toBeNull()
+    expect(tab.permissionDenied.tools).toHaveLength(1)
+    expect(tab.permissionDenied.tools[0].toolName).toBe('AskUserQuestion')
+    expect(tab.permissionDenied.tools[0].toolUseId).toBe('tu-1')
+    expect(tab.permissionDenied.tools[0].toolInput).toEqual({ question: 'Pick one', options: ['A', 'B'] })
+  })
+
+  it('sets tab.permissionDenied for ExitPlanMode denial', () => {
+    const { state, slice } = buildHarness()
+    const key = 'tab1:inst-a'
+
+    slice.handleEngineEvent(key, {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 12,
+        contextWindow: 200000,
+        permissionDenials: [
+          {
+            toolName: 'ExitPlanMode',
+            toolUseId: 'tu-2',
+            toolInput: { planFilePath: '/x/plan.md' },
+          },
+        ],
+      },
+    } as any)
+
+    const tab = state.tabs.find((t: any) => t.id === 'tab1')
+    expect(tab.permissionDenied?.tools[0].toolName).toBe('ExitPlanMode')
+  })
+
+  it('filters out non-interactive tool denials (Read, Bash, etc.)', () => {
+    const { state, slice } = buildHarness()
+    const key = 'tab1:inst-a'
+
+    slice.handleEngineEvent(key, {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 12,
+        contextWindow: 200000,
+        permissionDenials: [
+          { toolName: 'Read', toolUseId: 'tu-3', toolInput: { file_path: '/x' } },
+          { toolName: 'Bash', toolUseId: 'tu-4', toolInput: { command: 'ls' } },
+        ],
+      },
+    } as any)
+
+    const tab = state.tabs.find((t: any) => t.id === 'tab1')
+    // No AskUserQuestion / ExitPlanMode denials → tab.permissionDenied untouched (null).
+    expect(tab.permissionDenied).toBeNull()
+  })
+
+  it('preserves existing permissionDenied on follow-up cost-only status (no denials)', () => {
+    const { state, slice } = buildHarness()
+    const key = 'tab1:inst-a'
+
+    // Tick 1: denial arrives.
+    slice.handleEngineEvent(key, {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 12,
+        contextWindow: 200000,
+        permissionDenials: [
+          { toolName: 'AskUserQuestion', toolUseId: 'tu-1', toolInput: { question: 'q?' } },
+        ],
+      },
+    } as any)
+
+    // Tick 2: cost-only follow-up (engine emits this ~1ms after the denial tick).
+    slice.handleEngineEvent(key, {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 12,
+        contextWindow: 200000,
+        totalCostUsd: 0.001,
+        // permissionDenials absent
+      },
+    } as any)
+
+    const tab = state.tabs.find((t: any) => t.id === 'tab1')
+    expect(tab.permissionDenied).not.toBeNull()
+    expect(tab.permissionDenied.tools[0].toolName).toBe('AskUserQuestion')
+  })
+
+  it('derives parent tabId from compound key (key.split(":")[0])', () => {
+    const { state, slice } = buildHarness()
+    // Add a second tab to confirm we only touch the parent of the compound key.
+    state.tabs.push({ id: 'tab2', isEngine: true, lastEventAt: 0, status: 'running', permissionDenied: null })
+
+    slice.handleEngineEvent('tab1:inst-a', {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 0,
+        contextWindow: 200000,
+        permissionDenials: [
+          { toolName: 'AskUserQuestion', toolUseId: 'tu-1', toolInput: { question: 'q?' } },
+        ],
+      },
+    } as any)
+
+    const tab1 = state.tabs.find((t: any) => t.id === 'tab1')
+    const tab2 = state.tabs.find((t: any) => t.id === 'tab2')
+    expect(tab1.permissionDenied).not.toBeNull()
+    expect(tab2.permissionDenied).toBeNull()
+  })
+
+  it('ignores engine_status on bare (non-compound) keys', () => {
+    const { state, slice } = buildHarness()
+
+    // Bare tabId — handler should return early via the !key.includes(':') guard.
+    slice.handleEngineEvent('tab1', {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 0,
+        contextWindow: 200000,
+        permissionDenials: [
+          { toolName: 'AskUserQuestion', toolUseId: 'tu-1', toolInput: { question: 'q?' } },
+        ],
+      },
+    } as any)
+
+    const tab = state.tabs.find((t: any) => t.id === 'tab1')
+    expect(tab.permissionDenied).toBeNull()
+  })
+})

--- a/desktop/src/renderer/stores/__tests__/engine-event-slice-permission-denials.test.ts
+++ b/desktop/src/renderer/stores/__tests__/engine-event-slice-permission-denials.test.ts
@@ -1,21 +1,25 @@
 /**
- * engine-event-slice — engine_status.permissionDenials → tab.permissionDenied
+ * engine-event-slice — engine_status.permissionDenials → enginePermissionDenied
  *
  * The engine intercepts AskUserQuestion and ExitPlanMode and emits the
  * denial on the next engine_status event under `fields.permissionDenials`.
- * For engine-view tabs (compound `tabId:instanceId` key), the slice is the
- * only place that translates this signal into the renderer's
- * `tab.permissionDenied` shape — the CLI synthesis path in
- * engine-control-plane-events.ts:handleStatusEvent is bypassed for these
- * tabs because EngineControlPlane is keyed by bare tabId only.
+ * For engine-view tabs (compound `tabId:instanceId` key), the slice
+ * translates this signal into the renderer's
+ * `enginePermissionDenied` map (keyed by the FULL compound key) — the
+ * CLI synthesis path in engine-control-plane-events.ts:handleStatusEvent
+ * is bypassed for these tabs because EngineControlPlane is keyed by
+ * bare tabId only.
  *
  * Contract pinned here:
- *   1. AskUserQuestion / ExitPlanMode denials populate tab.permissionDenied.
+ *   1. AskUserQuestion / ExitPlanMode denials populate
+ *      `enginePermissionDenied.get(compoundKey)`.
  *   2. Other denial tool names are ignored.
  *   3. Cost-only follow-up status (no denials) preserves the existing
- *      permissionDenied — it does NOT clobber.
- *   4. The parent tabId (key.split(':')[0]) is updated, even when the
- *      event arrives on a compound key.
+ *      entry — it does NOT clobber.
+ *   4. Two compound keys under the same parent tabId track INDEPENDENT
+ *      denials. Sibling instances don't share a card.
+ *   5. The parent `tab.permissionDenied` is NOT mutated by this slice
+ *      for engine paths — that field is CLI-only.
  */
 
 import { describe, it, expect, vi } from 'vitest'
@@ -44,6 +48,7 @@ function buildHarness() {
     engineModelOverrides: new Map(),
     engineConversationIds: new Map(),
     enginePanes: new Map(),
+    enginePermissionDenied: new Map(),
   }
   const set = (partial: any) => {
     const patch = typeof partial === 'function' ? partial(state) : partial
@@ -54,8 +59,8 @@ function buildHarness() {
   return { state, slice }
 }
 
-describe('engine_status.permissionDenials → tab.permissionDenied', () => {
-  it('sets tab.permissionDenied for AskUserQuestion denial on compound key', () => {
+describe('engine_status.permissionDenials → enginePermissionDenied', () => {
+  it('sets enginePermissionDenied for AskUserQuestion denial on compound key', () => {
     const { state, slice } = buildHarness()
     const key = 'tab1:inst-a'
 
@@ -77,15 +82,18 @@ describe('engine_status.permissionDenials → tab.permissionDenied', () => {
       },
     } as any)
 
+    const entry = state.enginePermissionDenied.get(key)
+    expect(entry).not.toBeNull()
+    expect(entry.tools).toHaveLength(1)
+    expect(entry.tools[0].toolName).toBe('AskUserQuestion')
+    expect(entry.tools[0].toolUseId).toBe('tu-1')
+    expect(entry.tools[0].toolInput).toEqual({ question: 'Pick one', options: ['A', 'B'] })
+    // Parent tab's permissionDenied stays null — engine path no longer mutates it.
     const tab = state.tabs.find((t: any) => t.id === 'tab1')
-    expect(tab.permissionDenied).not.toBeNull()
-    expect(tab.permissionDenied.tools).toHaveLength(1)
-    expect(tab.permissionDenied.tools[0].toolName).toBe('AskUserQuestion')
-    expect(tab.permissionDenied.tools[0].toolUseId).toBe('tu-1')
-    expect(tab.permissionDenied.tools[0].toolInput).toEqual({ question: 'Pick one', options: ['A', 'B'] })
+    expect(tab.permissionDenied).toBeNull()
   })
 
-  it('sets tab.permissionDenied for ExitPlanMode denial', () => {
+  it('sets enginePermissionDenied for ExitPlanMode denial', () => {
     const { state, slice } = buildHarness()
     const key = 'tab1:inst-a'
 
@@ -107,8 +115,8 @@ describe('engine_status.permissionDenials → tab.permissionDenied', () => {
       },
     } as any)
 
-    const tab = state.tabs.find((t: any) => t.id === 'tab1')
-    expect(tab.permissionDenied?.tools[0].toolName).toBe('ExitPlanMode')
+    const entry = state.enginePermissionDenied.get(key)
+    expect(entry?.tools[0].toolName).toBe('ExitPlanMode')
   })
 
   it('filters out non-interactive tool denials (Read, Bash, etc.)', () => {
@@ -130,12 +138,11 @@ describe('engine_status.permissionDenials → tab.permissionDenied', () => {
       },
     } as any)
 
-    const tab = state.tabs.find((t: any) => t.id === 'tab1')
-    // No AskUserQuestion / ExitPlanMode denials → tab.permissionDenied untouched (null).
-    expect(tab.permissionDenied).toBeNull()
+    // No AskUserQuestion / ExitPlanMode denials → map entry stays absent.
+    expect(state.enginePermissionDenied.get(key)).toBeUndefined()
   })
 
-  it('preserves existing permissionDenied on follow-up cost-only status (no denials)', () => {
+  it('preserves existing enginePermissionDenied on follow-up cost-only status (no denials)', () => {
     const { state, slice } = buildHarness()
     const key = 'tab1:inst-a'
 
@@ -168,17 +175,18 @@ describe('engine_status.permissionDenials → tab.permissionDenied', () => {
       },
     } as any)
 
-    const tab = state.tabs.find((t: any) => t.id === 'tab1')
-    expect(tab.permissionDenied).not.toBeNull()
-    expect(tab.permissionDenied.tools[0].toolName).toBe('AskUserQuestion')
+    const entry = state.enginePermissionDenied.get(key)
+    expect(entry).not.toBeUndefined()
+    expect(entry.tools[0].toolName).toBe('AskUserQuestion')
   })
 
-  it('derives parent tabId from compound key (key.split(":")[0])', () => {
+  it('isolates sibling instances under the same parent tabId', () => {
     const { state, slice } = buildHarness()
-    // Add a second tab to confirm we only touch the parent of the compound key.
-    state.tabs.push({ id: 'tab2', isEngine: true, lastEventAt: 0, status: 'running', permissionDenied: null })
+    const keyA = 'tab1:inst-a'
+    const keyB = 'tab1:inst-b'
 
-    slice.handleEngineEvent('tab1:inst-a', {
+    // Instance A: AskUserQuestion denial.
+    slice.handleEngineEvent(keyA, {
       type: 'engine_status',
       fields: {
         label: 'engine',
@@ -187,15 +195,33 @@ describe('engine_status.permissionDenials → tab.permissionDenied', () => {
         contextPercent: 0,
         contextWindow: 200000,
         permissionDenials: [
-          { toolName: 'AskUserQuestion', toolUseId: 'tu-1', toolInput: { question: 'q?' } },
+          { toolName: 'AskUserQuestion', toolUseId: 'tu-a', toolInput: { question: 'A?' } },
         ],
       },
     } as any)
 
-    const tab1 = state.tabs.find((t: any) => t.id === 'tab1')
-    const tab2 = state.tabs.find((t: any) => t.id === 'tab2')
-    expect(tab1.permissionDenied).not.toBeNull()
-    expect(tab2.permissionDenied).toBeNull()
+    // Instance B: ExitPlanMode denial. Distinct compound key under the
+    // same parent tab.
+    slice.handleEngineEvent(keyB, {
+      type: 'engine_status',
+      fields: {
+        label: 'engine',
+        state: 'idle',
+        model: 'sonnet',
+        contextPercent: 0,
+        contextWindow: 200000,
+        permissionDenials: [
+          { toolName: 'ExitPlanMode', toolUseId: 'tu-b', toolInput: { planFilePath: '/p.md' } },
+        ],
+      },
+    } as any)
+
+    const entryA = state.enginePermissionDenied.get(keyA)
+    const entryB = state.enginePermissionDenied.get(keyB)
+    expect(entryA?.tools[0].toolName).toBe('AskUserQuestion')
+    expect(entryB?.tools[0].toolName).toBe('ExitPlanMode')
+    // Crucially, the two entries are independent — clearing one must
+    // not affect the other.
   })
 
   it('ignores engine_status on bare (non-compound) keys', () => {
@@ -216,6 +242,10 @@ describe('engine_status.permissionDenials → tab.permissionDenied', () => {
       },
     } as any)
 
+    // Neither the bare key nor any compound key receives an entry.
+    expect(state.enginePermissionDenied.get('tab1')).toBeUndefined()
+    expect(state.enginePermissionDenied.size).toBe(0)
+    // Parent tab's permissionDenied also stays null.
     const tab = state.tabs.find((t: any) => t.id === 'tab1')
     expect(tab.permissionDenied).toBeNull()
   })

--- a/desktop/src/renderer/stores/__tests__/engine-slice-move.test.ts
+++ b/desktop/src/renderer/stores/__tests__/engine-slice-move.test.ts
@@ -84,6 +84,7 @@ function buildHarness() {
     engineDraftInputs: new Map([['srcTab:inst1', 'draft']]),
     engineModelOverrides: new Map([['srcTab:inst1', 'claude-3']]),
     engineConversationIds: new Map([['srcTab:inst1', ['conv-abc']]]),
+    enginePermissionDenied: new Map([['srcTab:inst1', { tools: [{ toolName: 'AskUserQuestion', toolUseId: 'tu-1', toolInput: { question: 'q?' } }] }]]),
     closeTab: vi.fn(),
   }
 
@@ -129,7 +130,7 @@ vi.mock('../../preferences', () => ({
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe('moveEngineInstance', () => {
-  it('migrates state across all 11 compound-keyed Maps', () => {
+  it('migrates state across all 12 compound-keyed Maps', () => {
     const { state, slice } = buildHarness()
     slice.moveEngineInstance('srcTab', 'inst1', 'dstTab')
 
@@ -148,6 +149,7 @@ describe('moveEngineInstance', () => {
     expect(state.engineDraftInputs.has(newKey)).toBe(true)
     expect(state.engineModelOverrides.has(newKey)).toBe(true)
     expect(state.engineConversationIds.has(newKey)).toBe(true)
+    expect(state.enginePermissionDenied.has(newKey)).toBe(true)
 
     // Old key absent from every map
     expect(state.engineMessages.has(oldKey)).toBe(false)
@@ -161,6 +163,7 @@ describe('moveEngineInstance', () => {
     expect(state.engineDraftInputs.has(oldKey)).toBe(false)
     expect(state.engineModelOverrides.has(oldKey)).toBe(false)
     expect(state.engineConversationIds.has(oldKey)).toBe(false)
+    expect(state.enginePermissionDenied.has(oldKey)).toBe(false)
 
     // Values were actually transferred
     expect(state.engineModelOverrides.get(newKey)).toBe('claude-3')

--- a/desktop/src/renderer/stores/__tests__/tab-group-pin.test.ts
+++ b/desktop/src/renderer/stores/__tests__/tab-group-pin.test.ts
@@ -209,6 +209,7 @@ function buildHarness(initialTab: TabState) {
     enginePanes: new Map(),
     engineMessages: new Map(),
     engineDraftInputs: new Map(),
+    enginePermissionDenied: new Map(),
     fileExplorerOpenDirs: new Set(),
     fileEditorOpenDirs: new Set(),
   }
@@ -364,6 +365,7 @@ describe('toggleTabGroupPin', () => {
       enginePanes: new Map(),
       engineMessages: new Map(),
       engineDraftInputs: new Map(),
+      enginePermissionDenied: new Map(),
       fileExplorerOpenDirs: new Set(),
       fileEditorOpenDirs: new Set(),
     }

--- a/desktop/src/renderer/stores/session-store-persistence.ts
+++ b/desktop/src/renderer/stores/session-store-persistence.ts
@@ -105,7 +105,22 @@ function persistTabs(useSessionStore: Store): void {
               sessionIds[inst.id] = chain[chain.length - 1]
             }
           }
-          if (Object.keys(sessionIds).length > 0) result.engineSessionIds = sessionIds
+          if (Object.keys(sessionIds).length > 0) {
+            result.engineSessionIds = sessionIds
+          } else if (hPane.instances.length > 0) {
+            // Diagnostic: engine tab has instances but zero session IDs
+            // were resolved from the runtime map. This is the persisted
+            // shape of the bug the plan addresses — on the next restart
+            // `engineSessionIds` will be absent and every instance
+            // starts a brand new engine conversation. Log the runtime
+            // map's actual keys so we can see whether the source map
+            // is keyed differently than the lookup expects (e.g.
+            // `tabId` only vs. `${tabId}:${instanceId}`). This log is
+            // permanent per the repo logging policy.
+            const expectedKeys = hPane.instances.map((inst) => `${t.id}:${inst.id}`)
+            const actualKeys = [...eConvs.keys()].filter((k) => k.startsWith(`${t.id}`) || k === t.id)
+            console.log(`[persist] engineSessionIds empty for engine tab=${t.id.slice(0, 8)} instances=${hPane.instances.length} expectedKeys=${JSON.stringify(expectedKeys.map((k) => k.slice(0, 16)))} actualKeysUnderTab=${JSON.stringify(actualKeys.map((k) => k.slice(0, 16)))}`)
+          }
           return result
         })() : {}),
         ...(pane && pane.instances.length > 0 ? { terminalInstances: pane.instances } : {}),

--- a/desktop/src/renderer/stores/session-store-persistence.ts
+++ b/desktop/src/renderer/stores/session-store-persistence.ts
@@ -81,6 +81,15 @@ function persistTabs(useSessionStore: Store): void {
             if (d && d.length > 0) drafts[inst.id] = d
           }
           if (Object.keys(drafts).length > 0) result.engineDrafts = drafts
+          const { enginePermissionDenied: eDenials } = useSessionStore.getState()
+          const denials: Record<string, { tools: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> }> = {}
+          for (const inst of hPane.instances) {
+            const d = eDenials.get(`${t.id}:${inst.id}`)
+            if (d && d.tools && d.tools.length > 0) {
+              denials[inst.id] = { tools: d.tools }
+            }
+          }
+          if (Object.keys(denials).length > 0) result.engineDenials = denials
           return result
         })() : {}),
         ...(pane && pane.instances.length > 0 ? { terminalInstances: pane.instances } : {}),
@@ -184,15 +193,19 @@ function scanForStuckTabs(useSessionStore: Store): void {
 export function setupPersistence(useSessionStore: Store): void {
   let saveTimer: ReturnType<typeof setTimeout> | null = null
   useSessionStore.subscribe((state, prev) => {
-    if (state.tabs !== prev.tabs || state.activeTabId !== prev.activeTabId || state.fileEditorStates !== prev.fileEditorStates || state.isExpanded !== prev.isExpanded || state.fileEditorOpenDirs !== prev.fileEditorOpenDirs || state.editorGeometry !== prev.editorGeometry || state.planGeometry !== prev.planGeometry || state.terminalPanes !== prev.terminalPanes || state.enginePanes !== prev.enginePanes || state.engineDraftInputs !== prev.engineDraftInputs) {
+    if (state.tabs !== prev.tabs || state.activeTabId !== prev.activeTabId || state.fileEditorStates !== prev.fileEditorStates || state.isExpanded !== prev.isExpanded || state.fileEditorOpenDirs !== prev.fileEditorOpenDirs || state.editorGeometry !== prev.editorGeometry || state.planGeometry !== prev.planGeometry || state.terminalPanes !== prev.terminalPanes || state.enginePanes !== prev.enginePanes || state.engineDraftInputs !== prev.engineDraftInputs || state.enginePermissionDenied !== prev.enginePermissionDenied) {
       // Flush immediately when permissionDenied changes on any tab — this
       // state must survive a crash or force-quit (e.g. the desktop is killed
       // while an engine run is in progress and the AskUserQuestion / ExitPlanMode
-      // denial is never written to the conversation file).
-      const permissionDeniedChanged = state.tabs !== prev.tabs && state.tabs.some((t, i) => {
-        const p = prev.tabs[i]
-        return p && t.id === p.id && t.permissionDenied !== p.permissionDenied
-      })
+      // denial is never written to the conversation file). This covers both:
+      //   - CLI tabs: `tab.permissionDenied` changing on `state.tabs`.
+      //   - Engine tabs: `enginePermissionDenied` map identity change.
+      const permissionDeniedChanged =
+        (state.tabs !== prev.tabs && state.tabs.some((t, i) => {
+          const p = prev.tabs[i]
+          return p && t.id === p.id && t.permissionDenied !== p.permissionDenied
+        })) ||
+        state.enginePermissionDenied !== prev.enginePermissionDenied
       if (permissionDeniedChanged) {
         if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
         persistTabs(useSessionStore)

--- a/desktop/src/renderer/stores/session-store-persistence.ts
+++ b/desktop/src/renderer/stores/session-store-persistence.ts
@@ -56,7 +56,7 @@ function persistTabs(useSessionStore: Store): void {
             const k = `${t.id}:${inst.id}`
             const arr = eMsgs.get(k)
             if (arr && arr.length > 0) {
-              msgs[inst.id] = arr.map((m) => ({ role: m.role, content: m.content, toolName: m.toolName, toolId: m.toolId, toolStatus: m.toolStatus, timestamp: m.timestamp }))
+              msgs[inst.id] = arr.map((m) => ({ role: m.role, content: m.content, toolName: m.toolName, toolId: m.toolId, toolInput: m.toolInput, toolStatus: m.toolStatus, timestamp: m.timestamp }))
             }
           }
           if (Object.keys(msgs).length > 0) result.engineMessages = msgs
@@ -90,6 +90,22 @@ function persistTabs(useSessionStore: Store): void {
             }
           }
           if (Object.keys(denials).length > 0) result.engineDenials = denials
+          // Persist the most recent conversation ID for each instance so
+          // we can resume the engine session with continuity on relaunch
+          // and so the denial-backfill hook can locate the right
+          // conversation file. The runtime map (engineConversationIds)
+          // is keyed by the compound `${tabId}:${instanceId}` and may
+          // hold a chain of historical IDs — we serialize only the most
+          // recent (last) ID per instance.
+          const { engineConversationIds: eConvs } = useSessionStore.getState()
+          const sessionIds: Record<string, string> = {}
+          for (const inst of hPane.instances) {
+            const chain = eConvs.get(`${t.id}:${inst.id}`)
+            if (chain && chain.length > 0) {
+              sessionIds[inst.id] = chain[chain.length - 1]
+            }
+          }
+          if (Object.keys(sessionIds).length > 0) result.engineSessionIds = sessionIds
           return result
         })() : {}),
         ...(pane && pane.instances.length > 0 ? { terminalInstances: pane.instances } : {}),

--- a/desktop/src/renderer/stores/session-store-types.ts
+++ b/desktop/src/renderer/stores/session-store-types.ts
@@ -59,6 +59,26 @@ export interface State {
   engineMessages: Map<string, Message[]>
   engineModelOverrides: Map<string, string>
   engineDraftInputs: Map<string, string>
+  /**
+   * Pending AskUserQuestion / ExitPlanMode denials per engine instance,
+   * keyed by the compound `${tabId}:${instanceId}` key. A `null` slot is
+   * the explicit "no pending denial" marker for an instance (preserved
+   * across cost-only `engine_status` ticks).
+   *
+   * Engine sub-tabs (instances under a single engine view) are independent
+   * sub-conversations. Storing denial state per-instance (vs. on the
+   * parent `tab.permissionDenied`) keeps siblings from showing each
+   * other's AskUserQuestion / ExitPlanMode cards when the user switches
+   * between them. CLI tabs continue to use `tab.permissionDenied` — this
+   * map is engine-only.
+   *
+   * Parent-pill bubbling: `getWaitingState()` in `TabStripShared.ts` folds
+   * across an engine tab's instance entries so the strip pill still glows
+   * when any sub-tab is blocked. iOS receives the active instance's
+   * denial via `RemoteTabState.permissionQueue` (see snapshot.ts) so the
+   * iOS card path continues to work unchanged at the tab level.
+   */
+  enginePermissionDenied: Map<string, { tools: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> } | null>
 
   tallViewTabId: string | null
   scrollToBottomCounter: number

--- a/desktop/src/renderer/stores/sessionStore.ts
+++ b/desktop/src/renderer/stores/sessionStore.ts
@@ -60,6 +60,11 @@ const initialState = {
   engineMessages: new Map<string, Message[]>(),
   engineModelOverrides: new Map<string, string>(),
   engineDraftInputs: new Map<string, string>(),
+  // Per-engine-instance AskUserQuestion / ExitPlanMode denials. Keyed by
+  // `${tabId}:${instanceId}`. See `enginePermissionDenied` JSDoc on
+  // `State` (session-store-types.ts) for the full rationale. Mirrors the
+  // other per-instance maps (engineMessages, engineDraftInputs, etc.).
+  enginePermissionDenied: new Map<string, { tools: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> } | null>(),
   tallViewTabId: null,
   scrollToBottomCounter: 0,
   settingsOpen: false,

--- a/desktop/src/renderer/stores/slices/engine-event-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-slice.ts
@@ -147,19 +147,71 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
                 engineConversationIds.set(key, [...existing, sessionId])
               }
             }
+
+            // Promote AskUserQuestion / ExitPlanMode permissionDenials
+            // carried on engine_status into the parent tab's
+            // `permissionDenied` state. This is the engine-view counterpart
+            // to the sessionPlane synthesis at
+            // engine-control-plane-events.ts:handleStatusEvent — which is
+            // bypassed for engine-view tabs because EngineControlPlane is
+            // keyed by bare tabId and engine-view events arrive with the
+            // compound `tabId:instanceId` key.
+            //
+            // Snapshot/idempotence rules:
+            //   - Only the renderer's `tab.permissionDenied` is mutated;
+            //     `tab.status` is left to the existing isIdle/isRunning
+            //     logic above (we don't have a per-engine 'completed'
+            //     status concept like the CLI sessionPlane does).
+            //   - When the array is empty/absent (a follow-up cost-only
+            //     `engine_status` tick), we PRESERVE any existing
+            //     `tab.permissionDenied` so the card stays visible.
+            //     The renderer-side card render relies on this — the
+            //     engine emits one engine_status with denials and then
+            //     a stream of cost-only ticks; clobbering would make the
+            //     card flicker out.
+            //   - We log both branches with verbosity matching
+            //     event-slice.ts's `[task_complete] tab=... branch=...`
+            //     lines so a single grep covers CLI + engine paths.
+            const askOrExitDenials: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> = (event.fields?.permissionDenials || []).filter(
+              (d: { toolName: string }) => d.toolName === 'AskUserQuestion' || d.toolName === 'ExitPlanMode',
+            )
+            const hasInterestingDenials = askOrExitDenials.length > 0
+            let denialTabsUpdate: typeof state.tabs | null = null
+            if (hasInterestingDenials) {
+              const toolNamesStr = JSON.stringify(askOrExitDenials.map((d) => d.toolName))
+              const instanceId = key.split(':')[1] || ''
+              console.log(`[engine_status] tab=${tabId.slice(0, 8)} instance=${instanceId} branch=denials permDenied set to ${toolNamesStr}`)
+              denialTabsUpdate = state.tabs.map((t) =>
+                t.id === tabId ? { ...t, permissionDenied: { tools: askOrExitDenials } } : t,
+              )
+            } else if ((event.fields?.permissionDenials?.length ?? 0) === 0) {
+              // Cost-only or running tick — PRESERVE existing permissionDenied.
+              // Logged at debug verbosity (no state change). Keep the noise
+              // low; only log if we currently hold a card to preserve.
+              const existingTab = state.tabs.find((t) => t.id === tabId)
+              if (existingTab?.permissionDenied?.tools?.length) {
+                const instanceId = key.split(':')[1] || ''
+                console.log(`[engine_status] tab=${tabId.slice(0, 8)} instance=${instanceId} branch=noDenials preserving existing permDenied (${existingTab.permissionDenied.tools.length} tools)`)
+              }
+            }
+
             const needsTabUpdate = isActive && (sessionId || isIdle || isRunning)
-            if (needsTabUpdate) {
-              const tabs = state.tabs.map((t) => {
+            // If we computed a denialTabsUpdate, fold the conversationId /
+            // status updates into the same `tabs.map` pass so we don't drop
+            // either change.
+            if (needsTabUpdate || denialTabsUpdate) {
+              const baseTabs = denialTabsUpdate || state.tabs
+              const tabs = baseTabs.map((t) => {
                 if (t.id !== tabId) return t
                 const updates: Partial<typeof t> = {}
                 if (sessionId && t.conversationId !== sessionId) {
                   updates.conversationId = sessionId
                   updates.lastKnownSessionId = sessionId
                 }
-                if (isRunning && t.status !== 'running') {
+                if (isRunning && t.status !== 'running' && isActive) {
                   updates.status = 'running' as const
                 }
-                if (isIdle && t.status !== 'idle') {
+                if (isIdle && t.status !== 'idle' && isActive) {
                   updates.status = 'idle' as const
                 }
                 return Object.keys(updates).length > 0 ? { ...t, ...updates } : t

--- a/desktop/src/renderer/stores/slices/engine-event-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-slice.ts
@@ -116,6 +116,15 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
           break
         }
         case 'engine_status': {
+          // Track whether the inside-`set` reducer captured a new
+          // sessionId into engineConversationIds — if so, we trigger an
+          // immediate persistence flush after the reducer returns so the
+          // sessionId survives a hard kill (closed laptop lid, OS force-
+          // quit, power loss) that arrives before the next debounced save.
+          // Without this, the renderer holds the sessionId in memory only
+          // and the user's "continuous" conversation silently restarts
+          // from scratch on the next launch.
+          let didCaptureNewSessionId = false
           set((state) => {
             const statusFields = new Map(state.engineStatusFields)
 
@@ -145,6 +154,19 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
               if (existing[existing.length - 1] !== sessionId) {
                 engineConversationIds = new Map(state.engineConversationIds)
                 engineConversationIds.set(key, [...existing, sessionId])
+                didCaptureNewSessionId = true
+                // Permanent diagnostic log per the repo logging policy
+                // (~/.claude/docs/standards/logging.md, repo CLAUDE.md
+                // "Logging policy"). This is the only place the runtime
+                // `engineConversationIds` map is mutated for engine-view
+                // tabs (compound `${tabId}:${instanceId}` keys); without
+                // this line, we have no way to confirm from logs alone
+                // that the source map is being populated before the
+                // persistence layer reads from it. Logs the exact key
+                // shape so a future "session not resumed on restart"
+                // investigation can confirm the key matches what
+                // session-store-persistence.ts expects.
+                console.log(`[engine_status] engineConversationIds.set key=${key} sessionId=${sessionId} chainLen=${existing.length + 1}`)
               }
             }
 
@@ -231,6 +253,23 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
             }
             return returnPatch
           })
+          // Durability: persist immediately whenever a new sessionId
+          // arrived. The default subscriber debounces saves at 100 ms,
+          // which is normally fine but creates a window where a hard
+          // kill (OS terminated us, laptop lid closed mid-write) drops
+          // the sessionId. The cost of an extra synchronous IPC write
+          // is small (one fs.writeFileSync via atomicWriteFileSync) and
+          // only happens at session-start transitions, not on every
+          // status tick. `__ionForceFlushTabs` is wired in
+          // session-store-persistence.ts:setupPersistence — it clears
+          // the pending debounce timer and runs persistTabs() now.
+          if (didCaptureNewSessionId) {
+            const flush = (window as { __ionForceFlushTabs?: () => void }).__ionForceFlushTabs
+            if (typeof flush === 'function') {
+              console.log(`[engine_status] forcing immediate persist after sessionId capture key=${key}`)
+              flush()
+            }
+          }
           break
         }
         case 'engine_working_message': {

--- a/desktop/src/renderer/stores/slices/engine-event-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-slice.ts
@@ -149,59 +149,70 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
             }
 
             // Promote AskUserQuestion / ExitPlanMode permissionDenials
-            // carried on engine_status into the parent tab's
-            // `permissionDenied` state. This is the engine-view counterpart
-            // to the sessionPlane synthesis at
+            // carried on engine_status into the per-engine-instance
+            // `enginePermissionDenied` map (keyed by the compound
+            // `${tabId}:${instanceId}` key). This is the engine-view
+            // counterpart to the sessionPlane synthesis at
             // engine-control-plane-events.ts:handleStatusEvent — which is
             // bypassed for engine-view tabs because EngineControlPlane is
             // keyed by bare tabId and engine-view events arrive with the
-            // compound `tabId:instanceId` key.
+            // compound key.
+            //
+            // Per-instance scoping (vs. mutating the parent
+            // `tab.permissionDenied`) is what keeps sibling instances
+            // under the same engine tab from showing each other's cards
+            // when the user switches between sub-tabs. The parent tab's
+            // pill still glows via getWaitingState() in TabStripShared.ts,
+            // which folds across this map for engine tabs.
             //
             // Snapshot/idempotence rules:
-            //   - Only the renderer's `tab.permissionDenied` is mutated;
-            //     `tab.status` is left to the existing isIdle/isRunning
-            //     logic above (we don't have a per-engine 'completed'
-            //     status concept like the CLI sessionPlane does).
+            //   - We write `state.enginePermissionDenied.set(key, ...)`
+            //     using the FULL compound key — not the parent tabId.
             //   - When the array is empty/absent (a follow-up cost-only
-            //     `engine_status` tick), we PRESERVE any existing
-            //     `tab.permissionDenied` so the card stays visible.
-            //     The renderer-side card render relies on this — the
-            //     engine emits one engine_status with denials and then
-            //     a stream of cost-only ticks; clobbering would make the
+            //     `engine_status` tick), we PRESERVE any existing entry
+            //     for this key so the card stays visible. The renderer-
+            //     side card render in EngineView relies on this — the
+            //     engine emits one engine_status with denials and then a
+            //     stream of cost-only ticks; clobbering would make the
             //     card flicker out.
             //   - We log both branches with verbosity matching
             //     event-slice.ts's `[task_complete] tab=... branch=...`
             //     lines so a single grep covers CLI + engine paths.
+            //     `enginePermDenied` is the engine-tab marker; CLI tabs
+            //     use the older `permDenied` token in their own logs.
             const askOrExitDenials: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> = (event.fields?.permissionDenials || []).filter(
               (d: { toolName: string }) => d.toolName === 'AskUserQuestion' || d.toolName === 'ExitPlanMode',
             )
             const hasInterestingDenials = askOrExitDenials.length > 0
-            let denialTabsUpdate: typeof state.tabs | null = null
+            let enginePermissionDeniedUpdate: Map<string, { tools: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> } | null> | null = null
             if (hasInterestingDenials) {
               const toolNamesStr = JSON.stringify(askOrExitDenials.map((d) => d.toolName))
               const instanceId = key.split(':')[1] || ''
-              console.log(`[engine_status] tab=${tabId.slice(0, 8)} instance=${instanceId} branch=denials permDenied set to ${toolNamesStr}`)
-              denialTabsUpdate = state.tabs.map((t) =>
-                t.id === tabId ? { ...t, permissionDenied: { tools: askOrExitDenials } } : t,
-              )
+              console.log(`[engine_status] tab=${tabId.slice(0, 8)} instance=${instanceId} branch=denials enginePermDenied set to ${toolNamesStr}`)
+              enginePermissionDeniedUpdate = new Map(state.enginePermissionDenied)
+              enginePermissionDeniedUpdate.set(key, { tools: askOrExitDenials })
             } else if ((event.fields?.permissionDenials?.length ?? 0) === 0) {
-              // Cost-only or running tick — PRESERVE existing permissionDenied.
-              // Logged at debug verbosity (no state change). Keep the noise
-              // low; only log if we currently hold a card to preserve.
-              const existingTab = state.tabs.find((t) => t.id === tabId)
-              if (existingTab?.permissionDenied?.tools?.length) {
+              // Cost-only or running tick — PRESERVE existing entry for
+              // this key. Logged at debug verbosity (no state change).
+              // Keep the noise low; only log if we currently hold a card
+              // to preserve for this instance.
+              const existing = state.enginePermissionDenied.get(key)
+              if (existing?.tools?.length) {
                 const instanceId = key.split(':')[1] || ''
-                console.log(`[engine_status] tab=${tabId.slice(0, 8)} instance=${instanceId} branch=noDenials preserving existing permDenied (${existingTab.permissionDenied.tools.length} tools)`)
+                console.log(`[engine_status] tab=${tabId.slice(0, 8)} instance=${instanceId} branch=noDenials preserving existing enginePermDenied (${existing.tools.length} tools)`)
               }
             }
 
             const needsTabUpdate = isActive && (sessionId || isIdle || isRunning)
-            // If we computed a denialTabsUpdate, fold the conversationId /
-            // status updates into the same `tabs.map` pass so we don't drop
-            // either change.
-            if (needsTabUpdate || denialTabsUpdate) {
-              const baseTabs = denialTabsUpdate || state.tabs
-              const tabs = baseTabs.map((t) => {
+            // Fold conversationId / status updates into the same tabs.map
+            // pass when applicable. The `enginePermissionDenied` map is
+            // returned separately — it lives outside the per-tab struct.
+            const returnPatch: Partial<typeof state> = { engineStatusFields: statusFields, engineConversationIds }
+            if (enginePermissionDeniedUpdate) {
+              returnPatch.enginePermissionDenied = enginePermissionDeniedUpdate
+            }
+            if (needsTabUpdate) {
+              const tabs = state.tabs.map((t) => {
                 if (t.id !== tabId) return t
                 const updates: Partial<typeof t> = {}
                 if (sessionId && t.conversationId !== sessionId) {
@@ -216,9 +227,9 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
                 }
                 return Object.keys(updates).length > 0 ? { ...t, ...updates } : t
               })
-              return { engineStatusFields: statusFields, engineConversationIds, tabs }
+              returnPatch.tabs = tabs
             }
-            return { engineStatusFields: statusFields, engineConversationIds }
+            return returnPatch
           })
           break
         }

--- a/desktop/src/renderer/stores/slices/engine-event-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-slice.ts
@@ -334,6 +334,35 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
           })
           break
         }
+        case 'engine_tool_update': {
+          // The engine streams tool input incrementally as the model
+          // generates JSON. We accumulate the partial chunks onto the
+          // tool message's `toolInput` field so the persistence layer
+          // can serialize the final value (used by PermissionDeniedCard
+          // to render AskUserQuestion / ExitPlanMode question text and
+          // plan content on a fresh launch). Without this capture,
+          // `engineMessages[*].toolInput` was always undefined and the
+          // card lost its content across restarts.
+          //
+          // Snapshot semantics: each engine_tool_update is incremental
+          // — we concatenate partial chunks. The final value is the
+          // complete JSON-string toolInput. Storing it on the message
+          // (instead of a separate map) mirrors how CLI tabs do it via
+          // event-slice.ts so PermissionDeniedCard's fallback scan
+          // (`messages.find((m) => m.toolName === 'AskUserQuestion' &&
+          // m.toolInput)`) finds it on engine tabs too.
+          if (!event.toolId) break
+          set((state) => {
+            const messages = new Map(state.engineMessages)
+            const msgs = (messages.get(key) || []).map((m) => {
+              if (m.toolId !== event.toolId) return m
+              return { ...m, toolInput: (m.toolInput || '') + (event.partialInput || '') }
+            })
+            messages.set(key, msgs)
+            return { engineMessages: messages }
+          })
+          break
+        }
         case 'engine_tool_end': {
           set((state) => {
             const messages = new Map(state.engineMessages)

--- a/desktop/src/renderer/stores/slices/engine-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-slice.ts
@@ -145,6 +145,7 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       const enginePinnedPrompt = new Map(get().enginePinnedPrompt)
       const engineUsage = new Map(get().engineUsage)
       const engineDraftInputs = new Map(get().engineDraftInputs)
+      const enginePermissionDenied = new Map(get().enginePermissionDenied)
       engineMessages.delete(key)
       engineAgentStates.delete(key)
       engineStatusFields.delete(key)
@@ -154,9 +155,10 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       enginePinnedPrompt.delete(key)
       engineUsage.delete(key)
       engineDraftInputs.delete(key)
+      enginePermissionDenied.delete(key)
       const engineModelOverrides = new Map(get().engineModelOverrides)
       engineModelOverrides.delete(key)
-      set({ engineMessages, engineAgentStates, engineStatusFields, engineWorkingMessages, engineNotifications, engineDialogs, enginePinnedPrompt, engineUsage, engineDraftInputs, engineModelOverrides })
+      set({ engineMessages, engineAgentStates, engineStatusFields, engineWorkingMessages, engineNotifications, engineDialogs, enginePinnedPrompt, engineUsage, engineDraftInputs, engineModelOverrides, enginePermissionDenied })
     },
 
     selectEngineInstance: (tabId, instanceId) => {
@@ -213,6 +215,7 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       const engineDraftInputs = new Map(state.engineDraftInputs)
       const engineModelOverrides = new Map(state.engineModelOverrides)
       const engineConversationIds = new Map(state.engineConversationIds)
+      const enginePermissionDenied = new Map(state.enginePermissionDenied)
 
       const rekey = <V>(m: Map<string, V>) => {
         if (m.has(oldKey)) { m.set(newKey, m.get(oldKey)!); m.delete(oldKey) }
@@ -228,6 +231,7 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       rekey(engineDraftInputs)
       rekey(engineModelOverrides)
       rekey(engineConversationIds)
+      rekey(enginePermissionDenied)
 
       // Update enginePanes: remove from source, add to target
       const enginePanes = new Map(state.enginePanes)
@@ -260,6 +264,7 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
         engineDraftInputs,
         engineModelOverrides,
         engineConversationIds,
+        enginePermissionDenied,
       })
 
       // Close source tab if it's now empty
@@ -321,7 +326,12 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
         })
         messages.set(key, msgs)
         const tabs = state.tabs.map((t) => t.id === tabId ? { ...t, status: 'running' as const } : t)
-        return { enginePinnedPrompt: pinnedPrompt, engineMessages: messages, tabs }
+        // Clear any pending engine-instance denial — submitting a new
+        // prompt is the user moving past the question/plan card. Mirrors
+        // the engine-side clearing in `prompt_dispatch.go`.
+        const enginePermissionDenied = new Map(state.enginePermissionDenied)
+        enginePermissionDenied.set(key, null)
+        return { enginePinnedPrompt: pinnedPrompt, engineMessages: messages, tabs, enginePermissionDenied }
       })
       const prefs = usePreferencesStore.getState()
       const modelOverride = get().engineModelOverrides.get(key) || prefs.engineDefaultModel || prefs.preferredModel || undefined

--- a/desktop/src/renderer/stores/slices/tab-slice.ts
+++ b/desktop/src/renderer/stores/slices/tab-slice.ts
@@ -252,6 +252,7 @@ export function createTabSlice(set: StoreSet, get: StoreGet): Partial<State> {
         const engineConversationIds = new Map(get().engineConversationIds)
         const engineMessages = new Map(get().engineMessages)
         const engineDraftInputs = new Map(get().engineDraftInputs)
+        const enginePermissionDenied = new Map(get().enginePermissionDenied)
         const enginePanes = new Map(get().enginePanes)
         for (const k of engineAgentStates.keys()) if (k === tabId || k.startsWith(`${tabId}:`)) engineAgentStates.delete(k)
         for (const k of engineStatusFields.keys()) if (k === tabId || k.startsWith(`${tabId}:`)) engineStatusFields.delete(k)
@@ -263,8 +264,9 @@ export function createTabSlice(set: StoreSet, get: StoreGet): Partial<State> {
         for (const k of engineConversationIds.keys()) if (k === tabId || k.startsWith(`${tabId}:`)) engineConversationIds.delete(k)
         for (const k of engineMessages.keys()) if (k === tabId || k.startsWith(`${tabId}:`)) engineMessages.delete(k)
         for (const k of engineDraftInputs.keys()) if (k === tabId || k.startsWith(`${tabId}:`)) engineDraftInputs.delete(k)
+        for (const k of enginePermissionDenied.keys()) if (k === tabId || k.startsWith(`${tabId}:`)) enginePermissionDenied.delete(k)
         enginePanes.delete(tabId)
-        set({ engineAgentStates, engineStatusFields, engineWorkingMessages, engineNotifications, engineDialogs, enginePinnedPrompt, engineUsage, engineConversationIds, engineMessages, engineDraftInputs, enginePanes })
+        set({ engineAgentStates, engineStatusFields, engineWorkingMessages, engineNotifications, engineDialogs, enginePinnedPrompt, engineUsage, engineConversationIds, engineMessages, engineDraftInputs, enginePermissionDenied, enginePanes })
       }
       if (closingTab) {
         const dir = closingTab.workingDirectory

--- a/desktop/src/shared/types-persistence.ts
+++ b/desktop/src/shared/types-persistence.ts
@@ -34,8 +34,26 @@ export interface PersistedTab {
   isEngine?: boolean
   engineProfileId?: string | null
   engineInstances?: EngineInstance[]
-  engineMessages?: Record<string, Array<{ role: string; content: string; toolName?: string; toolId?: string; toolStatus?: string; timestamp: number }>>
+  engineMessages?: Record<string, Array<{ role: string; content: string; toolName?: string; toolId?: string; toolInput?: string; toolStatus?: string; timestamp: number }>>
   engineAgentStates?: Record<string, Array<{ name: string; status: string; metadata?: Record<string, any> }>>
+  /**
+   * Most recent engine conversation ID per engine instance, keyed by
+   * `instanceId`. Used on restoration to resume the engine session
+   * with continuity instead of starting a fresh conversation file.
+   *
+   * Why per-instance: a single engine tab hosts multiple independent
+   * sub-conversations (one per instance), each backed by its own
+   * `~/.ion/conversations/<sessionId>.jsonl`. Persisting the parent
+   * `tab.conversationId` alone wasn't enough — three instances under
+   * the same tab would collide on a single ID. The first version of
+   * the engine-tab persistence missed this; the field is added in
+   * the same change that introduces per-instance permission denials.
+   *
+   * Engine continuity also matters for `useEnginePermissionDenialBackfill`:
+   * the hook needs to know which conversation file to read to recover
+   * a pending AskUserQuestion / ExitPlanMode card after a restart.
+   */
+  engineSessionIds?: Record<string, string>
   /**
    * Per-engine-instance AskUserQuestion / ExitPlanMode denials, keyed by
    * `instanceId`. Mirrors the runtime `enginePermissionDenied` map (which

--- a/desktop/src/shared/types-persistence.ts
+++ b/desktop/src/shared/types-persistence.ts
@@ -36,6 +36,14 @@ export interface PersistedTab {
   engineInstances?: EngineInstance[]
   engineMessages?: Record<string, Array<{ role: string; content: string; toolName?: string; toolId?: string; toolStatus?: string; timestamp: number }>>
   engineAgentStates?: Record<string, Array<{ name: string; status: string; metadata?: Record<string, any> }>>
+  /**
+   * Per-engine-instance AskUserQuestion / ExitPlanMode denials, keyed by
+   * `instanceId`. Mirrors the runtime `enginePermissionDenied` map (which
+   * is keyed by the compound `${tabId}:${instanceId}`). Only instances
+   * with a non-null pending denial appear here. Restored on relaunch so
+   * a crash mid-question doesn't lose the card.
+   */
+  engineDenials?: Record<string, { tools: Array<{ toolName: string; toolUseId: string; toolInput?: Record<string, unknown> }> }>
   terminalInstances?: TerminalInstance[]
   terminalBuffers?: Record<string, string>
   /** Wall-clock ms of the most recent engine event for this tab. Persisted so

--- a/engine/internal/session/event_translation.go
+++ b/engine/internal/session/event_translation.go
@@ -179,20 +179,19 @@ func (m *Manager) handleNormalizedEvent(runID string, event types.NormalizedEven
 				s2.lastTotalCost = tc.CostUsd
 			}
 			// Capture pending denials so ReconcileState can re-emit them
-			// when a client reconnects to a session blocked on
-			// AskUserQuestion / ExitPlanMode. Cleared on next prompt
-			// dispatch (see prompt_dispatch.go). We retain the full
-			// PermissionDenials slice from the task_complete payload — the
-			// renderer / iOS already filter to AskUserQuestion /
-			// ExitPlanMode for card rendering, but the field itself is
-			// authoritative as published by the backend.
+			// on the engine_status snapshot a re-attaching consumer
+			// requests. Cleared on next prompt dispatch (see
+			// prompt_dispatch.go). The full PermissionDenials slice
+			// from the task_complete payload is retained verbatim;
+			// consumer-side filtering or interpretation is out of
+			// scope for the engine.
 			//
 			// Snapshot semantics: this assignment REPLACES whatever was
 			// previously retained. The most recent task_complete is the
 			// authoritative truth about what (if anything) is still blocked.
 			// An empty PermissionDenials slice correctly clears the
 			// retained state — a task that completed cleanly has no
-			// outstanding question to re-show.
+			// outstanding denials to re-emit.
 			s2.lastPermissionDenials = tc.PermissionDenials
 			utils.Log("Session", fmt.Sprintf("task_complete: key=%s retained %d permission_denials for reconcile", key, len(tc.PermissionDenials)))
 		}

--- a/engine/internal/session/event_translation.go
+++ b/engine/internal/session/event_translation.go
@@ -178,6 +178,23 @@ func (m *Manager) handleNormalizedEvent(runID string, event types.NormalizedEven
 			if tc.CostUsd > 0 {
 				s2.lastTotalCost = tc.CostUsd
 			}
+			// Capture pending denials so ReconcileState can re-emit them
+			// when a client reconnects to a session blocked on
+			// AskUserQuestion / ExitPlanMode. Cleared on next prompt
+			// dispatch (see prompt_dispatch.go). We retain the full
+			// PermissionDenials slice from the task_complete payload — the
+			// renderer / iOS already filter to AskUserQuestion /
+			// ExitPlanMode for card rendering, but the field itself is
+			// authoritative as published by the backend.
+			//
+			// Snapshot semantics: this assignment REPLACES whatever was
+			// previously retained. The most recent task_complete is the
+			// authoritative truth about what (if anything) is still blocked.
+			// An empty PermissionDenials slice correctly clears the
+			// retained state — a task that completed cleanly has no
+			// outstanding question to re-show.
+			s2.lastPermissionDenials = tc.PermissionDenials
+			utils.Log("Session", fmt.Sprintf("task_complete: key=%s retained %d permission_denials for reconcile", key, len(tc.PermissionDenials)))
 		}
 		m.mu.Unlock()
 		m.emit(key, types.EngineEvent{

--- a/engine/internal/session/manager.go
+++ b/engine/internal/session/manager.go
@@ -378,6 +378,14 @@ func (m *Manager) ClearConversationFile(sessionID string) error {
 // considers authoritative. Skipping the emission would leave reconnecting
 // clients showing stale agent rows from a previous session. See
 // docs/architecture/agent-state.md.
+//
+// `engine_status` follows the same snapshot rule. Beyond the existing
+// context/cost/model fields, the snapshot must also carry any unresolved
+// PermissionDenials (AskUserQuestion / ExitPlanMode awaiting user input)
+// — otherwise a desktop reinstall or daemon reconnect would lose the
+// card even though the session is still blocked on the question. The
+// session retains these via lastPermissionDenials, populated from the
+// most recent TaskCompleteEvent and cleared when a new prompt dispatches.
 func (m *Manager) ReconcileState(key string) {
 	m.mu.RLock()
 	s, ok := m.sessions[key]
@@ -394,15 +402,27 @@ func (m *Manager) ReconcileState(key string) {
 	utils.Log("Session", fmt.Sprintf("agent_snapshot_emitted key=%s count=%d reason=reconcile", key, len(snapshot)))
 	m.emit(key, types.EngineEvent{Type: "engine_agent_state", Agents: snapshot})
 
-	// Re-emit status
+	// Re-emit status. Read retained fields under the session lock so we
+	// observe a coherent snapshot (denials + cost + context together).
+	m.mu.RLock()
+	pendingDenials := s.lastPermissionDenials
+	lastPct := s.lastContextPct
+	lastWindow := s.lastContextWindow
+	lastModel := s.lastModel
+	lastCost := s.lastTotalCost
+	sessionState := m.sessionState(s)
+	m.mu.RUnlock()
+
+	utils.Log("Session", fmt.Sprintf("reconcile_status_emitted key=%s state=%s pendingDenials=%d model=%s contextPct=%d", key, sessionState, len(pendingDenials), lastModel, lastPct))
 	m.emit(key, types.EngineEvent{
 		Type: "engine_status",
 		Fields: &types.StatusFields{
-			State:          m.sessionState(s),
-			ContextPercent: s.lastContextPct,
-			ContextWindow:  s.lastContextWindow,
-			Model:          s.lastModel,
-			TotalCostUsd:   s.lastTotalCost,
+			State:             sessionState,
+			ContextPercent:    lastPct,
+			ContextWindow:     lastWindow,
+			Model:             lastModel,
+			TotalCostUsd:      lastCost,
+			PermissionDenials: pendingDenials,
 		},
 	})
 }

--- a/engine/internal/session/manager.go
+++ b/engine/internal/session/manager.go
@@ -381,11 +381,12 @@ func (m *Manager) ClearConversationFile(sessionID string) error {
 //
 // `engine_status` follows the same snapshot rule. Beyond the existing
 // context/cost/model fields, the snapshot must also carry any unresolved
-// PermissionDenials (AskUserQuestion / ExitPlanMode awaiting user input)
-// — otherwise a desktop reinstall or daemon reconnect would lose the
-// card even though the session is still blocked on the question. The
-// session retains these via lastPermissionDenials, populated from the
-// most recent TaskCompleteEvent and cleared when a new prompt dispatches.
+// PermissionDenials retained from the most recent TaskCompleteEvent —
+// otherwise a re-attaching consumer would observe an engine_status that
+// silently drops the field while the session is still blocked on those
+// denials. The session retains these via lastPermissionDenials,
+// populated in event_translation.go and cleared when a new prompt
+// dispatches (see prompt_dispatch.go).
 func (m *Manager) ReconcileState(key string) {
 	m.mu.RLock()
 	s, ok := m.sessions[key]

--- a/engine/internal/session/manager_permission_denials_test.go
+++ b/engine/internal/session/manager_permission_denials_test.go
@@ -12,18 +12,20 @@ import (
 // ReconcileState pending-permission-denial retention contract tests
 //
 // Background: AskUserQuestion and ExitPlanMode are interactive tool calls
-// that the engine intercepts and reports as PermissionDenials on the
-// TaskCompleteEvent. The renderer (desktop / iOS) renders a card from
-// these and blocks the conversation until the user answers.
+// the engine intercepts and reports as PermissionDenials on the
+// TaskCompleteEvent. The engine retains the most recent task_complete's
+// denial slice on engineSession.lastPermissionDenials so that the next
+// ReconcileState call can surface them on the engine_status snapshot.
 //
-// If a client disconnects (desktop reinstall, daemon reconnect) while a
-// session is blocked on an unanswered AskUserQuestion, the engine_status
-// emitted by ReconcileState must still carry the pending denials —
-// otherwise the reconnecting client has no signal to re-render the card,
-// even though the session is still genuinely blocked on it.
+// If a consumer re-attaches to a session that is still blocked on an
+// unanswered denial, the engine_status emitted by ReconcileState must
+// carry the retained PermissionDenials — otherwise the snapshot would
+// drop the field while the session is still in the same state. The
+// engine does not know or care how a consumer interprets the field;
+// it only guarantees the field's presence and authority.
 //
 // These tests pin that contract on the engine side. See
-// docs/engine-grounding.md §4 (snapshot contract) for the reconnect rule.
+// docs/engine-grounding.md §4 (snapshot contract) for the re-attach rule.
 // ---------------------------------------------------------------------------
 
 // TestReconcileState_RetainsPermissionDenials verifies that pending

--- a/engine/internal/session/manager_permission_denials_test.go
+++ b/engine/internal/session/manager_permission_denials_test.go
@@ -1,0 +1,246 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/session/agents"
+	"github.com/dsswift/ion/engine/internal/session/pending"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// ReconcileState pending-permission-denial retention contract tests
+//
+// Background: AskUserQuestion and ExitPlanMode are interactive tool calls
+// that the engine intercepts and reports as PermissionDenials on the
+// TaskCompleteEvent. The renderer (desktop / iOS) renders a card from
+// these and blocks the conversation until the user answers.
+//
+// If a client disconnects (desktop reinstall, daemon reconnect) while a
+// session is blocked on an unanswered AskUserQuestion, the engine_status
+// emitted by ReconcileState must still carry the pending denials —
+// otherwise the reconnecting client has no signal to re-render the card,
+// even though the session is still genuinely blocked on it.
+//
+// These tests pin that contract on the engine side. See
+// docs/engine-grounding.md §4 (snapshot contract) for the reconnect rule.
+// ---------------------------------------------------------------------------
+
+// TestReconcileState_RetainsPermissionDenials verifies that pending
+// AskUserQuestion / ExitPlanMode denials captured from a TaskCompleteEvent
+// are re-emitted by ReconcileState as part of the engine_status snapshot.
+func TestReconcileState_RetainsPermissionDenials(t *testing.T) {
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	_, _ = mgr.StartSession("recon-denials", defaultConfig())
+
+	// Seed the session with retained denials, simulating the post-state
+	// after a TaskCompleteEvent that carried an AskUserQuestion intercept.
+	mgr.mu.Lock()
+	s := mgr.sessions["recon-denials"]
+	s.lastPermissionDenials = []types.PermissionDenial{
+		{
+			ToolUseID: "tu-1",
+			ToolName:  "AskUserQuestion",
+			ToolInput: map[string]any{"question": "Pick one", "options": []string{"A", "B"}},
+		},
+	}
+	mgr.mu.Unlock()
+
+	// Collect the engine_status emitted by ReconcileState.
+	var statusEvents []types.EngineEvent
+	mgr.OnEvent(func(_ string, ev types.EngineEvent) {
+		if ev.Type == "engine_status" {
+			statusEvents = append(statusEvents, ev)
+		}
+	})
+
+	mgr.ReconcileState("recon-denials")
+
+	if len(statusEvents) == 0 {
+		t.Fatal("expected engine_status event from ReconcileState")
+	}
+	last := statusEvents[len(statusEvents)-1]
+	if last.Fields == nil {
+		t.Fatal("expected non-nil StatusFields on reconciled status")
+	}
+	if len(last.Fields.PermissionDenials) != 1 {
+		t.Fatalf("expected 1 PermissionDenial in reconciled status, got %d: %+v", len(last.Fields.PermissionDenials), last.Fields.PermissionDenials)
+	}
+	d := last.Fields.PermissionDenials[0]
+	if d.ToolName != "AskUserQuestion" {
+		t.Errorf("expected ToolName=AskUserQuestion, got %q", d.ToolName)
+	}
+	if d.ToolUseID != "tu-1" {
+		t.Errorf("expected ToolUseID=tu-1, got %q", d.ToolUseID)
+	}
+	q, _ := d.ToolInput["question"].(string)
+	if q != "Pick one" {
+		t.Errorf("expected ToolInput.question='Pick one', got %q", q)
+	}
+}
+
+// TestReconcileState_EmitsEmptyDenialsWhenNonePending verifies the
+// snapshot contract holds in the zero-state direction too: a session
+// with no retained denials emits engine_status with empty (nil)
+// PermissionDenials, not a stale value.
+func TestReconcileState_EmitsEmptyDenialsWhenNonePending(t *testing.T) {
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	_, _ = mgr.StartSession("recon-clean", defaultConfig())
+
+	var statusEvents []types.EngineEvent
+	mgr.OnEvent(func(_ string, ev types.EngineEvent) {
+		if ev.Type == "engine_status" {
+			statusEvents = append(statusEvents, ev)
+		}
+	})
+
+	mgr.ReconcileState("recon-clean")
+
+	if len(statusEvents) == 0 {
+		t.Fatal("expected engine_status event from ReconcileState")
+	}
+	last := statusEvents[len(statusEvents)-1]
+	if last.Fields == nil {
+		t.Fatal("expected non-nil StatusFields on reconciled status")
+	}
+	if len(last.Fields.PermissionDenials) != 0 {
+		t.Errorf("expected empty PermissionDenials in clean session, got %d: %+v", len(last.Fields.PermissionDenials), last.Fields.PermissionDenials)
+	}
+}
+
+// TestTaskComplete_RetainsPermissionDenialsOnSession verifies that the
+// session captures the PermissionDenials field from a TaskCompleteEvent
+// flowing through handleNormalizedEvent. This is the "write half" of the
+// retention contract — ReconcileState reads what TaskComplete wrote.
+func TestTaskComplete_RetainsPermissionDenialsOnSession(t *testing.T) {
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	_, _ = mgr.StartSession("tc-retain", defaultConfig())
+
+	// Wire a runID -> session key so handleNormalizedEvent resolves.
+	mgr.mu.Lock()
+	s := mgr.sessions["tc-retain"]
+	s.requestID = "run-tc-retain"
+	mgr.mu.Unlock()
+
+	// Drive a TaskCompleteEvent with PermissionDenials through the full
+	// handleNormalizedEvent path.
+	mgr.handleNormalizedEvent("run-tc-retain", types.NormalizedEvent{
+		Data: &types.TaskCompleteEvent{
+			Result:    "intercepted",
+			SessionID: "conv-1",
+			PermissionDenials: []types.PermissionDenial{
+				{ToolUseID: "tu-2", ToolName: "AskUserQuestion", ToolInput: map[string]any{"question": "q?"}},
+			},
+		},
+	})
+
+	mgr.mu.RLock()
+	got := s.lastPermissionDenials
+	mgr.mu.RUnlock()
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 retained denial, got %d: %+v", len(got), got)
+	}
+	if got[0].ToolName != "AskUserQuestion" || got[0].ToolUseID != "tu-2" {
+		t.Errorf("retained denial mismatch: %+v", got[0])
+	}
+}
+
+// TestTaskComplete_ClearsRetainedDenialsWhenEmpty verifies that a clean
+// task_complete (no denials) REPLACES any previously retained denials.
+// Snapshot semantics: the most recent task_complete is authoritative.
+// A session that finished cleanly has no outstanding question.
+func TestTaskComplete_ClearsRetainedDenialsWhenEmpty(t *testing.T) {
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	_, _ = mgr.StartSession("tc-clear", defaultConfig())
+
+	mgr.mu.Lock()
+	s := mgr.sessions["tc-clear"]
+	s.requestID = "run-tc-clear"
+	// Pre-seed retained denials from a prior task_complete.
+	s.lastPermissionDenials = []types.PermissionDenial{
+		{ToolUseID: "tu-old", ToolName: "AskUserQuestion"},
+	}
+	mgr.mu.Unlock()
+
+	// Drive a CLEAN TaskCompleteEvent (no denials).
+	mgr.handleNormalizedEvent("run-tc-clear", types.NormalizedEvent{
+		Data: &types.TaskCompleteEvent{
+			Result:    "ok",
+			SessionID: "conv-2",
+			// PermissionDenials intentionally nil
+		},
+	})
+
+	mgr.mu.RLock()
+	got := s.lastPermissionDenials
+	mgr.mu.RUnlock()
+
+	if len(got) != 0 {
+		t.Errorf("expected retained denials to be cleared by clean task_complete, got %d: %+v", len(got), got)
+	}
+}
+
+// TestReconcileState_PendingDenialsArePerSession verifies that retained
+// denials are scoped to the session that owns them — a reconcile on
+// session A must not re-emit denials retained on session B.
+func TestReconcileState_PendingDenialsArePerSession(t *testing.T) {
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	_, _ = mgr.StartSession("sess-a", defaultConfig())
+	_, _ = mgr.StartSession("sess-b", defaultConfig())
+
+	mgr.mu.Lock()
+	mgr.sessions["sess-a"].lastPermissionDenials = []types.PermissionDenial{
+		{ToolUseID: "tu-a", ToolName: "AskUserQuestion"},
+	}
+	// sess-b has no denials.
+	mgr.mu.Unlock()
+
+	// Track per-key status emissions.
+	statusByKey := map[string][]types.EngineEvent{}
+	mgr.OnEvent(func(key string, ev types.EngineEvent) {
+		if ev.Type == "engine_status" {
+			statusByKey[key] = append(statusByKey[key], ev)
+		}
+	})
+
+	mgr.ReconcileState("sess-b")
+	mgr.ReconcileState("sess-a")
+
+	if len(statusByKey["sess-a"]) == 0 || len(statusByKey["sess-b"]) == 0 {
+		t.Fatalf("expected status emitted for both sessions: a=%d b=%d", len(statusByKey["sess-a"]), len(statusByKey["sess-b"]))
+	}
+	lastA := statusByKey["sess-a"][len(statusByKey["sess-a"])-1]
+	lastB := statusByKey["sess-b"][len(statusByKey["sess-b"])-1]
+
+	if lastA.Fields == nil || len(lastA.Fields.PermissionDenials) != 1 {
+		t.Errorf("expected sess-a to carry 1 denial, got %+v", lastA.Fields)
+	}
+	if lastB.Fields == nil || len(lastB.Fields.PermissionDenials) != 0 {
+		t.Errorf("expected sess-b to carry 0 denials, got %+v", lastB.Fields)
+	}
+}
+
+// makeSessionWithDenials is a small helper to assemble an engineSession
+// with retained denials for tests that don't need to go through the full
+// handleNormalizedEvent translation path.
+func makeSessionWithDenials(key string, denials []types.PermissionDenial) *engineSession {
+	return &engineSession{
+		key:                   key,
+		config:                defaultConfig(),
+		agents:                agents.NewRegistry(),
+		childPIDs:             make(map[int]struct{}),
+		pending:               pending.New(),
+		lastPermissionDenials: denials,
+	}
+}
+
+// Compile-time guarantee that the helper above is referenced (it's
+// available for future tests that need it; the linter would otherwise
+// flag it as unused if left dangling).
+var _ = makeSessionWithDenials

--- a/engine/internal/session/prompt_dispatch.go
+++ b/engine/internal/session/prompt_dispatch.go
@@ -213,6 +213,16 @@ func (m *Manager) SendPrompt(key, text string, overrides *PromptOverrides) (retE
 	m.mu.Lock()
 	s.lastModel = opts.Model
 	s.lastContextWindow = promptCtxWindow
+	// Clear any retained permission denials from a prior task_complete —
+	// the user is dispatching a new prompt, which is implicitly the answer
+	// to (or dismissal of) the previous AskUserQuestion / ExitPlanMode.
+	// Without this, a subsequent ReconcileState would re-surface a stale
+	// card on top of an in-flight prompt. The renderer would clobber its
+	// own already-cleared permissionDenied state with the stale snapshot.
+	if len(s.lastPermissionDenials) > 0 {
+		utils.Log("Session", fmt.Sprintf("prompt_dispatch: key=%s clearing %d retained permission_denials (new prompt supersedes)", key, len(s.lastPermissionDenials)))
+		s.lastPermissionDenials = nil
+	}
 	lastPct := s.lastContextPct
 	m.mu.Unlock()
 

--- a/engine/internal/session/prompt_dispatch.go
+++ b/engine/internal/session/prompt_dispatch.go
@@ -217,8 +217,8 @@ func (m *Manager) SendPrompt(key, text string, overrides *PromptOverrides) (retE
 	// the user is dispatching a new prompt, which is implicitly the answer
 	// to (or dismissal of) the previous AskUserQuestion / ExitPlanMode.
 	// Without this, a subsequent ReconcileState would re-surface a stale
-	// card on top of an in-flight prompt. The renderer would clobber its
-	// own already-cleared permissionDenied state with the stale snapshot.
+	// denial on top of an in-flight prompt, contradicting the session's
+	// current state.
 	if len(s.lastPermissionDenials) > 0 {
 		utils.Log("Session", fmt.Sprintf("prompt_dispatch: key=%s clearing %d retained permission_denials (new prompt supersedes)", key, len(s.lastPermissionDenials)))
 		s.lastPermissionDenials = nil

--- a/engine/internal/session/types.go
+++ b/engine/internal/session/types.go
@@ -76,6 +76,31 @@ type engineSession struct {
 	lastModel         string
 	lastTotalCost     float64
 
+	// lastPermissionDenials retains the AskUserQuestion / ExitPlanMode
+	// denial entries from the most recent TaskCompleteEvent. These are
+	// intercepted-tool calls that need a user response before the next
+	// prompt can be dispatched. We keep them on the session so a freshly
+	// reconnected client (desktop reinstall, daemon reconnect, etc.) can
+	// pick the card back up via ReconcileState — without this, the
+	// snapshot emitted on reconnect would drop the field and the
+	// AskUserQuestion / ExitPlanMode card would silently vanish from the
+	// client's view even though the session is still blocked on it.
+	//
+	// Lifecycle:
+	//   - Populated in event_translation.go when a TaskCompleteEvent
+	//     carries non-empty PermissionDenials.
+	//   - Cleared in prompt_dispatch.go when a new prompt is dispatched
+	//     (the user is moving past the question).
+	//   - Re-emitted by manager.go ReconcileState as part of the
+	//     engine_status snapshot.
+	//
+	// Engine contract: engine_status is a snapshot of the session's
+	// current observable state. PermissionDenials was already part of
+	// that contract on the task_complete-derived emission; this field
+	// closes the gap so ReconcileState emits it too. Not a new field —
+	// already declared on StatusFields, mirrored in TS / Swift.
+	lastPermissionDenials []types.PermissionDenial
+
 	// Agent spawner counter – monotonically increasing across runs so
 	// agent names are globally unique within the session.
 	agentCounter int

--- a/engine/internal/session/types.go
+++ b/engine/internal/session/types.go
@@ -76,21 +76,23 @@ type engineSession struct {
 	lastModel         string
 	lastTotalCost     float64
 
-	// lastPermissionDenials retains the AskUserQuestion / ExitPlanMode
-	// denial entries from the most recent TaskCompleteEvent. These are
-	// intercepted-tool calls that need a user response before the next
-	// prompt can be dispatched. We keep them on the session so a freshly
-	// reconnected client (desktop reinstall, daemon reconnect, etc.) can
-	// pick the card back up via ReconcileState — without this, the
-	// snapshot emitted on reconnect would drop the field and the
-	// AskUserQuestion / ExitPlanMode card would silently vanish from the
-	// client's view even though the session is still blocked on it.
+	// lastPermissionDenials retains the PermissionDenials slice from the
+	// most recent TaskCompleteEvent. The slice typically contains
+	// AskUserQuestion / ExitPlanMode entries — intercepted tool calls
+	// that the session reports as denied but unresolved until the next
+	// prompt either supersedes them or answers them. The engine keeps
+	// them on the session so ReconcileState can include them on the
+	// engine_status snapshot it emits; without this retention, a
+	// re-attaching consumer would observe an engine_status that
+	// silently drops a field that was authoritative on the last
+	// task_complete, while the session itself is still in the same
+	// state.
 	//
 	// Lifecycle:
 	//   - Populated in event_translation.go when a TaskCompleteEvent
 	//     carries non-empty PermissionDenials.
 	//   - Cleared in prompt_dispatch.go when a new prompt is dispatched
-	//     (the user is moving past the question).
+	//     (the new prompt supersedes the prior unresolved denial).
 	//   - Re-emitted by manager.go ReconcileState as part of the
 	//     engine_status snapshot.
 	//

--- a/ios/IonRemote/Models/RemoteTabState.swift
+++ b/ios/IonRemote/Models/RemoteTabState.swift
@@ -48,6 +48,15 @@ struct TerminalInstanceInfo: Codable, Identifiable, Sendable {
 struct EngineInstanceInfo: Codable, Identifiable, Sendable {
     let id: String
     var label: String
+    /// Per-engine-instance waiting state, decoded from the desktop snapshot.
+    /// Values: `"question"` (AskUserQuestion pending), `"plan-ready"`
+    /// (ExitPlanMode pending), or nil/absent (no waiting state). Engine
+    /// sub-tabs are independent sub-conversations on the desktop, so each
+    /// instance carries its own state — `EngineInstanceBar` renders a dot
+    /// when this is non-nil. The parent tab's overall waiting state comes
+    /// through `permissionQueue` on the enclosing `RemoteTabState` (the
+    /// desktop promotes the active instance's denial into that queue).
+    var waitingState: String? = nil
 }
 
 // MARK: - PermissionMode

--- a/ios/IonRemote/ViewModels/SessionViewModel+Snapshot.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+Snapshot.swift
@@ -143,7 +143,13 @@ extension SessionViewModel {
             }
             // Populate engine instance state from snapshot tab data
             if tab.isEngine == true, let instances = tab.engineInstances {
-                engineInstances[tab.id] = instances.map { EngineInstanceInfo(id: $0.id, label: $0.label) }
+                // Carry waitingState through to the local model so
+                // EngineInstanceBar can render its per-instance status
+                // dot. Desktop sends nil for no-state, "question" for
+                // AskUserQuestion, "plan-ready" for ExitPlanMode.
+                engineInstances[tab.id] = instances.map {
+                    EngineInstanceInfo(id: $0.id, label: $0.label, waitingState: $0.waitingState)
+                }
                 activeEngineInstance[tab.id] = tab.activeEngineInstanceId ?? instances.first?.id
                 ionLog.info("snapshot: engine tab \(tab.id.prefix(8)), instances=\(instances.map(\.id)), active=\(tab.activeEngineInstanceId ?? "nil")")
                 // Pre-load engine conversation history for all engine tabs

--- a/ios/IonRemote/Views/EngineInstanceBar.swift
+++ b/ios/IonRemote/Views/EngineInstanceBar.swift
@@ -49,6 +49,17 @@ struct EngineInstanceBar: View {
             viewModel.selectEngineInstance(tabId: tabId, instanceId: instance.id)
         } label: {
             HStack(spacing: 4) {
+                // Per-instance waiting-state dot. Desktop maps the value
+                // to "question" (AskUserQuestion pending) or "plan-ready"
+                // (ExitPlanMode pending) per the snapshot contract. Color
+                // and semantic priority mirror the desktop palette
+                // (yellow/orange for question, green for plan-ready).
+                // When nil, no dot is shown.
+                if let ws = instance.waitingState {
+                    Circle()
+                        .fill(ws == "question" ? Color.orange : Color.green)
+                        .frame(width: 6, height: 6)
+                }
                 Image(systemName: "bolt")
                     .font(.caption2)
                 Text(instance.label)


### PR DESCRIPTION
## Summary

Engine view tabs lost a class of in-flight state on every desktop restart and on every fresh attach to an already-running engine: pending AskUserQuestion / ExitPlanMode cards disappeared, per-instance waiting states didn't render, footer values reset, and engine session IDs silently fell out of the persisted tabs file — causing every restart to start a brand new engine conversation even though the renderer still displayed the prior messages. This PR closes those gaps end-to-end across the engine and desktop.

## Changes

- **engine:** Retain the most recent task_complete's PermissionDenials on engineSession.lastPermissionDenials and include them in the engine_status emitted by ReconcileState, so a client attaching to a session blocked on an unanswered AskUserQuestion still sees the card. Snapshot contract: lastPermissionDenials is REPLACED on every task_complete; clearing happens when a new prompt dispatches.
- **engine:** Clarify the retention comments on the permission-denial path so the snapshot semantics are obvious at the call sites.
- **desktop:** After every successful start_session attach, issue a reconcile_state RPC. The engine re-emits engine_agent_state and engine_status (with retained PermissionDenials) which the renderer translates into tab.permissionDenied, agent rows, and footer values — populating state for already-running sessions that idempotent start_session would otherwise leave invisible. Extracts startSession and conversation-data RPCs into sibling files to keep engine-bridge.ts under the 600-line cap.
- **desktop:** Render the AskUserQuestion / ExitPlanMode card in engine view tabs by promoting permissionDenials carried on engine_status into a per-instance enginePermissionDenied map keyed by the full compound \`\${tabId}:\${instanceId}\` key. Sibling instances under the same engine tab no longer show each other's cards.
- **desktop:** Add a per-instance waiting state to engine UI so the tab strip pill glows on the right sub-instance and the parent tab folds across the per-instance map.
- **desktop:** Restore engine AskUserQuestion cards across restarts by persisting and rehydrating per-instance denials, synthesizing a denial from the last tool message in history when the engine's reconcile slice is empty, and capturing toolInput from engine_tool_update so the card has its question content on a fresh launch.
- **desktop:** Persist engine session IDs immediately on capture. The 100ms debounced save was the window where a force-quit / lid close / OS kill dropped the sessionId, causing the next restart to start a new engine conversation. Triggers \`__ionForceFlushTabs\` synchronously on the first sessionId arrival per instance. Adds permanent diagnostic logging for the runtime engineConversationIds map and for the persistence loop's empty-result branch so a future key-shape mismatch is observable from logs alone.