### PR TITLE
Engine fix, desktop running state & dialog fix, iOS parity, cross-platform docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,34 @@ Engine executes, harness decides. Engine never blocks for user input, never pers
 
 When labeling work: engine, harness, or client. If a harness gap is caused by missing engine capability, note both.
 
+## Cross-platform parity (desktop ↔ iOS)
+
+Desktop and iOS are co-equal clients. When a desktop change touches a feature that also exists on iOS, **you must assess the iOS impact before considering the work complete.**
+
+### Checklist for every desktop UI/state change
+
+1. **Does this feature exist on iOS?** Check `ios/IonRemote/Views/` and `ios/IonRemote/ViewModels/` for the iOS counterpart.
+2. **If yes:** update the iOS side in the same PR, or document why it's deferred.
+3. **If the feature can't translate to iOS** (no physical space, no interaction model): document the trade-off. Consider an alternate iOS-appropriate rendering before deciding to skip.
+4. **If state flows through the snapshot** (`desktop/src/main/remote/snapshot.ts`): check whether the snapshot projection needs updating. The snapshot is the bridge — iOS can only see what the snapshot sends.
+
+### Common parity surfaces
+
+| Desktop | iOS counterpart | Sync path |
+|---------|----------------|-----------|
+| Tab status dot (TabStripTabPill, StatusDot) | Tab list dot (TabRowView.statusInfo) | `snapshot.ts` → `RemoteTabState.status` |
+| Engine instance bar (EngineStatusBar) | Engine instance bar (EngineInstanceBar) | `snapshot.ts` → `RemoteTabState.engineInstances` |
+| Permission denials / waiting state | Permission queue / waiting state | `snapshot.ts` promotes denials into `permissionQueue`; per-instance `waitingState` on `engineInstances` |
+| Tab group pills | Tab group sections | `snapshot.ts` → group fields on `RemoteTabState` |
+| Thinking indicator / interrupt button | Activity indicator / interrupt button | Real-time events (`engineTextDelta`, `tabStatus`) |
+
+### When to skip iOS
+
+Only when the interface physically cannot work on iOS (e.g. a keyboard-only interaction, a desktop window management feature, or a rendering surface that doesn't exist on mobile). In that case:
+- Note in the PR description why iOS was skipped.
+- Consider whether an alternate mobile-appropriate rendering exists.
+- At minimum, ensure the iOS app doesn't break or show stale data because of the desktop change.
+
 ## Contract stability (never break the client)
 
 The client is the consumer of the Ion engine — desktop, iOS, and harness extensions all depend on published contracts. **Never ship a breaking change to a published contract.**

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -61,6 +61,12 @@ desktop/src/
 - Framer Motion for animations.
 - Narrow Zustand selectors with custom equality functions; avoid whole-store subscriptions.
 
+## PopoverLayer and pointer events
+
+The `PopoverLayer` has `pointerEvents: 'none'` so it doesn't block interaction with the page beneath it. Any element portaled into it (context menus, dialogs, tooltips) must set `pointerEvents: 'auto'` on its outermost interactive container or clicks will silently pass through.
+
+Context-menu components already do this on their `motion.div`. The `ConfirmDialog` component sets it on its backdrop. If you create a new overlay component that portals into `PopoverLayer`, add `pointerEvents: 'auto'` to its root — without it the component will render but be completely non-interactable with no visible error.
+
 ## Subprocess env
 
 - `CLAUDECODE` and similar leakage env vars are stripped before spawn (`main/cli-env.ts`). Don't bypass.

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -129,3 +129,4 @@ If a Go struct gained a field you don't have, the test says `"Go-only: [fieldNam
 3. `make check-file-sizes` passes.
 4. UI changes: smoke-tested in `npm run dev`. Report what was tested.
 5. Don't `git push`.
+6. **iOS parity check.** If the change affects a feature that exists on iOS (tab status, engine instances, permissions, working state), verify the iOS side is updated or document why it's deferred. See root `AGENTS.md` § "Cross-platform parity".

--- a/desktop/src/main/app-lifecycle.ts
+++ b/desktop/src/main/app-lifecycle.ts
@@ -14,6 +14,25 @@ function log(msg: string): void {
   _log('main', msg)
 }
 
+/**
+ * Force the renderer to flush any pending debounced tab persistence.
+ * The Zustand store debounces persistTabs() at 100ms — if we call
+ * app.exit(0) before the timer fires, the latest tab state (including
+ * conversationId, titles, etc.) is lost. This mirrors the pattern used
+ * by SWITCH_BACKEND in ipc/settings.ts.
+ */
+async function flushRendererTabs(): Promise<void> {
+  for (const win of BrowserWindow.getAllWindows()) {
+    try {
+      await win.webContents.executeJavaScript(
+        'window.__ionForceFlushTabs && window.__ionForceFlushTabs()',
+      )
+    } catch {
+      // Window may already be destroyed or renderer unresponsive — safe to skip.
+    }
+  }
+}
+
 export function setupAppLifecycle(): void {
   app.whenReady().then(async () => {
     if (process.platform === 'darwin' && app.dock) {
@@ -125,8 +144,9 @@ export function setupAppLifecycle(): void {
 
   process.on('SIGUSR1', () => {
     log('SIGUSR1 received — draining active work before quit')
-    const timeout = setTimeout(() => {
+    const timeout = setTimeout(async () => {
       log('Drain timeout (5min) — force quitting')
+      await flushRendererTabs()
       state.forceQuit = true
       terminalManager.destroyAll()
       engineBridge.stopAll()
@@ -138,9 +158,10 @@ export function setupAppLifecycle(): void {
       app.exit(0)
     }, 5 * 60 * 1000)
 
-    sessionPlane.drain(() => bashProcesses.size > 0).then(() => {
+    sessionPlane.drain(() => bashProcesses.size > 0).then(async () => {
       clearTimeout(timeout)
       log('All agents finished — quitting')
+      await flushRendererTabs()
       state.forceQuit = true
       terminalManager.destroyAll()
       engineBridge.stopAll()

--- a/desktop/src/main/remote/protocol.ts
+++ b/desktop/src/main/remote/protocol.ts
@@ -26,7 +26,7 @@ export interface RemoteTabState {
   isTerminalOnly?: boolean
   isEngine?: boolean
   engineProfileId?: string | null
-  engineInstances?: Array<{ id: string; label: string; waitingState?: 'plan-ready' | 'question' | null }>
+  engineInstances?: Array<{ id: string; label: string; waitingState?: 'plan-ready' | 'question' | null; isRunning?: boolean }>
   activeEngineInstanceId?: string | null
   terminalInstances?: TerminalInstanceInfo[]
   activeTerminalInstanceId?: string | null

--- a/desktop/src/main/remote/snapshot.ts
+++ b/desktop/src/main/remote/snapshot.ts
@@ -128,15 +128,36 @@ export async function getRemoteTabStates(): Promise<RemoteTabState[]> {
                     if (ws === null && hasPlanReady) ws = 'plan-ready';
                   }
                 }
-                return { id: inst.id, label: inst.label, waitingState: ws };
+                // Per-instance running state so iOS EngineInstanceBar can
+                // show a pulsing dot on each running sub-tab. Parallels the
+                // waitingState derivation above.
+                var instRunning = false;
+                if (s.engineStatusFields && s.engineStatusFields.get) {
+                  var sf = s.engineStatusFields.get(t.id + ':' + inst.id);
+                  if (sf) {
+                    var st = sf.state;
+                    instRunning = st === 'running' || st === 'connecting' || st === 'starting';
+                  }
+                }
+                return { id: inst.id, label: inst.label, waitingState: ws, isRunning: instRunning || undefined };
               });
               activeEngineInstanceId = ePaneForList.activeInstanceId || ePaneForList.instances[0].id;
+            }
+            // Aggregate running state across all engine instances so the
+            // iOS tab-list dot pulses when ANY instance is running, even
+            // if the active instance is idle. Parallels the desktop's
+            // isAnyEngineInstanceRunning helper in TabStripShared.ts.
+            var anyInstanceRunning = false;
+            if (engineInstances) {
+              for (var ei = 0; ei < engineInstances.length; ei++) {
+                if (engineInstances[ei].isRunning) { anyInstanceRunning = true; break; }
+              }
             }
             return {
               id: t.id,
               title: t.title,
               customTitle: t.customTitle,
-              status: t.status,
+              status: (t.isEngine && anyInstanceRunning && t.status !== 'running' && t.status !== 'connecting') ? 'running' : t.status,
               workingDirectory: t.workingDirectory,
               permissionMode: t.permissionMode,
               permissionQueue: queue,

--- a/desktop/src/main/window-manager.ts
+++ b/desktop/src/main/window-manager.ts
@@ -178,16 +178,30 @@ export function createWindow(): void {
       detail: 'Tip: Press ⌥Space to hide/show the app without quitting.',
     })
     if (choice === 0) {
-      state.forceQuit = true
-      terminalManager.destroyAll()
-      sessionPlane.shutdown()
-      globalShortcut.unregisterAll()
-      if (state.tray) {
-        state.tray.destroy()
-        state.tray = null
-      }
-      flushLogs()
-      app.exit(0)
+      // Flush renderer tab state before exiting — the Zustand store debounces
+      // persistTabs() at 100ms and app.exit(0) kills the renderer immediately,
+      // so any pending state (conversationId, titles, etc.) would be lost.
+      void (async () => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          try {
+            await win.webContents.executeJavaScript(
+              'window.__ionForceFlushTabs && window.__ionForceFlushTabs()',
+            )
+          } catch {
+            // Window may already be destroyed or renderer unresponsive.
+          }
+        }
+        state.forceQuit = true
+        terminalManager.destroyAll()
+        sessionPlane.shutdown()
+        globalShortcut.unregisterAll()
+        if (state.tray) {
+          state.tray.destroy()
+          state.tray = null
+        }
+        flushLogs()
+        app.exit(0)
+      })()
     }
   })
   mainWindow.on('close', (e) => {

--- a/desktop/src/renderer/components/TabStripInactiveGroupMenu.tsx
+++ b/desktop/src/renderer/components/TabStripInactiveGroupMenu.tsx
@@ -40,11 +40,13 @@ export function InactiveGroupMenu({
   const [newGroupName, setNewGroupName] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const [pendingMoveAll, setPendingMoveAll] = useState<{ groupId: string; label: string } | null>(null)
+  const confirmDialogRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node) &&
-          (!submenuRef.current || !submenuRef.current.contains(e.target as Node))) { setMoveSubmenu(null); onClose() }
+          (!submenuRef.current || !submenuRef.current.contains(e.target as Node)) &&
+          (!confirmDialogRef.current || !confirmDialogRef.current.contains(e.target as Node))) { setMoveSubmenu(null); onClose() }
     }
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') { setMoveSubmenu(null); onClose() }
@@ -159,6 +161,7 @@ export function InactiveGroupMenu({
       )}
       </motion.div>
       {pendingMoveAll && (
+        <div ref={confirmDialogRef}>
         <ConfirmDialog
           title="Move all tabs?"
           message={`Move all ${group.tabs.length} tab${group.tabs.length !== 1 ? 's' : ''} to "${pendingMoveAll.label}"? This will move every tab in the current group.`}
@@ -177,6 +180,7 @@ export function InactiveGroupMenu({
             onClose()
           }}
         />
+        </div>
       )}
     </>,
     popoverLayer,

--- a/desktop/src/renderer/components/TabStripShared.ts
+++ b/desktop/src/renderer/components/TabStripShared.ts
@@ -336,6 +336,28 @@ export function getEngineInstanceWaitingState(key: string): WaitingState {
   return waitingStateFromTools(entry?.tools)
 }
 
+/**
+ * Check whether any engine instance under a tab is currently running.
+ * Folds across `enginePanes` instances and reads per-instance state
+ * from `engineStatusFields` — parallel to how `getWaitingState` folds
+ * across `enginePermissionDenied` for denial aggregation.
+ *
+ * NOTE: This reads from `useSessionStore.getState()` — it is not
+ * reactive on its own. Callers in React components must separately
+ * subscribe to `engineStatusFields` (or a projection of it) so the
+ * component re-renders when instance states change.
+ */
+export function isAnyEngineInstanceRunning(tabId: string): boolean {
+  const s = useSessionStore.getState()
+  const pane = s.enginePanes.get(tabId)
+  if (!pane || pane.instances.length === 0) return false
+  for (const inst of pane.instances) {
+    const state = s.engineStatusFields.get(`${tabId}:${inst.id}`)?.state
+    if (state === 'running' || state === 'connecting' || state === 'starting') return true
+  }
+  return false
+}
+
 /** Status-dot color/pulse/glow derived from a tab's runtime state. Used by both single dots and stacked group dots. */
 export function getTabStatusColor(
   tab: TabState,
@@ -356,7 +378,7 @@ export function getTabStatusColor(
     bg = colors.statusComplete; glow = true; glowColor = colors.tabGlowPlanReady
   } else if (waitingState === 'question') {
     bg = colors.infoText; glow = true; glowColor = colors.tabGlowQuestion
-  } else if (tab.status === 'connecting' || tab.status === 'running') {
+  } else if (tab.status === 'connecting' || tab.status === 'running' || (tab.isEngine && isAnyEngineInstanceRunning(tab.id))) {
     bg = colors.statusRunning; pulse = true
   } else if (tab.bashExecuting) {
     bg = colors.statusBash; pulse = true; glow = true; glowColor = colors.statusBashGlow

--- a/desktop/src/renderer/components/TabStripTabContextMenu.tsx
+++ b/desktop/src/renderer/components/TabStripTabContextMenu.tsx
@@ -71,6 +71,7 @@ export function TabContextMenu({
   const [newGroupName, setNewGroupName] = useState('')
   const newGroupInputRef = useRef<HTMLInputElement>(null)
   const [pendingMoveAll, setPendingMoveAll] = useState<{ groupId: string; label: string } | null>(null)
+  const confirmDialogRef = useRef<HTMLDivElement>(null)
 
   const showMoveAll = groupTabs && groupTabs.length > 1
   const [isGitRepo, setIsGitRepo] = useState(false)
@@ -90,7 +91,8 @@ export function TabContextMenu({
       if (ref.current && !ref.current.contains(e.target as Node) &&
           (!submenuRef.current || !submenuRef.current.contains(e.target as Node)) &&
           (!movePinSubmenuRef.current || !movePinSubmenuRef.current.contains(e.target as Node)) &&
-          (!moveAllSubmenuRef.current || !moveAllSubmenuRef.current.contains(e.target as Node))) { setMoveSubmenu(null); setMovePinSubmenu(null); setMoveAllSubmenu(null); onClose() }
+          (!moveAllSubmenuRef.current || !moveAllSubmenuRef.current.contains(e.target as Node)) &&
+          (!confirmDialogRef.current || !confirmDialogRef.current.contains(e.target as Node))) { setMoveSubmenu(null); setMovePinSubmenu(null); setMoveAllSubmenu(null); onClose() }
     }
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') { setMoveSubmenu(null); setMovePinSubmenu(null); setMoveAllSubmenu(null); onClose() }
@@ -398,6 +400,7 @@ export function TabContextMenu({
       )}
     </motion.div>
     {pendingMoveAll && groupTabs && (
+      <div ref={confirmDialogRef}>
       <ConfirmDialog
         title="Move all tabs?"
         message={`Move all ${groupTabs.length} tab${groupTabs.length !== 1 ? 's' : ''} to "${pendingMoveAll.label}"? This will move every tab in the current group.`}
@@ -416,6 +419,7 @@ export function TabContextMenu({
           onClose()
         }}
       />
+      </div>
     )}
     </>,
     popoverLayer,

--- a/desktop/src/renderer/components/TabStripTabPill.tsx
+++ b/desktop/src/renderer/components/TabStripTabPill.tsx
@@ -2,8 +2,9 @@ import React, { useCallback } from 'react'
 import { X, GitBranch, GitFork, FolderSimple, PushPin } from '@phosphor-icons/react'
 import { useColors } from '../theme'
 import { usePreferencesStore } from '../preferences'
+import { useSessionStore } from '../stores/sessionStore'
 import type { TabState } from '../../shared/types'
-import { getWaitingState, formatRelativeShort } from './TabStripShared'
+import { getWaitingState, isAnyEngineInstanceRunning, formatRelativeShort } from './TabStripShared'
 import { StatusDot } from './TabStripStatusDot'
 import { InlineRenameInput } from './TabStripInlineRenameInput'
 
@@ -56,8 +57,19 @@ export function TabPill({
   const gitOpsMode = usePreferencesStore((s) => s.gitOpsMode)
   const tabGroupMode = usePreferencesStore((s) => s.tabGroupMode)
 
+  // Subscribe to engineStatusFields so this component re-renders when
+  // any engine instance's state changes (e.g. running → idle). Without
+  // this, isAnyEngineInstanceRunning reads stale getState() data. Only
+  // engine tabs need this subscription — CLI tabs never touch the map.
+  useSessionStore((s) => tab.isEngine ? s.engineStatusFields : null)
+
   const isRunning = tab.status === 'running' || tab.status === 'connecting'
   const displayTitle = tab.customTitle || tab.title
+
+  // For engine tabs, check if any sub-tab instance is running so the
+  // main tab pill pulses even when the active instance is idle.
+  const anyInstanceRunning = tab.isEngine && isAnyEngineInstanceRunning(tab.id)
+  const effectiveStatus = (anyInstanceRunning && !isRunning) ? 'running' as const : tab.status
 
   // Derive waiting-for-user state from permission denials
   const waitingState = getWaitingState(tab)
@@ -117,7 +129,7 @@ export function TabPill({
           onOpenColorPicker(tab.id, { x: e.clientX, y: e.clientY })
         }}
       >
-        <StatusDot status={tab.status} hasUnread={tab.hasUnread} hasPermission={tab.permissionQueue.length > 0} bashExecuting={tab.bashExecuting} waitingState={waitingState} pillIcon={tab.pillIcon} />
+        <StatusDot status={effectiveStatus} hasUnread={tab.hasUnread} hasPermission={tab.permissionQueue.length > 0} bashExecuting={tab.bashExecuting} waitingState={waitingState} pillIcon={tab.pillIcon} />
       </span>
       {tab.groupPinned && tabGroupMode === 'manual' && (
         <PushPin size={10} color={colors.textTertiary} className="flex-shrink-0" style={{ opacity: 0.7 }} />

--- a/desktop/src/renderer/components/git/ConfirmDialog.tsx
+++ b/desktop/src/renderer/components/git/ConfirmDialog.tsx
@@ -42,6 +42,7 @@ export function ConfirmDialog({
         justifyContent: 'center',
         background: 'rgba(0,0,0,0.4)',
         zIndex: 10000,
+        pointerEvents: 'auto',
       }}
       onClick={onCancel}
     >

--- a/desktop/src/renderer/hooks/useTabRestoration-engine.ts
+++ b/desktop/src/renderer/hooks/useTabRestoration-engine.ts
@@ -244,6 +244,16 @@ export function restoreEngineTab(st: PersistedTab, restoredTabIds: Array<{ tabId
           extensions: profile.extensions,
           workingDirectory: st.workingDirectory,
           ...(instSessionId ? { sessionId: instSessionId } : {}),
+        }).then(() => {
+          // Sync plan mode to the engine after the session exists.
+          // The engine creates fresh sessions with planMode=false;
+          // without this, a restored plan-mode tab loses its engine
+          // plan mode state until the next submitEnginePrompt fires
+          // the belt-and-suspenders sync.
+          if (st.permissionMode === 'plan') {
+            console.log(`[restore] syncing plan mode to engine for ${key}`)
+            window.ion.engineSetPlanMode(key, true)
+          }
         }).catch((err: { message?: string }) => {
           console.error(`[restore] engine start failed for ${key}: ${err.message}`)
         })

--- a/desktop/src/renderer/stores/session-store-persistence.ts
+++ b/desktop/src/renderer/stores/session-store-persistence.ts
@@ -238,7 +238,22 @@ export function setupPersistence(useSessionStore: Store): void {
           return p && t.id === p.id && t.permissionDenied !== p.permissionDenied
         })) ||
         state.enginePermissionDenied !== prev.enginePermissionDenied
-      if (permissionDeniedChanged) {
+
+      // Flush immediately when a CLI tab captures its first conversationId.
+      // The engine event slice already does this for engine tabs via
+      // __ionForceFlushTabs (engine-event-slice.ts:126–142). For CLI tabs,
+      // session_init sets conversationId inside the Zustand reducer
+      // (event-slice.ts), and the normal 100ms debounce creates a window
+      // where a hard kill (SIGUSR1 drain → app.exit, laptop lid close)
+      // drops the session ID — making the tab irrecoverable on restart
+      // (conversationId: null → sessionless blank tab path).
+      const conversationIdCaptured =
+        state.tabs !== prev.tabs && state.tabs.some((t, i) => {
+          const p = prev.tabs[i]
+          return p && t.id === p.id && !p.conversationId && !!t.conversationId
+        })
+
+      if (permissionDeniedChanged || conversationIdCaptured) {
         if (saveTimer) { clearTimeout(saveTimer); saveTimer = null }
         persistTabs(useSessionStore)
         return

--- a/desktop/src/renderer/stores/slices/engine-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-slice.ts
@@ -173,7 +173,71 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       const pane = panes.get(tabId)
       if (!pane) return
       panes.set(tabId, { ...pane, activeInstanceId: instanceId })
-      set({ enginePanes: panes })
+
+      // Reconcile tab.status from the newly-active instance's known
+      // state so the thinking indicator, interrupt button, and status
+      // bar correctly reflect the selected sub-tab. Without this, the
+      // tab status stays frozen at whatever the *previous* instance
+      // last set — e.g. stuck 'running' after switching to an idle
+      // instance.
+      const key = `${tabId}:${instanceId}`
+      const statusFields = get().engineStatusFields.get(key)
+      const instanceState = statusFields?.state
+      const denial = get().enginePermissionDenied.get(key)
+
+      // Also sync conversationId so the status bar footer shows the
+      // correct conversation for the newly-active instance.
+      const convChain = get().engineConversationIds.get(key)
+      const lastConvId = convChain?.[convChain.length - 1]
+
+      if (instanceState) {
+        // Map instance state to tab.status — mirrors the logic in
+        // engine-event-status.ts:167-181.
+        let newStatus: TabStatus
+        if (instanceState === 'running' || instanceState === 'connecting' || instanceState === 'starting') {
+          newStatus = 'running'
+        } else if (instanceState === 'idle') {
+          // Check for "interesting" denials (AskUserQuestion / ExitPlanMode)
+          const hasInterestingDenials = denial?.tools?.some(
+            (t) => t.toolName === 'AskUserQuestion' || t.toolName === 'ExitPlanMode',
+          ) ?? false
+          newStatus = hasInterestingDenials ? 'completed' : 'idle'
+        } else {
+          newStatus = 'idle'
+        }
+
+        console.log(`[selectEngineInstance] tab=${tabId.slice(0, 8)} instance=${instanceId} reconciledStatus=${newStatus}`)
+
+        set((state) => ({
+          enginePanes: panes,
+          tabs: state.tabs.map((t) => {
+            if (t.id !== tabId) return t
+            const updates: Partial<typeof t> = { status: newStatus }
+            if (lastConvId && t.conversationId !== lastConvId) {
+              updates.conversationId = lastConvId
+              updates.lastKnownSessionId = lastConvId
+            }
+            return { ...t, ...updates }
+          }),
+        }))
+      } else {
+        // No status entry yet (instance just created, no events
+        // received) — update panes and conversationId only, leave
+        // tab.status unchanged.
+        console.log(`[selectEngineInstance] tab=${tabId.slice(0, 8)} instance=${instanceId} noStatusEntry, panes only`)
+        if (lastConvId) {
+          set((state) => ({
+            enginePanes: panes,
+            tabs: state.tabs.map((t) => {
+              if (t.id !== tabId) return t
+              if (t.conversationId === lastConvId) return { ...t }
+              return { ...t, conversationId: lastConvId, lastKnownSessionId: lastConvId }
+            }),
+          }))
+        } else {
+          set({ enginePanes: panes })
+        }
+      }
     },
 
     renameEngineInstance: (tabId, instanceId, label) => {

--- a/engine/internal/backend/runloop_tools.go
+++ b/engine/internal/backend/runloop_tools.go
@@ -254,11 +254,19 @@ func (b *ApiBackend) executeTools(
 				}
 			}
 
-			// Intercept ExitPlanMode sentinel — only during plan-mode runs.
-			// In auto mode the LLM may hallucinate this call from conversation
-			// history; let it fall through to "Unknown tool" so it self-corrects.
-			if run.planMode && block.Name == tools.ExitPlanModeName {
-				utils.Info("PlanMode", fmt.Sprintf("run=%s exit_tool plan_file=%s", run.requestID, run.planFilePath))
+			// Intercept ExitPlanMode sentinel — in any mode. When
+			// run.planMode is true, this is the normal plan-mode exit
+			// flow. When run.planMode is false, the model is following
+			// prompt-level plan mode instructions (e.g. from AGENTS.md
+			// context) rather than the engine's plan mode machinery.
+			// Either way, intercept the call so the model never sees an
+			// "Unknown tool" / "not found" error for ExitPlanMode.
+			if block.Name == tools.ExitPlanModeName {
+				if !run.planMode {
+					utils.Warn("PlanMode", fmt.Sprintf("run=%s exit_tool called outside engine plan mode (prompt-level plan mode detected) plan_file=%s", run.requestID, run.planFilePath))
+				} else {
+					utils.Info("PlanMode", fmt.Sprintf("run=%s exit_tool plan_file=%s", run.requestID, run.planFilePath))
+				}
 
 				// Fire before_plan_mode_exit hook so extensions can veto.
 				exitAllowed := true

--- a/engine/internal/backend/runloop_tools_plan_gate_test.go
+++ b/engine/internal/backend/runloop_tools_plan_gate_test.go
@@ -250,9 +250,9 @@ func TestPlanGate_ExitPlanModeIntercepted(t *testing.T) {
 	}
 }
 
-// Test 9: ExitPlanMode in auto mode falls through to unknown tool
-func TestPlanGate_ExitPlanModeAutoModeFallthrough(t *testing.T) {
-	b, run, _ := planGateHelper(t, false, "")
+// Test 9: ExitPlanMode in auto mode is still intercepted (prompt-level plan mode)
+func TestPlanGate_ExitPlanModeAutoModeIntercepted(t *testing.T) {
+	b, run, emitted := planGateHelper(t, false, "")
 
 	blocks := []types.LlmContentBlock{{
 		Name:  tools.ExitPlanModeName,
@@ -263,12 +263,34 @@ func TestPlanGate_ExitPlanModeAutoModeFallthrough(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// In auto mode, ExitPlanMode is not intercepted — it falls through
-	// to the "Unknown tool" handler.
-	if !results[0].IsError {
-		t.Error("expected ExitPlanMode in auto mode to produce an error (unknown tool)")
+	// ExitPlanMode is now intercepted even in auto mode — the model may be
+	// following prompt-level plan mode instructions (e.g. from AGENTS.md).
+	// It should NOT produce an "Unknown tool" error.
+	if results[0].IsError {
+		t.Errorf("expected ExitPlanMode in auto mode to succeed (intercepted), got error: %s", results[0].Content)
 	}
-	if !strings.Contains(results[0].Content, "Unknown tool") {
-		t.Errorf("expected 'Unknown tool' error, got: %s", results[0].Content)
+	if !strings.Contains(results[0].Content, "Plan mode exited") {
+		t.Errorf("expected 'Plan mode exited' result, got: %s", results[0].Content)
+	}
+	// The run should be flagged for exit, just like in plan mode.
+	run.mu.Lock()
+	exited := run.exitPlanMode
+	denials := len(run.permissionDenials)
+	run.mu.Unlock()
+	if !exited {
+		t.Error("expected ExitPlanMode in auto mode to set run.exitPlanMode = true")
+	}
+	if denials != 1 {
+		t.Errorf("expected 1 permission denial, got %d", denials)
+	}
+	// Verify a PlanProposalEvent was emitted.
+	foundProposal := false
+	for _, ev := range *emitted {
+		if pp, ok := ev.Data.(*types.PlanProposalEvent); ok && pp.Kind == "exit" {
+			foundProposal = true
+		}
+	}
+	if !foundProposal {
+		t.Error("expected a PlanProposalEvent{Kind:exit} to be emitted")
 	}
 }

--- a/ios/IonRemote/Models/RemoteTabState.swift
+++ b/ios/IonRemote/Models/RemoteTabState.swift
@@ -57,6 +57,13 @@ struct EngineInstanceInfo: Codable, Identifiable, Sendable {
     /// through `permissionQueue` on the enclosing `RemoteTabState` (the
     /// desktop promotes the active instance's denial into that queue).
     var waitingState: String? = nil
+    /// Per-engine-instance running state, decoded from the desktop snapshot.
+    /// `true` when the instance's engine state is `running`, `connecting`,
+    /// or `starting`. `EngineInstanceBar` renders a pulsing orange dot when
+    /// this is true and no `waitingState` is set. The parent tab's overall
+    /// status is aggregated by the snapshot — if any instance is running,
+    /// `RemoteTabState.status` is promoted to `.running`.
+    var isRunning: Bool? = nil
 }
 
 // MARK: - PermissionMode

--- a/ios/IonRemote/Views/EngineInstanceBar.swift
+++ b/ios/IonRemote/Views/EngineInstanceBar.swift
@@ -49,16 +49,19 @@ struct EngineInstanceBar: View {
             viewModel.selectEngineInstance(tabId: tabId, instanceId: instance.id)
         } label: {
             HStack(spacing: 4) {
-                // Per-instance waiting-state dot. Desktop maps the value
-                // to "question" (AskUserQuestion pending) or "plan-ready"
-                // (ExitPlanMode pending) per the snapshot contract. Color
-                // and semantic priority mirror the desktop palette
-                // (yellow/orange for question, green for plan-ready).
-                // When nil, no dot is shown.
+                // Per-instance status dot. Priority:
+                // 1. waitingState (question → blue, plan-ready → green)
+                //    Colors match TabRowView.statusInfo and desktop
+                //    EngineStatusBar palette: blue (#4A9EF5) for question,
+                //    green for plan-ready.
+                // 2. isRunning → pulsing orange (matches tab-list running dot)
+                // 3. Neither → no dot shown
                 if let ws = instance.waitingState {
                     Circle()
-                        .fill(ws == "question" ? Color.orange : Color.green)
+                        .fill(ws == "question" ? Color(hex: 0x4A9EF5) : Color.green)
                         .frame(width: 6, height: 6)
+                } else if instance.isRunning == true {
+                    InstancePulsingDot()
                 }
                 Image(systemName: "bolt")
                     .font(.caption2)
@@ -111,5 +114,25 @@ struct EngineInstanceBar: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - InstancePulsingDot
+
+/// Small pulsing orange dot for running engine instances. Matches the
+/// pulse animation from `TabRowView` (1.5s easeInOut, opacity 1→0.3).
+private struct InstancePulsingDot: View {
+    @State private var pulseOpacity: Double = 1.0
+
+    var body: some View {
+        Circle()
+            .fill(IonTheme.statusRunning)
+            .frame(width: 6, height: 6)
+            .opacity(pulseOpacity)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                    pulseOpacity = 0.3
+                }
+            }
     }
 }


### PR DESCRIPTION
## Summary

A mixed batch: adds "running" state to engine instances on both desktop and iOS, fixes two desktop UI bugs (confirm dialog interaction and tab state flush on exit), fixes engine plan mode interception, and documents cross-platform parity guidelines.

## Changes

- **engine:** intercept exit plan mode in all modes, not just the expected one
- **desktop:** add running state to engine instances with snapshot projection
- **desktop:** fix ConfirmDialog not being interactable due to pointerEvents inheritance and mousedown outside-click handler dismissing it prematurely
- **desktop:** flush tab state before app exit to prevent stale state on relaunch
- **ios:** add running state to engine instances (parity with desktop)
- **docs:** add cross-platform parity guidelines to AGENTS.md