### PR TITLE
Wire plan mode through dispatch agents and desktop engine tabs

### DIFF
--- a/desktop/src/main/ipc/engine.ts
+++ b/desktop/src/main/ipc/engine.ts
@@ -16,8 +16,8 @@ export function registerEngineIpc(): void {
     return engineBridge.startSession(key, config)
   })
 
-  ipcMain.handle(IPC.ENGINE_PROMPT, async (_event, { key, text, model, appendSystemPrompt, imageAttachments, rawAttachments }: { key: string; text: string; model?: string; appendSystemPrompt?: string; imageAttachments?: import('../../shared/types').ImageAttachmentPayload[]; rawAttachments?: import('../../shared/types-session').FileAttachment[] }) => {
-    log(`IPC ENGINE_PROMPT: key=${key} model=${model ?? 'default'} hasSysPrompt=${!!appendSystemPrompt} images=${imageAttachments?.length ?? 0} rawAttachments=${rawAttachments?.length ?? 0}`)
+  ipcMain.handle(IPC.ENGINE_PROMPT, async (_event, { key, text, model, appendSystemPrompt, imageAttachments, rawAttachments, implementationPhase }: { key: string; text: string; model?: string; appendSystemPrompt?: string; imageAttachments?: import('../../shared/types').ImageAttachmentPayload[]; rawAttachments?: import('../../shared/types-session').FileAttachment[]; implementationPhase?: boolean }) => {
+    log(`IPC ENGINE_PROMPT: key=${key} model=${model ?? 'default'} hasSysPrompt=${!!appendSystemPrompt} images=${imageAttachments?.length ?? 0} rawAttachments=${rawAttachments?.length ?? 0} implementationPhase=${implementationPhase ?? false}`)
     // Encode raw file attachments when present (desktop InputBar path).
     // This mirrors the remote handler pattern at handlers/engine.ts:108-114.
     let resolvedText = text
@@ -74,6 +74,7 @@ export function registerEngineIpc(): void {
         appendSystemPrompt,
         model,
         imageAttachments: resolvedImageAttachments,
+        implementationPhase,
         planFilePath,
       })
       return { ok: true }

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -136,7 +136,7 @@ export interface IonAPI {
 
   // ─── Engine operations ───
   engineStart(key: string, config: EngineConfig): Promise<{ ok: boolean; error?: string }>
-  enginePrompt(key: string, text: string, model?: string, appendSystemPrompt?: string, imageAttachments?: ImageAttachmentPayload[], rawAttachments?: FileAttachment[]): Promise<{ ok: boolean; error?: string }>
+  enginePrompt(key: string, text: string, model?: string, appendSystemPrompt?: string, imageAttachments?: ImageAttachmentPayload[], rawAttachments?: FileAttachment[], implementationPhase?: boolean): Promise<{ ok: boolean; error?: string }>
   engineSetPlanMode(key: string, enabled: boolean): void
   engineAbort(key: string): Promise<void>
   engineAbortAgent(key: string, agentName: string, subtree: boolean): Promise<void>
@@ -360,7 +360,7 @@ const api: IonAPI = {
 
   // ─── Engine operations ───
   engineStart: (key, config) => ipcRenderer.invoke(IPC.ENGINE_START, { key, config }),
-  enginePrompt: (key, text, model, appendSystemPrompt, imageAttachments, rawAttachments) => ipcRenderer.invoke(IPC.ENGINE_PROMPT, { key, text, model, appendSystemPrompt, imageAttachments, rawAttachments }),
+  enginePrompt: (key, text, model, appendSystemPrompt, imageAttachments, rawAttachments, implementationPhase) => ipcRenderer.invoke(IPC.ENGINE_PROMPT, { key, text, model, appendSystemPrompt, imageAttachments, rawAttachments, implementationPhase }),
   engineSetPlanMode: (key, enabled) => ipcRenderer.send('ion:engine-set-plan-mode', key, enabled),
   engineAbort: (key) => ipcRenderer.invoke(IPC.ENGINE_ABORT, { key }),
   engineAbortAgent: (key, agentName, subtree) =>

--- a/desktop/src/renderer/components/EngineView.tsx
+++ b/desktop/src/renderer/components/EngineView.tsx
@@ -267,7 +267,7 @@ export function EngineView({ tabId }: EngineViewProps) {
       ? `Implement the following plan:\n\n${planContent}`
       : 'Implement the plan.'
     console.log(`[EngineView] submitting implement prompt: tab=${tabId.slice(0, 8)} promptLen=${implementPrompt.length}`)
-    submitEnginePrompt(tabId, implementPrompt, undefined, undefined)
+    submitEnginePrompt(tabId, implementPrompt, undefined, undefined, undefined, true)
   }, [tabId, key, clearPermissionDenied, submitEnginePrompt, tabPlanFilePath, permissionDenied])
 
   const handleImplementAndUnpin = useCallback(async () => {

--- a/desktop/src/renderer/stores/session-store-types.ts
+++ b/desktop/src/renderer/stores/session-store-types.ts
@@ -170,7 +170,7 @@ export interface State {
   setWorktreeUncommitted: (tabId: string, hasChanges: boolean) => void
   createEngineTab: (dir?: string, profileId?: string) => string
   handleEngineEvent: (key: string, event: any) => void
-  submitEnginePrompt: (tabId: string, text: string, appendSystemPrompt?: string, imageAttachments?: ImageAttachmentPayload[], rawAttachments?: FileAttachment[]) => void
+  submitEnginePrompt: (tabId: string, text: string, appendSystemPrompt?: string, imageAttachments?: ImageAttachmentPayload[], rawAttachments?: FileAttachment[], implementationPhase?: boolean) => void
   respondEngineDialog: (tabId: string, dialogId: string, value: any) => void
   addEngineInstance: (tabId: string) => string
   removeEngineInstance: (tabId: string, instanceId: string) => void

--- a/desktop/src/renderer/stores/slices/engine-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-slice.ts
@@ -375,9 +375,8 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       // `tabId:instanceId`; the generic setPermissionMode path uses
       // bare tabId which silently misses the engine session.
       const currentTab = get().tabs.find(t => t.id === tabId)
-      if (currentTab?.permissionMode === 'plan') {
-        window.ion.engineSetPlanMode(key, true)
-      }
+      const isPlanMode = currentTab?.permissionMode === 'plan'
+      window.ion.engineSetPlanMode(key, isPlanMode)
       // Build a FileAttachment list from the encoded image attachments so
       // the user-message bubble can render images inline. The path is the
       // only field needed at render time; main-side READ_IMAGE_DATA_URL

--- a/desktop/src/renderer/stores/slices/engine-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-slice.ts
@@ -365,7 +365,7 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       set({ engineModelOverrides: overrides })
     },
 
-    submitEnginePrompt: (tabId, text, appendSystemPrompt, imageAttachments, rawAttachments) => {
+    submitEnginePrompt: (tabId, text, appendSystemPrompt, imageAttachments, rawAttachments, implementationPhase) => {
       const pane = get().enginePanes.get(tabId)
       const instanceId = pane?.activeInstanceId
       if (!instanceId) return
@@ -421,7 +421,7 @@ export function createEngineSlice(set: StoreSet, get: StoreGet): Partial<State> 
       })
       const prefs = usePreferencesStore.getState()
       const modelOverride = get().engineModelOverrides.get(key) || prefs.engineDefaultModel || prefs.preferredModel || undefined
-      window.ion.enginePrompt(key, text, modelOverride, appendSystemPrompt, imageAttachments, rawAttachments).then((result) => {
+      window.ion.enginePrompt(key, text, modelOverride, appendSystemPrompt, imageAttachments, rawAttachments, implementationPhase).then((result) => {
         if (result && !result.ok) {
           set((state) => {
             const messages = new Map(state.engineMessages)

--- a/docs/extensions/json-rpc-protocol.md
+++ b/docs/extensions/json-rpc-protocol.md
@@ -420,7 +420,10 @@ Dispatch an engine-native agent. Creates a child session with optional extension
     "model": "claude-sonnet-4-6",
     "extensionDir": "~/.ion/extensions/my-ext",
     "systemPrompt": "You are a research agent.",
-    "projectPath": "/Users/you/project"
+    "projectPath": "/Users/you/project",
+    "planMode": true,
+    "planFilePath": "/tmp/my-plan.md",
+    "planModeTools": ["Read", "Grep", "Glob"]
   }
 }
 ```
@@ -434,12 +437,14 @@ Dispatch an engine-native agent. Creates a child session with optional extension
   "result": {
     "output": "Found 3 uses of deprecated API...",
     "exitCode": 0,
-    "elapsed": 12.5
+    "elapsed": 12.5,
+    "planFilePath": "/tmp/my-plan.md",
+    "planExited": true
   }
 }
 ```
 
-Only `name` and `task` are required. All other fields are optional.
+Only `name` and `task` are required. All other fields are optional. When `planMode` is true, the child runs in plan mode with a restricted tool set; `planFilePath` and `planModeTools` override the defaults.
 
 ## Event buffering during hooks
 

--- a/docs/extensions/sdk-go.md
+++ b/docs/extensions/sdk-go.md
@@ -398,20 +398,25 @@ type ToolResult struct {
 
 ```go
 type DispatchAgentOpts struct {
-    Name         string `json:"name"`
-    Task         string `json:"task"`
-    Model        string `json:"model,omitempty"`
-    ExtensionDir string `json:"extensionDir,omitempty"`
-    SystemPrompt string `json:"systemPrompt,omitempty"`
-    ProjectPath  string `json:"projectPath,omitempty"`
-    SessionID    string `json:"sessionId,omitempty"`
-    MaxTurns     int    `json:"maxTurns,omitempty"` // cap child loop turns; <=0 means unlimited
+    Name          string   `json:"name"`
+    Task          string   `json:"task"`
+    Model         string   `json:"model,omitempty"`
+    ExtensionDir  string   `json:"extensionDir,omitempty"`
+    SystemPrompt  string   `json:"systemPrompt,omitempty"`
+    ProjectPath   string   `json:"projectPath,omitempty"`
+    SessionID     string   `json:"sessionId,omitempty"`
+    MaxTurns      int      `json:"maxTurns,omitempty"`      // cap child loop turns; <=0 means unlimited
+    PlanMode      bool     `json:"planMode,omitempty"`      // start child in plan mode
+    PlanFilePath  string   `json:"planFilePath,omitempty"`  // override plan file path
+    PlanModeTools []string `json:"planModeTools,omitempty"` // override allowed tools during plan mode
 }
 
 type DispatchAgentResult struct {
-    Output   string  `json:"output"`
-    ExitCode int     `json:"exitCode"`
-    Elapsed  float64 `json:"elapsed"`
+    Output       string  `json:"output"`
+    ExitCode     int     `json:"exitCode"`
+    Elapsed      float64 `json:"elapsed"`
+    PlanFilePath string  `json:"planFilePath,omitempty"` // plan file written by child
+    PlanExited   bool    `json:"planExited,omitempty"`   // true when child called ExitPlanMode
 }
 ```
 

--- a/docs/extensions/sdk-raw.md
+++ b/docs/extensions/sdk-raw.md
@@ -262,6 +262,7 @@ When a background dispatch is active (started with `ext/dispatch_agent` and `bac
 | `dispatch_tool_error` | Tool errored in child | `{name, toolName, toolId, content}` |
 | `dispatch_usage` | Token usage update from child | `{name, inputTokens, outputTokens, cumulativeInputTokens, cumulativeOutputTokens, cumulativeCost}` |
 | `dispatch_text_delta` | Streaming text from child | `{name, delta, accumulated}` |
+| `dispatch_plan_proposal` | Child agent proposed a plan (called ExitPlanMode) | `{name, agentId, planFilePath, planSlug, planRequested}` |
 
 Example incoming notification:
 

--- a/docs/extensions/sdk-typescript.md
+++ b/docs/extensions/sdk-typescript.md
@@ -450,6 +450,9 @@ interface DispatchAgentOpts {
   projectPath?: string      // working directory for the agent
   sessionId?: string        // resume an existing child session
   maxTurns?: number         // cap child agent loop turns (omit or <=0 = unlimited)
+  planMode?: boolean        // start child in plan mode
+  planFilePath?: string     // override plan file path (default: engine allocates one)
+  planModeTools?: string[]  // override allowed tools during plan mode
   background?: boolean      // run async; return stub result immediately
   onComplete?: (result: DispatchAgentResult) => void   // background: success
   onError?: (err: DispatchError) => void               // background: failure
@@ -459,6 +462,7 @@ interface DispatchAgentOpts {
   onToolError?: (info: DispatchToolErrorInfo) => void   // tool errored in child
   onUsage?: (info: DispatchUsageInfo) => void           // token/cost usage update
   onTextDelta?: (info: DispatchTextDeltaInfo) => void   // streaming text chunks from child
+  onPlanProposal?: (info: DispatchPlanProposalInfo) => void  // child proposed a plan
 }
 ```
 
@@ -474,6 +478,8 @@ interface DispatchAgentResult {
   inputTokens: number
   outputTokens: number
   sessionId?: string  // child session ID (for resume)
+  planFilePath?: string  // plan file written by child (when planMode was true)
+  planExited?: boolean   // true when child called ExitPlanMode
 }
 ```
 
@@ -553,6 +559,14 @@ interface DispatchTextDeltaInfo {
   name: string       // agent name
   delta: string      // new text chunk
   accumulated: string // all text so far
+}
+
+interface DispatchPlanProposalInfo {
+  name: string          // agent name
+  agentId: string       // dispatch-generated agent ID
+  planFilePath: string  // absolute path to the plan file
+  planSlug: string      // human-readable slug (basename minus .md)
+  planRequested: boolean // true when caller set planMode=true; false if child self-initiated
 }
 ```
 

--- a/engine/internal/extension/host_rpc.go
+++ b/engine/internal/extension/host_rpc.go
@@ -299,14 +299,10 @@ func (h *Host) handleExtRequest(method string, id int64, raw []byte) {
 					data, _ := json.Marshal(info)
 					h.sendNotification("dispatch_text_delta", data)
 				}
-				req.Params.OnPlanProposal = func(info DispatchPlanProposalInfo) DispatchPlanProposalResult {
+				req.Params.OnPlanProposal = func(info DispatchPlanProposalInfo) {
 					info.Name = agentName
 					data, _ := json.Marshal(info)
 					h.sendNotification("dispatch_plan_proposal", data)
-					// Default: not handled by extension RPC — let the engine
-					// surface it. Extensions that want to intercept must use
-					// the in-process API, not the JSON-RPC bridge.
-					return DispatchPlanProposalResult{Handled: false}
 				}
 
 				// Dispatch in a goroutine; respond immediately with stub.

--- a/engine/internal/extension/host_rpc.go
+++ b/engine/internal/extension/host_rpc.go
@@ -299,6 +299,15 @@ func (h *Host) handleExtRequest(method string, id int64, raw []byte) {
 					data, _ := json.Marshal(info)
 					h.sendNotification("dispatch_text_delta", data)
 				}
+				req.Params.OnPlanProposal = func(info DispatchPlanProposalInfo) DispatchPlanProposalResult {
+					info.Name = agentName
+					data, _ := json.Marshal(info)
+					h.sendNotification("dispatch_plan_proposal", data)
+					// Default: not handled by extension RPC — let the engine
+					// surface it. Extensions that want to intercept must use
+					// the in-process API, not the JSON-RPC bridge.
+					return DispatchPlanProposalResult{Handled: false}
+				}
 
 				// Dispatch in a goroutine; respond immediately with stub.
 				go func() {

--- a/engine/internal/extension/sdk_types.go
+++ b/engine/internal/extension/sdk_types.go
@@ -182,6 +182,24 @@ type DispatchAgentOpts struct {
 	// touching global engine config.
 	MaxTurns int `json:"maxTurns,omitempty"`
 
+	// --- Plan mode ---
+
+	// PlanMode, when true, starts the child session in plan mode. The child
+	// receives a plan-mode-filtered tool set, the plan-mode system prompt,
+	// and the ExitPlanMode sentinel tool. When the child calls ExitPlanMode,
+	// the run terminates with the plan file path in the result.
+	PlanMode bool `json:"planMode,omitempty"`
+
+	// PlanFilePath overrides the plan file path for the child session. When
+	// empty and PlanMode is true, the engine allocates a fresh plan file
+	// with a word-slug name (the default behavior for any plan-mode session).
+	PlanFilePath string `json:"planFilePath,omitempty"`
+
+	// PlanModeTools overrides the set of allowed tools during plan mode for
+	// the child session. When nil/empty and PlanMode is true, the engine
+	// uses the default plan-mode tool set.
+	PlanModeTools []string `json:"planModeTools,omitempty"`
+
 	// OnEvent is called for each engine event emitted by the child session.
 	// Not serialized -- set via the host when dispatching from an extension.
 	OnEvent func(ev types.EngineEvent) `json:"-"`
@@ -225,6 +243,16 @@ type DispatchAgentOpts struct {
 	// OnTextDelta fires when the dispatched agent emits a text chunk,
 	// carrying the delta and accumulated text so far.
 	OnTextDelta func(info DispatchTextDeltaInfo) `json:"-"`
+
+	// --- Plan mode lifecycle callbacks ---
+
+	// OnPlanProposal fires when a dispatched agent calls ExitPlanMode,
+	// proposing a plan for approval. The extension can inspect the plan
+	// and decide whether to handle it (return handled=true to suppress
+	// the default plan card rendering on the parent session) or let the
+	// engine surface it to the client (return handled=false or don't set
+	// the callback).
+	OnPlanProposal func(info DispatchPlanProposalInfo) DispatchPlanProposalResult `json:"-"`
 }
 
 // DispatchAgentResult holds the outcome of a dispatched agent.
@@ -239,6 +267,17 @@ type DispatchAgentResult struct {
 	CacheReadInputTokens     int     `json:"cacheReadInputTokens,omitempty"`
 	CacheCreationInputTokens int     `json:"cacheCreationInputTokens,omitempty"`
 	SessionID                string  `json:"sessionId,omitempty"`
+
+	// PlanFilePath is the absolute path of the plan file written by the
+	// child session. Non-empty only when the child was in plan mode and
+	// wrote a plan (regardless of whether it called ExitPlanMode).
+	PlanFilePath string `json:"planFilePath,omitempty"`
+
+	// PlanExited is true when the child called ExitPlanMode (the run
+	// terminated because the model proposed a plan for approval). When
+	// false and PlanFilePath is non-empty, the child was in plan mode but
+	// finished without proposing (e.g. hit max turns or was recalled).
+	PlanExited bool `json:"planExited,omitempty"`
 }
 
 // DispatchError describes a failed background dispatch.
@@ -306,6 +345,26 @@ type DispatchTextDeltaInfo struct {
 	Name        string `json:"name"`
 	Delta       string `json:"delta"`
 	Accumulated string `json:"accumulated"`
+}
+
+// DispatchPlanProposalInfo carries data for the OnPlanProposal callback.
+type DispatchPlanProposalInfo struct {
+	Name         string `json:"name"`
+	AgentID      string `json:"agentId"`
+	PlanFilePath string `json:"planFilePath"`
+	PlanSlug     string `json:"planSlug"`
+	// PlanRequested is true when the caller explicitly set PlanMode=true
+	// on the dispatch opts. False when the child agent self-initiated
+	// plan mode (called EnterPlanMode without being told to).
+	PlanRequested bool `json:"planRequested"`
+}
+
+// DispatchPlanProposalResult is returned by OnPlanProposal.
+type DispatchPlanProposalResult struct {
+	// Handled, when true, tells the engine not to re-emit the plan
+	// proposal on the parent session's event stream. The extension
+	// owns the UX for this proposal.
+	Handled bool `json:"handled"`
 }
 
 // DiscoverAgentsOpts configures which directories to scan for agent definitions

--- a/engine/internal/extension/sdk_types.go
+++ b/engine/internal/extension/sdk_types.go
@@ -247,12 +247,11 @@ type DispatchAgentOpts struct {
 	// --- Plan mode lifecycle callbacks ---
 
 	// OnPlanProposal fires when a dispatched agent calls ExitPlanMode,
-	// proposing a plan for approval. The extension can inspect the plan
-	// and decide whether to handle it (return handled=true to suppress
-	// the default plan card rendering on the parent session) or let the
-	// engine surface it to the client (return handled=false or don't set
-	// the callback).
-	OnPlanProposal func(info DispatchPlanProposalInfo) DispatchPlanProposalResult `json:"-"`
+	// proposing a plan for approval. This callback is observational — the
+	// plan proposal event is always forwarded to the parent session via
+	// OnEvent regardless of whether this callback is set. Use it to react
+	// to proposals (e.g. log, notify, update state) without suppressing them.
+	OnPlanProposal func(info DispatchPlanProposalInfo) `json:"-"`
 }
 
 // DispatchAgentResult holds the outcome of a dispatched agent.
@@ -357,14 +356,6 @@ type DispatchPlanProposalInfo struct {
 	// on the dispatch opts. False when the child agent self-initiated
 	// plan mode (called EnterPlanMode without being told to).
 	PlanRequested bool `json:"planRequested"`
-}
-
-// DispatchPlanProposalResult is returned by OnPlanProposal.
-type DispatchPlanProposalResult struct {
-	// Handled, when true, tells the engine not to re-emit the plan
-	// proposal on the parent session's event stream. The extension
-	// owns the UX for this proposal.
-	Handled bool `json:"handled"`
 }
 
 // DiscoverAgentsOpts configures which directories to scan for agent definitions

--- a/engine/internal/session/extcontext/dispatch_agent.go
+++ b/engine/internal/session/extcontext/dispatch_agent.go
@@ -176,7 +176,7 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 			}
 
 			// Phase 2: Structured lifecycle callbacks.
-			fireLifecycleCallbacks(&opts, ev, toolNames, &toolCount, &accumulatedText,
+			fireLifecycleCallbacks(&opts, ev, agentID, toolNames, &toolCount, &accumulatedText,
 				&cumulativeInputTokens, &cumulativeOutputTokens, &cumulativeCost)
 
 			// Live progress forwarding for the agent panel.
@@ -210,12 +210,20 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 			case *types.PlanModeChangedEvent:
 				if pe.PlanFilePath != "" {
 					childPlanFilePath = pe.PlanFilePath
+					utils.Debug("Dispatch", fmt.Sprintf(
+						"child plan file path updated agent=%q planFilePath=%q session=%s",
+						opts.Name, childPlanFilePath, sa.SessionKey(),
+					))
 				}
 			case *types.PlanProposalEvent:
 				childPlanExited = true
 				if pe.PlanFilePath != "" {
 					childPlanFilePath = pe.PlanFilePath
 				}
+				utils.Debug("Dispatch", fmt.Sprintf(
+					"child plan exited agent=%q planFilePath=%q session=%s",
+					opts.Name, childPlanFilePath, sa.SessionKey(),
+				))
 			}
 
 			// Capture final result, cost, and session ID from TaskCompleteEvent.
@@ -535,6 +543,7 @@ func startChild(child backend.RunBackend, reqID string, runOpts types.RunOptions
 func fireLifecycleCallbacks(
 	opts *extension.DispatchAgentOpts,
 	ev types.NormalizedEvent,
+	agentID string,
 	toolNames map[string]string,
 	toolCount *int,
 	accumulatedText *string,
@@ -613,17 +622,15 @@ func fireLifecycleCallbacks(
 		if opts.OnPlanProposal != nil {
 			info := extension.DispatchPlanProposalInfo{
 				Name:          opts.Name,
+				AgentID:       agentID,
 				PlanFilePath:  e.PlanFilePath,
 				PlanSlug:      e.PlanSlug,
 				PlanRequested: opts.PlanMode,
 			}
-			result := opts.OnPlanProposal(info)
-			// If the extension handled it, we're done. If not, the event
-			// was already forwarded via OnEvent above — the parent session
-			// stream gets the raw plan_proposal event.
+			opts.OnPlanProposal(info)
 			utils.Log("Dispatch", fmt.Sprintf(
-				"plan proposal agent=%q planSlug=%q requested=%v handled=%v",
-				opts.Name, e.PlanSlug, opts.PlanMode, result.Handled,
+				"plan proposal callback fired agent=%q planSlug=%q requested=%v",
+				opts.Name, e.PlanSlug, opts.PlanMode,
 			))
 		}
 	}

--- a/engine/internal/session/extcontext/dispatch_agent.go
+++ b/engine/internal/session/extcontext/dispatch_agent.go
@@ -36,8 +36,8 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 		start := time.Now()
 
 		utils.Log("Dispatch", fmt.Sprintf(
-			"starting dispatch agent=%q task=%q model=%q sysPromptLen=%d background=%v session=%s",
-			opts.Name, truncate(opts.Task, 80), opts.Model, len(opts.SystemPrompt), opts.Background, sa.SessionKey(),
+			"starting dispatch agent=%q task=%q model=%q sysPromptLen=%d background=%v planMode=%v session=%s",
+			opts.Name, truncate(opts.Task, 80), opts.Model, len(opts.SystemPrompt), opts.Background, opts.PlanMode, sa.SessionKey(),
 		))
 
 		// Determine model and project path.
@@ -158,6 +158,10 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 		// Track active tool names by ID for structured callbacks.
 		toolNames := make(map[string]string)
 
+		// Plan mode tracking.
+		var childPlanFilePath string
+		var childPlanExited bool
+
 		// Cancellation context for background dispatch / recall support.
 		ctx, cancelFn := context.WithCancel(context.Background())
 		var recalled bool
@@ -201,6 +205,19 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 				emitProgress(fmt.Sprintf("Using %s...", e.ToolName))
 			}
 
+			// Track plan mode state from child events.
+			switch pe := ev.Data.(type) {
+			case *types.PlanModeChangedEvent:
+				if pe.PlanFilePath != "" {
+					childPlanFilePath = pe.PlanFilePath
+				}
+			case *types.PlanProposalEvent:
+				childPlanExited = true
+				if pe.PlanFilePath != "" {
+					childPlanFilePath = pe.PlanFilePath
+				}
+			}
+
 			// Capture final result, cost, and session ID from TaskCompleteEvent.
 			if tc, ok := ev.Data.(*types.TaskCompleteEvent); ok {
 				resultText = tc.Result
@@ -242,6 +259,15 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 		}
 		if opts.MaxTurns > 0 {
 			runOpts.MaxTurns = opts.MaxTurns
+		}
+		if opts.PlanMode {
+			runOpts.PlanMode = true
+			if opts.PlanFilePath != "" {
+				runOpts.PlanFilePath = opts.PlanFilePath
+			}
+			if len(opts.PlanModeTools) > 0 {
+				runOpts.PlanModeTools = opts.PlanModeTools
+			}
 		}
 
 		key = sa.SessionKey()
@@ -317,6 +343,8 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 				CacheReadInputTokens:     totalCacheReadTokens,
 				CacheCreationInputTokens: totalCacheCreationTokens,
 				SessionID:                childSessionID,
+				PlanFilePath:             childPlanFilePath,
+				PlanExited:               childPlanExited,
 			}
 
 			// Update agent state with terminal status and conversation ID.
@@ -580,6 +608,24 @@ func fireLifecycleCallbacks(
 	case *types.TaskCompleteEvent:
 		// Update cumulative cost from the authoritative source.
 		*cumulativeCost = e.CostUsd
+
+	case *types.PlanProposalEvent:
+		if opts.OnPlanProposal != nil {
+			info := extension.DispatchPlanProposalInfo{
+				Name:          opts.Name,
+				PlanFilePath:  e.PlanFilePath,
+				PlanSlug:      e.PlanSlug,
+				PlanRequested: opts.PlanMode,
+			}
+			result := opts.OnPlanProposal(info)
+			// If the extension handled it, we're done. If not, the event
+			// was already forwarded via OnEvent above — the parent session
+			// stream gets the raw plan_proposal event.
+			utils.Log("Dispatch", fmt.Sprintf(
+				"plan proposal agent=%q planSlug=%q requested=%v handled=%v",
+				opts.Name, e.PlanSlug, opts.PlanMode, result.Handled,
+			))
+		}
 	}
 }
 

--- a/engine/internal/session/extcontext/dispatch_agent_test.go
+++ b/engine/internal/session/extcontext/dispatch_agent_test.go
@@ -29,7 +29,7 @@ func TestFireLifecycleCallbacks_ToolCall(t *testing.T) {
 
 	ev := types.NormalizedEvent{Data: &types.ToolCallEvent{ToolName: "bash", ToolID: "tc-1", Index: 0}}
 
-	fireLifecycleCallbacks(opts, ev, toolNames, &toolCount, &accumulatedText,
+	fireLifecycleCallbacks(opts, ev, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 		&cumIn, &cumOut, &cumCost)
 
 	if !fired {
@@ -79,7 +79,7 @@ func TestFireLifecycleCallbacks_ToolResult(t *testing.T) {
 			IsError: false,
 		}}
 
-		fireLifecycleCallbacks(opts, ev, toolNames, &toolCount, &accumulatedText,
+		fireLifecycleCallbacks(opts, ev, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 			&cumIn, &cumOut, &cumCost)
 
 		if !endFired {
@@ -126,7 +126,7 @@ func TestFireLifecycleCallbacks_ToolResult(t *testing.T) {
 			IsError: true,
 		}}
 
-		fireLifecycleCallbacks(opts, ev, toolNames, &toolCount, &accumulatedText,
+		fireLifecycleCallbacks(opts, ev, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 			&cumIn, &cumOut, &cumCost)
 
 		if !errFired {
@@ -164,7 +164,7 @@ func TestFireLifecycleCallbacks_TextChunk(t *testing.T) {
 	chunks := []string{"Hello", ", ", "world!"}
 	for _, chunk := range chunks {
 		ev := types.NormalizedEvent{Data: &types.TextChunkEvent{Text: chunk}}
-		fireLifecycleCallbacks(opts, ev, toolNames, &toolCount, &accumulatedText,
+		fireLifecycleCallbacks(opts, ev, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 			&cumIn, &cumOut, &cumCost)
 	}
 
@@ -225,7 +225,7 @@ func TestFireLifecycleCallbacks_Usage(t *testing.T) {
 	ev1 := types.NormalizedEvent{Data: &types.UsageEvent{
 		Usage: types.UsageData{InputTokens: &in1, OutputTokens: &out1},
 	}}
-	fireLifecycleCallbacks(opts, ev1, toolNames, &toolCount, &accumulatedText,
+	fireLifecycleCallbacks(opts, ev1, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 		&cumIn, &cumOut, &cumCost)
 
 	// Second usage event — cumulative totals should grow.
@@ -234,7 +234,7 @@ func TestFireLifecycleCallbacks_Usage(t *testing.T) {
 	ev2 := types.NormalizedEvent{Data: &types.UsageEvent{
 		Usage: types.UsageData{InputTokens: &in2, OutputTokens: &out2},
 	}}
-	fireLifecycleCallbacks(opts, ev2, toolNames, &toolCount, &accumulatedText,
+	fireLifecycleCallbacks(opts, ev2, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 		&cumIn, &cumOut, &cumCost)
 
 	if len(gotUsage) != 2 {
@@ -361,7 +361,7 @@ func TestFireLifecycleCallbacks_NilCallbacks(t *testing.T) {
 	}
 
 	for _, ev := range events {
-		fireLifecycleCallbacks(opts, ev, toolNames, &toolCount, &accumulatedText,
+		fireLifecycleCallbacks(opts, ev, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 			&cumIn, &cumOut, &cumCost)
 	}
 
@@ -397,7 +397,7 @@ func TestFireLifecycleCallbacks_TaskCompleteUpdatesCost(t *testing.T) {
 
 	// TaskCompleteEvent sets the authoritative cost.
 	tcEv := types.NormalizedEvent{Data: &types.TaskCompleteEvent{CostUsd: 0.042}}
-	fireLifecycleCallbacks(opts, tcEv, toolNames, &toolCount, &accumulatedText,
+	fireLifecycleCallbacks(opts, tcEv, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 		&cumIn, &cumOut, &cumCost)
 
 	if cumCost != 0.042 {
@@ -410,7 +410,7 @@ func TestFireLifecycleCallbacks_TaskCompleteUpdatesCost(t *testing.T) {
 	usageEv := types.NormalizedEvent{Data: &types.UsageEvent{
 		Usage: types.UsageData{InputTokens: &in, OutputTokens: &out},
 	}}
-	fireLifecycleCallbacks(opts, usageEv, toolNames, &toolCount, &accumulatedText,
+	fireLifecycleCallbacks(opts, usageEv, "test-agent-id", toolNames, &toolCount, &accumulatedText,
 		&cumIn, &cumOut, &cumCost)
 
 	if gotUsage.CumulativeCost != 0.042 {


### PR DESCRIPTION
## Summary

Enable dispatched child agents to start in plan mode with structured lifecycle callbacks for plan proposals, and fix the desktop engine tab IPC chain to properly pass `implementationPhase` and sync plan mode state.

## Changes

- **engine:** Add `PlanMode`, `PlanFilePath`, and `PlanModeTools` fields to `DispatchAgentOpts`; add `PlanFilePath` and `PlanExited` to `DispatchAgentResult`
- **engine:** Add `OnPlanProposal` lifecycle callback (fire-and-forget) that fires when a dispatched agent calls ExitPlanMode, carrying agent name, plan file path, slug, and origin info
- **engine:** Wire `dispatch_plan_proposal` JSON-RPC notification for background dispatches
- **engine:** Populate `AgentID` on `DispatchPlanProposalInfo`, add debug logging for plan-mode state tracking in `OnNormalized`
- **desktop:** Wire `implementationPhase=true` through the full IPC chain (`submitEnginePrompt` → `enginePrompt` → `ENGINE_PROMPT` handler → `processIncomingPrompt` → `engineBridge.sendPrompt`) when user clicks Implement on a plan card
- **desktop:** Sync plan mode unconditionally on engine prompt to prevent desync when toggling between plan and auto modes