### PR TITLE
feat(engine): wire task_created/task_completed hooks for CliBackend

### DIFF
--- a/engine/internal/extension/group.go
+++ b/engine/internal/extension/group.go
@@ -87,6 +87,12 @@ func (g *ExtensionGroup) FireMessageUpdate(ctx *Context, info MessageUpdateInfo)
 func (g *ExtensionGroup) FireToolEnd(ctx *Context) error {
 	return g.fireVoid(func(h *Host) error { return h.FireToolEnd(ctx) })
 }
+func (g *ExtensionGroup) FireTaskCreated(ctx *Context, info TaskLifecycleInfo) error {
+	return g.fireVoid(func(h *Host) error { return h.FireTaskCreated(ctx, info) })
+}
+func (g *ExtensionGroup) FireTaskCompleted(ctx *Context, info TaskLifecycleInfo) error {
+	return g.fireVoid(func(h *Host) error { return h.FireTaskCompleted(ctx, info) })
+}
 
 func (g *ExtensionGroup) FireOnError(ctx *Context, info ErrorInfo) error {
 	return g.fireVoid(func(h *Host) error { return h.FireOnError(ctx, info) })

--- a/engine/internal/extension/hook_dispatch.go
+++ b/engine/internal/extension/hook_dispatch.go
@@ -16,6 +16,12 @@ func (h *Host) FireSessionEnd(ctx *Context) error           { return h.sdk.FireS
 func (h *Host) FireMessageStart(ctx *Context) error         { return h.sdk.FireMessageStart(ctx) }
 func (h *Host) FireMessageEnd(ctx *Context) error           { return h.sdk.FireMessageEnd(ctx) }
 func (h *Host) FireToolEnd(ctx *Context) error              { return h.sdk.FireToolEnd(ctx) }
+func (h *Host) FireTaskCreated(ctx *Context, info TaskLifecycleInfo) error {
+	return h.sdk.FireTaskCreated(ctx, info)
+}
+func (h *Host) FireTaskCompleted(ctx *Context, info TaskLifecycleInfo) error {
+	return h.sdk.FireTaskCompleted(ctx, info)
+}
 func (h *Host) FireMessageUpdate(ctx *Context, info MessageUpdateInfo) error {
 	return h.sdk.FireMessageUpdate(ctx, info)
 }

--- a/engine/internal/extension/sdk_hooks_misc.go
+++ b/engine/internal/extension/sdk_hooks_misc.go
@@ -53,13 +53,15 @@ func (s *SDK) FireWorkspaceFileChanged(ctx *Context, info WorkspaceFileChangedIn
 }
 
 // FireTaskCreated fires the task_created hook.
-func (s *SDK) FireTaskCreated(ctx *Context, info TaskLifecycleInfo) {
+func (s *SDK) FireTaskCreated(ctx *Context, info TaskLifecycleInfo) error {
 	s.fire(HookTaskCreated, ctx, info)
+	return nil
 }
 
 // FireTaskCompleted fires the task_completed hook.
-func (s *SDK) FireTaskCompleted(ctx *Context, info TaskLifecycleInfo) {
+func (s *SDK) FireTaskCompleted(ctx *Context, info TaskLifecycleInfo) error {
 	s.fire(HookTaskCompleted, ctx, info)
+	return nil
 }
 
 // FireElicitationRequest fires the elicitation_request hook.

--- a/engine/internal/session/event_translation.go
+++ b/engine/internal/session/event_translation.go
@@ -384,6 +384,12 @@ func (m *Manager) fireCliTurnHooks(s *engineSession, key string, sOk bool, event
 		if !alreadyActive {
 			ctx := m.newExtContext(s, key)
 			s.extGroup.FireTurnStart(ctx, extension.TurnInfo{TurnNumber: turnNum})
+			taskID := fmt.Sprintf("%s-t%d", key, turnNum)
+			_ = s.extGroup.FireTaskCreated(ctx, extension.TaskLifecycleInfo{
+				TaskID: taskID,
+				Name:   fmt.Sprintf("turn-%d", turnNum),
+				Status: "running",
+			})
 		}
 
 	case *types.ToolCallEvent:
@@ -442,6 +448,17 @@ func (m *Manager) fireCliTurnHooks(s *engineSession, key string, sOk bool, event
 				})
 			}
 			s.extGroup.FireTurnEnd(ctx, extension.TurnInfo{TurnNumber: turnNum})
+		}
+		// task_completed fires unconditionally: the run is fully done whether or
+		// not a turn was active when it finished.
+		{
+			ctx := m.newExtContext(s, key)
+			taskID := fmt.Sprintf("%s-t%d", key, turnNum)
+			_ = s.extGroup.FireTaskCompleted(ctx, extension.TaskLifecycleInfo{
+				TaskID: taskID,
+				Name:   fmt.Sprintf("turn-%d", turnNum),
+				Status: "completed",
+			})
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`FireTaskCreated` and `FireTaskCompleted` were defined in the extension SDK but had no callers in the engine — the hooks never fired for any extension.

This wires them at the natural task lifecycle points in `fireCliTurnHooks` (CliBackend):

- **`task_created`** fires at turn start (alongside `turn_start`), once per new turn activation
- **`task_completed`** fires unconditionally on `TaskCompleteEvent` — the run is fully done whether or not a turn was active when it finished

Changes to thread the callers through the call stack:

| File | Change |
|------|--------|
| `sdk_hooks_misc.go` | `FireTaskCreated`/`FireTaskCompleted` now return `error` (consistent with `FireExtensionRespawned`, `FireTurnAborted`, `FireOnError`, etc.) |
| `hook_dispatch.go` | Host-level wrappers for both methods |
| `group.go` | `ExtensionGroup` wrappers using `fireVoid` (same pattern as `FireToolEnd`, `FireOnError`) |
| `event_translation.go` | Callers in `fireCliTurnHooks` — `task_created` on first `TextChunkEvent`, `task_completed` on `TaskCompleteEvent` |

TaskID format: `<session-key>-t<turn-number>`, which correlates with the `TurnInfo.TurnNumber` emitted by the adjacent `turn_start`/`turn_end` hooks.

## Test plan

- [ ] `go test -race ./internal/extension/... ./internal/session/...` passes
- [ ] `go build ./...` passes
- [ ] Send a prompt through an extension; confirm `task_created` fires before the first `turn_start` and `task_completed` fires after the final `turn_end`