### PR TITLE
fix(desktop): use static import for engineBridge in engine-bridge-fs

### DIFF
--- a/desktop/src/main/engine-bridge-fs.ts
+++ b/desktop/src/main/engine-bridge-fs.ts
@@ -1,15 +1,22 @@
 import { IS_REMOTE } from './engine-bridge'
+import { engineBridge } from './state'
 import { log } from './logger'
 import type { EngineDirListing, EngineHostInfo } from '../shared/types'
 
-/** Lazy lookup of the bridge singleton. Avoids a static import of './state',
- *  which transitively imports EngineControlPlane and would create a circular
- *  load-order dependency (state -> control-plane -> engine-bridge-fs -> state).
- *  The first call after app boot is when the picker is opened, by which
- *  point state.ts has finished initializing. */
+/** Returns the bridge singleton.
+ *
+ *  The import cycle (state → control-plane → engine-bridge-fs → state) is
+ *  safe because the binding is read inside a function body, never at
+ *  module-eval time. The first call is when the directory picker opens — long
+ *  after all modules have finished initialising.
+ *
+ *  A runtime `require('./state')` would work in a multi-file Electron build
+ *  (Node resolves siblings at runtime), but it silently breaks when esbuild
+ *  produces a single-file bundle: there is no sibling `state.js` to require.
+ *  A static `import` is resolved by esbuild at bundle time and is safe for
+ *  both build modes. */
 function bridge(): import('./engine-bridge').EngineBridge {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require('./state').engineBridge
+  return engineBridge
 }
 
 /**


### PR DESCRIPTION
## Problem

`engine-bridge-fs.ts` uses a runtime `require('./state')` to obtain the
`engineBridge` singleton:

```ts
function bridge(): EngineBridge {
  // eslint-disable-next-line @typescript-eslint/no-require-imports
  return require('./state').engineBridge
}
```

The comment explains this was chosen to avoid a circular load-order issue
(state → control-plane → engine-bridge-fs → state). That concern is real, but
the chosen fix introduces a different problem: **`require()` silently breaks
when esbuild produces a single-file bundle.**

In a single-file bundle there is no sibling `state.js` on disk for Node to
resolve at runtime. The `require('./state')` call returns `undefined`,
`engineBridge` is `undefined`, and every downstream call to `get_host_info` or
`list_directory` throws.

## Fix

Replace with a static `import`. The circular-dependency concern does not
actually apply here because the import binding is only *read* inside the
`bridge()` function body — never at module-eval time. The first call site (the
directory picker opening) occurs long after all modules have finished
initialising, so there is no load-order race.

```ts
import { engineBridge } from './state'

function bridge(): EngineBridge {
  return engineBridge
}
```

Static imports are resolved by esbuild at bundle time and work correctly in
both multi-file (standard Electron) and single-file build configurations.

## Testing

- `npm run typecheck` passes (no circular-dependency type errors)
- `npm test` passes
- Manually verified in a single-file esbuild bundle: `get_host_info` and
  `list_directory` RPCs return correctly