### PR TITLE
Structural compaction dedup, compact_boundary contract, fuzzy slash commands, and cross-platform truncation fixes

### DIFF
--- a/desktop/src/main/remote/handlers/engine.ts
+++ b/desktop/src/main/remote/handlers/engine.ts
@@ -333,7 +333,6 @@ export async function handleLoadEngineConversation(cmd: Extract<RemoteCommand, {
         return msgs.map(function(m) {
           var content = m.content || '';
           if (m.role === 'tool' && content.length > 2048) content = content.substring(0, 2048) + '\\n... [truncated]';
-          else if (content.length > 10000) content = content.substring(0, 10000);
           // Carry dedupKey through to iOS so the data is available on
           // reconnect / history-replay. iOS does not yet act on the key,
           // but having it on the wire lets a future iOS-side dedup

--- a/desktop/src/main/remote/handlers/tabs.ts
+++ b/desktop/src/main/remote/handlers/tabs.ts
@@ -317,7 +317,6 @@ export async function handleLoadConversation(cmd: Extract<RemoteCommand, { type:
           var page = all.slice(startIdx, endIdx).map(function(m) {
             var content = m.content || '';
             if (m.role === 'tool' && content.length > 2048) content = content.substring(0, 2048) + '\\n... [truncated]';
-            else if (content.length > 10000) content = content.substring(0, 10000);
             return {
               id: m.id, role: m.role, content: content,
               toolName: m.toolName, toolInput: m.toolInput,

--- a/desktop/src/renderer/components/InputBar.tsx
+++ b/desktop/src/renderer/components/InputBar.tsx
@@ -3,10 +3,11 @@ import { AnimatePresence } from 'framer-motion'
 import { create } from 'zustand'
 import { useSessionStore } from '../stores/sessionStore'
 import { AttachmentChips } from './AttachmentChips'
-import { SlashCommandMenu, getFilteredCommandsWithExtras, type SlashCommand } from './SlashCommandMenu'
+import { SlashCommandMenu, getFilteredCommandsWithExtras, ExtensionCommandIcon, type SlashCommand } from './SlashCommandMenu'
 import { useColors } from '../theme'
 import { usePreferencesStore } from '../preferences'
 import type { DiscoveredCommand } from '../../shared/types'
+import { getRendererExtensionCommands } from '../stores/slices/engine-event-slice'
 import { useVoiceRecording, VoiceButtons } from './InputBarVoiceButton'
 import { SendButton } from './InputBarSendButton'
 import { UpdateButton } from './UpdateButton'
@@ -89,12 +90,26 @@ export function InputBar() {
     return () => { cancelled = true }
   }, [workingDir])
 
-  const extraCommands: SlashCommand[] = discoveredCommands.map((dc) => ({
+  const discoveredExtra: SlashCommand[] = discoveredCommands.map((dc) => ({
     command: `/${dc.name}`,
     description: dc.description || `${dc.source}: ${dc.name}`,
     icon: <span className="text-[11px]">{dc.scope === 'project' ? '◆' : '✦'}</span>,
     group: dc.scope === 'project' ? 'project' as const : 'user' as const,
   }))
+
+  // Merge extension-registered commands from the engine's command registry.
+  // The key matches the engine session key used by engine-event-slice.ts.
+  const extensionKey = tab?.isEngine && activeInstanceId ? `${activeTabId}:${activeInstanceId}` : activeTabId
+  const extensionExtra: SlashCommand[] = extensionKey
+    ? getRendererExtensionCommands(extensionKey).map((ec) => ({
+      command: `/${ec.name}`,
+      description: ec.description || ec.name,
+      icon: <ExtensionCommandIcon />,
+      group: 'extension' as const,
+    }))
+    : []
+
+  const extraCommands: SlashCommand[] = [...discoveredExtra, ...extensionExtra]
 
   // ─── Per-tab draft input sync ───
   // Save current input to departing tab, restore arriving tab's draft
@@ -230,7 +245,7 @@ export function InputBar() {
 
   // ─── Slash command detection ───
   const updateSlashFilter = useCallback((value: string) => {
-    const match = value.match(/^(\/[a-zA-Z-]*)$/)
+    const match = value.match(/^(\/[a-zA-Z0-9_:-]*)$/)
     if (match) {
       setSlashFilter(match[1])
       setSlashIndex(0)

--- a/desktop/src/renderer/components/SlashCommandMenu.tsx
+++ b/desktop/src/renderer/components/SlashCommandMenu.tsx
@@ -1,23 +1,27 @@
 import React, { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
-import { Trash } from '@phosphor-icons/react'
+import { Trash, PuzzlePiece } from '@phosphor-icons/react'
 import { usePopoverLayer } from './PopoverLayer'
 import { useColors } from '../theme'
+import { fuzzyFilterAndSort } from '../../shared/fuzzy-match'
 
 export interface SlashCommand {
   command: string
   description: string
   icon: React.ReactNode
-  group?: 'builtin' | 'user' | 'project'
+  group?: 'builtin' | 'project' | 'extension' | 'user'
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
   { command: '/clear', description: 'Clear conversation history', icon: <Trash size={13} />, group: 'builtin' },
 ]
 
-const GROUP_ORDER: Record<string, number> = { builtin: 0, project: 1, user: 2 }
-const GROUP_LABELS: Record<string, string> = { project: 'Project', user: 'User' }
+/** Icon used for extension-registered commands in the slash menu. */
+export const ExtensionCommandIcon = () => <PuzzlePiece size={13} />
+
+const GROUP_ORDER: Record<string, number> = { builtin: 0, project: 1, extension: 2, user: 3 }
+const GROUP_LABELS: Record<string, string> = { project: 'Project', extension: 'Extension', user: 'User' }
 
 interface Props {
   filter: string
@@ -32,20 +36,13 @@ export function getFilteredCommands(filter: string): SlashCommand[] {
 }
 
 export function getFilteredCommandsWithExtras(filter: string, extraCommands: SlashCommand[]): SlashCommand[] {
-  const q = filter.toLowerCase()
   const merged: SlashCommand[] = [...SLASH_COMMANDS]
   for (const cmd of extraCommands) {
     if (!merged.some((c) => c.command === cmd.command)) {
       merged.push(cmd)
     }
   }
-  const filtered = merged.filter((c) => c.command.startsWith(q))
-  filtered.sort((a, b) => {
-    const groupDiff = (GROUP_ORDER[a.group || 'builtin'] || 0) - (GROUP_ORDER[b.group || 'builtin'] || 0)
-    if (groupDiff !== 0) return groupDiff
-    return a.command.localeCompare(b.command)
-  })
-  return filtered
+  return fuzzyFilterAndSort(filter, merged)
 }
 
 export function SlashCommandMenu({ filter, selectedIndex, onSelect, anchorRect, extraCommands = [] }: Props) {
@@ -95,7 +92,7 @@ export function SlashCommandMenu({ filter, selectedIndex, onSelect, anchorRect, 
           const showHeader = currentGroup !== 'builtin' && currentGroup !== prevGroup
 
           return (
-            <React.Fragment key={cmd.command}>
+            <React.Fragment key={`${cmd.command}-${cmd.group || 'builtin'}`}>
               {showHeader && (
                 <div
                   className="px-3 pt-2 pb-0.5 text-[10px] uppercase tracking-wider font-medium"

--- a/desktop/src/shared/__tests__/contract-sync.test.ts
+++ b/desktop/src/shared/__tests__/contract-sync.test.ts
@@ -150,6 +150,32 @@ const TS_SHARED_TYPES: Record<string, string[]> = {
   // The desktop's prompt pipeline reads this off the wire to populate a
   // routing-hint cache keyed by session — see desktop/src/main/prompt-pipeline.ts.
   EngineCommandListing: ['description', 'name'],
+  // Wire shape for content blocks carried inside LlmMessage payloads.
+  // The compact_boundary variant (gentle-knitting-cup plan) added the
+  // optional summary / trigger / messages* / clearedBlocks / tokensBefore
+  // / factCount / recentFiles fields; the existing tool/image/text
+  // variants share the same struct so every variant shows up here.
+  LlmContentBlock: [
+    'clearedBlocks',
+    'content',
+    'factCount',
+    'id',
+    'input',
+    'is_error',
+    'messagesAfter',
+    'messagesBefore',
+    'messagesSummarized',
+    'name',
+    'recentFiles',
+    'source',
+    'summary',
+    'text',
+    'thinking',
+    'tokensBefore',
+    'tool_use_id',
+    'trigger',
+    'type',
+  ],
 }
 
 // ─── Tests ───

--- a/desktop/src/shared/__tests__/fuzzy-match.test.ts
+++ b/desktop/src/shared/__tests__/fuzzy-match.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the shared fuzzy-match helpers.
+ *
+ * `fuzzyMatchCommand` scores a single query→command pair.
+ * `fuzzyFilterAndSort` filters a command list and returns matches ranked by
+ * score (desc), then group priority (builtin < project < extension < user),
+ * then alphabetical name.
+ *
+ * The algorithm strips the leading `/` from both query and candidate, then
+ * treats `--` as a segment separator, rewarding matches that land on segment
+ * boundaries over interior subsequences.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { fuzzyMatchCommand, fuzzyFilterAndSort } from '../fuzzy-match'
+
+// ─── fuzzyMatchCommand ───
+
+describe('fuzzyMatchCommand', () => {
+  it('matches a subsequence at a segment boundary (/review → /ion--review--changes)', () => {
+    const result = fuzzyMatchCommand('/review', '/ion--review--changes')
+    expect(result).not.toBeNull()
+    expect(result!.match).toBe(true)
+    expect(result!.score).toBeGreaterThan(0)
+  })
+
+  it('matches an exact prefix (/compact → /compact)', () => {
+    const result = fuzzyMatchCommand('/compact', '/compact')
+    expect(result).not.toBeNull()
+    expect(result!.match).toBe(true)
+    expect(result!.score).toBeGreaterThan(0)
+  })
+
+  it('returns null for a non-matching query (/xyz → /compact)', () => {
+    const result = fuzzyMatchCommand('/xyz', '/compact')
+    expect(result).toBeNull()
+  })
+
+  it('is case-insensitive (/Review → /ion--review--changes)', () => {
+    const result = fuzzyMatchCommand('/Review', '/ion--review--changes')
+    expect(result).not.toBeNull()
+    expect(result!.match).toBe(true)
+  })
+
+  it('strips the leading `/` from both query and candidate before matching', () => {
+    const withSlashes = fuzzyMatchCommand('/compact', '/compact')
+    const withoutSlashes = fuzzyMatchCommand('compact', 'compact')
+
+    expect(withSlashes).not.toBeNull()
+    expect(withoutSlashes).not.toBeNull()
+    expect(withSlashes!.score).toBe(withoutSlashes!.score)
+  })
+
+  it('empty query `/` matches everything with score 0', () => {
+    const result = fuzzyMatchCommand('/', '/anything')
+    expect(result).not.toBeNull()
+    expect(result!.match).toBe(true)
+    expect(result!.score).toBe(0)
+  })
+})
+
+// ─── Score ordering ───
+
+describe('fuzzyMatchCommand score ordering', () => {
+  it('ranks exact prefix > boundary match > interior subsequence', () => {
+    const query = '/cl'
+
+    // Exact prefix: the query `cl` is a prefix of `clear`.
+    const exactPrefix = fuzzyMatchCommand(query, '/clear')
+    // Boundary match: `cl` matches at the start of the `cli` segment.
+    const boundaryMatch = fuzzyMatchCommand(query, '/ion--cli--tools')
+    // Interior subsequence: `c…l` found inside `declare` (non-boundary).
+    const interiorSubsequence = fuzzyMatchCommand(query, '/declare')
+
+    expect(exactPrefix).not.toBeNull()
+    expect(boundaryMatch).not.toBeNull()
+    expect(interiorSubsequence).not.toBeNull()
+
+    // Exact prefix beats boundary match.
+    expect(exactPrefix!.score).toBeGreaterThan(boundaryMatch!.score)
+    // Boundary match beats interior subsequence.
+    expect(boundaryMatch!.score).toBeGreaterThan(interiorSubsequence!.score)
+  })
+})
+
+// ─── fuzzyFilterAndSort ───
+
+describe('fuzzyFilterAndSort', () => {
+  it('empty query `/` matches everything', () => {
+    const commands = [
+      { command: '/alpha' },
+      { command: '/beta' },
+      { command: '/gamma' },
+    ]
+    const result = fuzzyFilterAndSort('/', commands)
+    expect(result).toHaveLength(3)
+  })
+
+  it('filters out non-matching commands', () => {
+    const commands = [
+      { command: '/compact' },
+      { command: '/review' },
+      { command: '/deploy' },
+    ]
+    const result = fuzzyFilterAndSort('/rev', commands)
+
+    expect(result.some((c) => c.command === '/review')).toBe(true)
+    expect(result.some((c) => c.command === '/compact')).toBe(false)
+  })
+
+  it('sorts by score descending for the `/cl` example', () => {
+    const commands = [
+      { command: '/declare' },
+      { command: '/ion--cli--tools' },
+      { command: '/clear' },
+    ]
+    const result = fuzzyFilterAndSort('/cl', commands)
+
+    expect(result).toHaveLength(3)
+    expect(result[0].command).toBe('/clear')
+    expect(result[1].command).toBe('/ion--cli--tools')
+    expect(result[2].command).toBe('/declare')
+  })
+
+  it('breaks score ties by group priority (builtin < project < extension < user)', () => {
+    const commands = [
+      { command: '/foo', group: 'user' },
+      { command: '/foo', group: 'builtin' },
+      { command: '/foo', group: 'extension' },
+      { command: '/foo', group: 'project' },
+    ]
+    const result = fuzzyFilterAndSort('/foo', commands)
+
+    expect(result).toHaveLength(4)
+    expect(result[0].group).toBe('builtin')
+    expect(result[1].group).toBe('project')
+    expect(result[2].group).toBe('extension')
+    expect(result[3].group).toBe('user')
+  })
+
+  it('breaks score + group ties alphabetically by command name', () => {
+    const commands = [
+      { command: '/zebra', group: 'builtin' },
+      { command: '/alpha', group: 'builtin' },
+      { command: '/mango', group: 'builtin' },
+    ]
+    const result = fuzzyFilterAndSort('/', commands)
+
+    expect(result).toHaveLength(3)
+    expect(result[0].command).toBe('/alpha')
+    expect(result[1].command).toBe('/mango')
+    expect(result[2].command).toBe('/zebra')
+  })
+
+  it('applies all three tiebreakers together: score → group → alpha', () => {
+    const commands = [
+      { command: '/clear', group: 'project' },
+      { command: '/clear', group: 'builtin' },
+      { command: '/ion--cli--tools', group: 'builtin' },
+      { command: '/declare', group: 'builtin' },
+    ]
+    const result = fuzzyFilterAndSort('/cl', commands)
+
+    expect(result).toHaveLength(4)
+    // Highest score first, then builtin before project for the tie.
+    expect(result[0]).toMatchObject({ command: '/clear', group: 'builtin' })
+    expect(result[1]).toMatchObject({ command: '/clear', group: 'project' })
+    // Lower-scoring matches follow in their own order.
+    expect(result[2].command).toBe('/ion--cli--tools')
+    expect(result[3].command).toBe('/declare')
+  })
+})

--- a/desktop/src/shared/fuzzy-match.ts
+++ b/desktop/src/shared/fuzzy-match.ts
@@ -1,0 +1,167 @@
+/**
+ * Fuzzy matching utilities for slash-command filtering.
+ *
+ * Pure functions — no React, no DOM dependencies.
+ * Algorithm mirrors `ios/IonRemote/Utilities/FuzzyMatch.swift` for
+ * cross-platform parity.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FuzzyCandidate {
+  command: string
+  group?: string
+}
+
+export interface FuzzyMatchResult {
+  match: boolean
+  score: number
+}
+
+// ---------------------------------------------------------------------------
+// Scoring constants
+// ---------------------------------------------------------------------------
+
+const BONUS_EXACT_PREFIX = 20
+const BONUS_START_OF_STRING = 10
+const BONUS_SEGMENT_BOUNDARY = 8
+const BONUS_CONSECUTIVE = 5
+
+const SEPARATORS = new Set(['-', '_', ':'])
+
+const GROUP_ORDER: Record<string, number> = {
+  builtin: 0,
+  project: 1,
+  extension: 2,
+  user: 3,
+}
+
+// ---------------------------------------------------------------------------
+// fuzzyMatchCommand
+// ---------------------------------------------------------------------------
+
+/**
+ * Attempt a fuzzy subsequence match of `query` against `commandName`.
+ *
+ * Leading `/` is stripped from both query and command name before matching
+ * so that `/clear`, `clear`, and `/clear` vs `/clear` all work identically.
+ *
+ * Returns `null` when the query is not a subsequence of the candidate.
+ * Otherwise returns `{ match: true, score }`.
+ */
+export function fuzzyMatchCommand(
+  query: string,
+  commandName: string,
+): FuzzyMatchResult | null {
+  // Normalise: strip a leading slash from both, lowercase both.
+  const q = stripSlash(query).toLowerCase()
+  const name = stripSlash(commandName).toLowerCase()
+
+  // Empty query matches everything with a neutral score.
+  if (q.length === 0) {
+    return { match: true, score: 0 }
+  }
+
+  // --- Subsequence gate --------------------------------------------------
+  // Walk through `name` consuming characters from `q` in order.
+  // Along the way, record the index in `name` where each query char matched
+  // so we can compute bonuses in one pass.
+
+  const matchIndices: number[] = []
+  let qi = 0
+
+  for (let ni = 0; ni < name.length && qi < q.length; ni++) {
+    if (name[ni] === q[qi]) {
+      matchIndices.push(ni)
+      qi++
+    }
+  }
+
+  if (qi !== q.length) {
+    // Not every query character was consumed — no subsequence match.
+    return null
+  }
+
+  // --- Scoring -----------------------------------------------------------
+
+  let score = 0
+
+  for (let i = 0; i < matchIndices.length; i++) {
+    const idx = matchIndices[i]
+
+    // Base: +1 per matched character.
+    score += 1
+
+    // Start-of-string bonus (first character of the name).
+    if (idx === 0) {
+      score += BONUS_START_OF_STRING
+    }
+
+    // Segment-boundary bonus: character immediately after a separator.
+    if (idx > 0 && SEPARATORS.has(name[idx - 1])) {
+      score += BONUS_SEGMENT_BOUNDARY
+    }
+
+    // Consecutive-match bonus: current match index is exactly one past the
+    // previous match index (i.e. the characters are adjacent in `name`).
+    if (i > 0 && idx === matchIndices[i - 1] + 1) {
+      score += BONUS_CONSECUTIVE
+    }
+  }
+
+  // Exact prefix bonus: the entire query matches the start of the candidate.
+  if (matchIndices.length === q.length && matchIndices[0] === 0 && matchIndices[matchIndices.length - 1] === q.length - 1) {
+    score += BONUS_EXACT_PREFIX
+  }
+
+  return { match: true, score }
+}
+
+// ---------------------------------------------------------------------------
+// fuzzyFilterAndSort
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter `commands` to those that fuzzy-match `query`, then sort by:
+ *   1. Score descending (best match first)
+ *   2. Group order ascending  (builtin → project → extension → user)
+ *   3. Alphabetical by command name
+ */
+export function fuzzyFilterAndSort<T extends FuzzyCandidate>(
+  query: string,
+  commands: T[],
+): T[] {
+  const scored: Array<{ item: T; score: number }> = []
+
+  for (const cmd of commands) {
+    const result = fuzzyMatchCommand(query, cmd.command)
+    if (result !== null) {
+      scored.push({ item: cmd, score: result.score })
+    }
+  }
+
+  scored.sort((a, b) => {
+    // 1. Higher score first.
+    if (a.score !== b.score) return b.score - a.score
+
+    // 2. Group order.
+    const ga = GROUP_ORDER[a.item.group || 'builtin'] ?? 99
+    const gb = GROUP_ORDER[b.item.group || 'builtin'] ?? 99
+    if (ga !== gb) return ga - gb
+
+    // 3. Alphabetical.
+    return a.item.command.localeCompare(b.item.command)
+  })
+
+  return scored.map((s) => s.item)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stripSlash(s: string): string {
+  return s.startsWith('/') ? s.slice(1) : s
+}

--- a/desktop/src/shared/types-engine.ts
+++ b/desktop/src/shared/types-engine.ts
@@ -91,6 +91,53 @@ export interface EngineCommandListing {
   description?: string
 }
 
+/**
+ * Mirror of Go's `types.LlmContentBlock`. This is the wire shape for
+ * every block carried inside an `LlmMessage` — providers, persistence,
+ * and the conversation history all serialize through it.
+ *
+ * The desktop does NOT currently render `LlmMessage` payloads directly
+ * (the engine emits normalized events instead), but the type is mirrored
+ * for two reasons:
+ *
+ *   1. Cross-language contract sync — the Go side adds field-level
+ *      coverage via `contract_test.go`, and this mirror keeps drift
+ *      detectable. The `compact_boundary` variant added in the
+ *      gentle-knitting-cup plan ships with several optional metadata
+ *      fields (`trigger`, `summary`, `clearedBlocks`, etc.) that future
+ *      desktop work may want to render in a compaction marker UI; the
+ *      type being already mirrored avoids a churn-PR when that lands.
+ *
+ *   2. Unknown block types must not crash a renderer. Any future
+ *      renderer that walks an `LlmContentBlock[]` should fall through
+ *      `type` it doesn't recognise — the field is open-string by design
+ *      because the engine ships new block variants additively.
+ */
+export interface LlmContentBlock {
+  type: string
+  text?: string
+  id?: string
+  name?: string
+  input?: Record<string, unknown>
+  tool_use_id?: string
+  content?: string
+  is_error?: boolean
+  thinking?: string
+  source?: { type: string; media_type: string; data: string }
+  // compact_boundary structured fields. All optional; only populated
+  // when `type === 'compact_boundary'`. See Go-side llm.go for canonical
+  // semantics.
+  trigger?: string
+  messagesSummarized?: number
+  messagesBefore?: number
+  messagesAfter?: number
+  clearedBlocks?: number
+  tokensBefore?: number
+  summary?: string
+  factCount?: number
+  recentFiles?: string[]
+}
+
 export type EngineEvent =
   | { type: 'engine_agent_state'; agents: AgentStateUpdate[] }
   | { type: 'engine_status'; fields: StatusFields; metadata?: Record<string, unknown> }

--- a/docs/extensions/sdk-go.md
+++ b/docs/extensions/sdk-go.md
@@ -145,6 +145,23 @@ sdk.FireSessionCompact(ctx, CompactionInfo{
     },
 })
 
+// compact_summary_request fires inside proactive (auto) and reactive
+// (prompt_too_long) compaction, after the session-memory and LLM tiers
+// and before the regex fallback. Substitute a harness-side summariser
+// for the engine's regex fact extractor by registering a handler that
+// returns a non-empty string; an empty return falls through to the
+// regex path. Branch on Strategy ("auto" | "reactive") to tune the
+// summariser to the trigger — reactive summaries should be aggressive
+// (fewer tokens) because the provider just rejected the prompt; auto
+// summaries can afford a richer rendering. The engine never blocks on
+// the handler; wrap LLM calls in a bounded timeout and return ("",
+// false) on failure rather than blocking the run.
+summary, ok := sdk.FireCompactSummaryRequest(ctx, CompactSummaryRequestInfo{
+    Strategy:     "auto",
+    MessageCount: len(messages),
+    Messages:     messages,
+}) // returns (summary string, ok bool); ok=false means "fall back to regex"
+
 sdk.FireSessionBeforeFork(ctx, ForkInfo{...})           // returns (cancelled bool, error)
 sdk.FireSessionFork(ctx, ForkInfo{...})
 sdk.FireSessionBeforeSwitch(ctx)

--- a/docs/extensions/sdk-typescript.md
+++ b/docs/extensions/sdk-typescript.md
@@ -378,6 +378,27 @@ ion.hook('turn_end', async (info, ctx) => {
 
 Useful for: replacing the engine's default summarization with a custom strategy (e.g. vector-store-backed, domain-specific extraction, or multi-modal summarization).
 
+**`compact_summary_request` hook** -- substitute a harness-side summariser for the engine's regex fact extractor. The hook fires inside proactive (auto) and reactive (prompt_too_long) compaction, after the session-memory and LLM tiers and before the regex fallback. The handler receives the compaction strategy (`'auto'` or `'reactive'`) and the pre-compaction message slice (already filtered through the boundary firewall so prior summaries are not in scope). Return a non-empty string to short-circuit the regex fallback; return an empty string or skip the return to let the engine fall through to its regex pipeline.
+
+```typescript
+ion.hook('compact_summary_request', async (info, ctx) => {
+  // info.strategy is 'auto' or 'reactive' — tune the summariser to the
+  // trigger. Reactive summaries should be aggressive (fewer tokens)
+  // because the provider just rejected the prompt; auto summaries can
+  // afford a richer rendering.
+  const targetWords = info.strategy === 'reactive' ? 80 : 250
+  try {
+    const summary = await myLLMSummarizer(info.messages, { targetWords })
+    return summary // becomes the compact_boundary block's Summary field
+  } catch (err) {
+    ctx.log('warn', `compact summary failed, falling back to regex: ${err}`)
+    return '' // empty return → engine uses regex fact extractor
+  }
+})
+```
+
+Useful for: replacing the engine's regex fact extractor with an LLM-based summariser, branching summary strategy on the compaction trigger, and integrating with external summarisation services. The engine never blocks on the handler — wrap any LLM call in a bounded timeout and return an empty string on failure rather than throwing or blocking.
+
 **`elicit(opts)`** -- ask the user a structured question via the connected client. Resolves with the user's response (or a cancellation signal). The engine blocks the calling extension's hook until the user replies or the client times out.
 
 ```typescript

--- a/docs/hooks/reference.md
+++ b/docs/hooks/reference.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Hook Reference
 
-All 66 hooks grouped by category. For each hook: when it fires, what payload it receives, what return values do, and the dispatch pattern.
+All 67 hooks grouped by category. For each hook: when it fires, what payload it receives, what return values do, and the dispatch pattern.
 
 ## Lifecycle (13)
 
@@ -88,12 +88,13 @@ type BeforePromptResult struct {
 }
 ```
 
-## Session Management (5)
+## Session Management (6)
 
 | Hook | When | Payload | Return | Effect |
 |------|------|---------|--------|--------|
 | `session_before_compact` | Before context compaction | `CompactionInfo{Strategy, MessagesBefore, MessagesAfter}` | `bool` | Return `true` to cancel compaction. |
 | `session_compact` | After compaction completes | `CompactionInfo{Strategy, MessagesBefore, MessagesAfter, Facts}` | ignored | Observe only. `Facts` carries structured snippets extracted from the pre-compaction messages — useful for persisting to external memory before they're discarded. May be empty. |
+| `compact_summary_request` | Inside proactive / reactive compaction, after session-memory and LLM tiers and before the regex fallback | `CompactSummaryRequestInfo{Strategy, MessageCount, Messages}` | `CompactSummaryRequestResult{Summary}` or bare `string` | First non-empty `Summary` becomes the new `compact_boundary` block's `Summary` field, short-circuiting the engine's regex fact extractor. Empty/nil return falls through to the regex pipeline. Use this to wire a harness-side summariser (LLM-based, vector-store-backed, domain-specific) that produces higher-quality summaries than the engine's regex pipeline. |
 | `session_before_fork` | Before session fork | `ForkInfo{SourceSessionKey, NewSessionKey, ForkMessageIndex}` | `bool` | Return `true` to cancel fork. |
 | `session_fork` | After fork completes | `ForkInfo{SourceSessionKey, NewSessionKey, ForkMessageIndex}` | ignored | Observe only |
 | `session_before_switch` | Before session switch | `nil` | ignored | Observe only |
@@ -127,6 +128,24 @@ type CompactionFact struct {
 `Facts` is populated on `session_compact` only (not on `session_before_compact`), and may be empty when step-1 micro-compaction alone is sufficient and no fact patterns matched. Message indices are intentionally not exposed — by the time the hook fires, the source messages have been mutated or truncated.
 
 `SessionMemory` contains the background session memory content when it was used as the summary source (tier 1 of the three-tier fallback). Empty when session memory was not available and the summary came from LLM or regex extraction.
+
+**CompactSummaryRequestInfo**
+```go
+type CompactSummaryRequestInfo struct {
+    Strategy     string             // "auto" (proactive) or "reactive" (prompt_too_long retry)
+    MessageCount int                // len(Messages); supplied so handlers can log without re-counting
+    Messages     []types.LlmMessage // pre-compaction slice, already filtered through MessagesAfterLastCompactBoundary so prior summaries are not in scope
+}
+```
+
+**CompactSummaryRequestResult**
+```go
+type CompactSummaryRequestResult struct {
+    Summary string // when non-empty, replaces the engine's regex-built summary text; empty means "no opinion — fall back to regex"
+}
+```
+
+The `compact_summary_request` handler may return a `CompactSummaryRequestResult` value, a `*CompactSummaryRequestResult` pointer, or a bare `string`. All three shapes flow through the same first-non-empty selection. The engine never blocks on this handler; harness implementations that call an LLM must do so with a bounded timeout and surface failures by returning `("", false)` rather than blocking the run. Branch on `Strategy` to tune the summariser to the trigger — e.g. a reactive summary may want to be more aggressive (fewer tokens) because the provider just rejected the prompt, while an auto summary can afford a richer rendering.
 
 **ForkInfo**
 ```go

--- a/engine/AGENTS.md
+++ b/engine/AGENTS.md
@@ -135,7 +135,7 @@ Optional (harness opt-in): TaskCreate, TaskList, TaskGet, TaskStop.
 
 ## Hooks
 
-66 total: 13 lifecycle + 5 session + 2 pre-action + 2 early-stop + 7 content + 14 per-tool + 3 context + 3 permission + 1 file + 1 workspace + 2 task + 2 elicitation + 4 plan-mode/system-inject + 1 context-inject + 3 capability + 4 extension-lifecycle.
+67 total: 13 lifecycle + 6 session + 2 pre-action + 2 early-stop + 7 content + 14 per-tool + 3 context + 3 permission + 1 file + 1 workspace + 2 task + 2 elicitation + 4 plan-mode/system-inject + 1 context-inject + 3 capability + 4 extension-lifecycle.
 
 The `before_plan_mode_enter`, `before_plan_mode_exit`, `system_inject`, `before_early_stop_decision`, `early_stop_continued`, `before_provider_request`, and `workspace_file_changed` hooks are recent additions; consult `docs/hooks/reference.md` for the canonical breakdown and per-hook payload shapes.
 

--- a/engine/extensions/sdk/ion-sdk/runtime.ts
+++ b/engine/extensions/sdk/ion-sdk/runtime.ts
@@ -377,16 +377,24 @@ async function handleRequest(
       const payload = { ...params }
       delete payload._ctx
 
+      // The engine wraps non-object payloads (bare strings) as
+      // {_payload: value} because they can't be merged into the
+      // params map. Unwrap so handlers receive the bare value.
+      const payloadKeys = Object.keys(payload)
+      const unwrapped =
+        payloadKeys.length === 1 && payloadKeys[0] === '_payload'
+          ? payload._payload
+          : payloadKeys.length > 0
+            ? payload
+            : undefined
+
       // Use a local array to collect events. Save/restore the global so
       // reentrant hook calls (possible when handlers await) don't clobber.
       const savedEvents = activeEvents
       const localEvents: EngineEvent[] = []
       activeEvents = localEvents
       const ctx = buildContext(ctxData)
-      const result = await handler(
-        ctx,
-        Object.keys(payload).length > 0 ? payload : undefined,
-      )
+      const result = await handler(ctx, unwrapped)
       activeEvents = savedEvents
 
       // Wrap the handler return value with any accumulated events.

--- a/engine/go.mod
+++ b/engine/go.mod
@@ -2,7 +2,7 @@ module github.com/dsswift/ion/engine
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require github.com/bmatcuk/doublestar/v4 v4.10.0
 

--- a/engine/internal/backend/backend.go
+++ b/engine/internal/backend/backend.go
@@ -199,12 +199,19 @@ type RunHooks struct {
 	// OnRequestCompactSummary is an optional harness-owned summariser
 	// invoked during proactive / reactive compaction in place of the
 	// engine's built-in regex fact extractor. The handler receives the
-	// pre-compaction message slice (already filtered through
+	// compaction strategy ("auto" for proactive token-limit driven,
+	// "reactive" for prompt_too_long retry) along with the pre-compaction
+	// message slice (already filtered through
 	// MessagesAfterLastCompactBoundary so prior summaries are not in
 	// scope) and returns (summary, ok). When ok is true, summary is
 	// used verbatim as the boundary block's Summary field. When ok is
 	// false (or the field is nil), the engine falls back to its
 	// FormatFactsSummary(ExtractFacts(...)) pipeline.
+	//
+	// The strategy parameter lets harness summarisers tune their output
+	// to the trigger — e.g. a reactive summary may want to be more
+	// aggressive (fewer tokens) because the provider just rejected the
+	// prompt, while an auto summary can afford a richer rendering.
 	//
 	// The engine never blocks on this callback; the runloop dispatches
 	// synchronously. Harness implementations that want to call an LLM
@@ -215,7 +222,7 @@ type RunHooks struct {
 	// "compact_summary_request" hook on the extension SDK. See
 	// docs/hooks/reference.md and the runloop_compaction.go logging for
 	// the "path=hook" / "path=regex" markers.
-	OnRequestCompactSummary func(runID string, messages []types.LlmMessage) (summary string, ok bool)
+	OnRequestCompactSummary func(runID string, strategy string, messages []types.LlmMessage) (summary string, ok bool)
 
 	OnFileChanged func(runID string, path string, action string)
 

--- a/engine/internal/backend/backend.go
+++ b/engine/internal/backend/backend.go
@@ -196,6 +196,27 @@ type RunHooks struct {
 	// OnSessionCompact observes a completed compaction.
 	OnSessionCompact func(runID string, info interface{})
 
+	// OnRequestCompactSummary is an optional harness-owned summariser
+	// invoked during proactive / reactive compaction in place of the
+	// engine's built-in regex fact extractor. The handler receives the
+	// pre-compaction message slice (already filtered through
+	// MessagesAfterLastCompactBoundary so prior summaries are not in
+	// scope) and returns (summary, ok). When ok is true, summary is
+	// used verbatim as the boundary block's Summary field. When ok is
+	// false (or the field is nil), the engine falls back to its
+	// FormatFactsSummary(ExtractFacts(...)) pipeline.
+	//
+	// The engine never blocks on this callback; the runloop dispatches
+	// synchronously. Harness implementations that want to call an LLM
+	// must do so with a bounded timeout and surface failures by
+	// returning ("", false) — never by blocking the run.
+	//
+	// This is the engine-side bridge for the optional
+	// "compact_summary_request" hook on the extension SDK. See
+	// docs/hooks/reference.md and the runloop_compaction.go logging for
+	// the "path=hook" / "path=regex" markers.
+	OnRequestCompactSummary func(runID string, messages []types.LlmMessage) (summary string, ok bool)
+
 	OnFileChanged func(runID string, path string, action string)
 
 	OnPermissionRequest func(runID string, info interface{})

--- a/engine/internal/backend/runloop_compact_boundary_test.go
+++ b/engine/internal/backend/runloop_compact_boundary_test.go
@@ -129,10 +129,12 @@ func TestCompactReactive_HookPathShortCircuitsRegex(t *testing.T) {
 	}
 
 	hookCalls := 0
+	gotStrategy := ""
 	const hookSummary = "harness-generated summary"
 	hooks := RunHooks{
-		OnRequestCompactSummary: func(_ string, _ []types.LlmMessage) (string, bool) {
+		OnRequestCompactSummary: func(_ string, strategy string, _ []types.LlmMessage) (string, bool) {
 			hookCalls++
+			gotStrategy = strategy
 			return hookSummary, true
 		},
 	}
@@ -140,6 +142,10 @@ func TestCompactReactive_HookPathShortCircuitsRegex(t *testing.T) {
 	run := &activeRun{requestID: "reactive-hook", conv: conv}
 	if !b.compactReactive(context.Background(), run, conv, hooks, testContextWindow, 1, testCP()) {
 		t.Fatalf("compactReactive returned false")
+	}
+
+	if gotStrategy != "reactive" {
+		t.Errorf("hook received strategy=%q, want %q (compactReactive must always pass \"reactive\")", gotStrategy, "reactive")
 	}
 
 	if hookCalls != 1 {
@@ -180,9 +186,11 @@ func TestCompactReactive_HookEmptyReturnFallsBackToRegex(t *testing.T) {
 	}
 
 	hookCalls := 0
+	gotStrategy := ""
 	hooks := RunHooks{
-		OnRequestCompactSummary: func(_ string, _ []types.LlmMessage) (string, bool) {
+		OnRequestCompactSummary: func(_ string, strategy string, _ []types.LlmMessage) (string, bool) {
 			hookCalls++
+			gotStrategy = strategy
 			return "", false
 		},
 	}
@@ -190,6 +198,10 @@ func TestCompactReactive_HookEmptyReturnFallsBackToRegex(t *testing.T) {
 	run := &activeRun{requestID: "reactive-hook-empty", conv: conv}
 	if !b.compactReactive(context.Background(), run, conv, hooks, testContextWindow, 1, testCP()) {
 		t.Fatalf("compactReactive returned false")
+	}
+
+	if gotStrategy != "reactive" {
+		t.Errorf("hook received strategy=%q, want %q", gotStrategy, "reactive")
 	}
 
 	if hookCalls != 1 {

--- a/engine/internal/backend/runloop_compact_boundary_test.go
+++ b/engine/internal/backend/runloop_compact_boundary_test.go
@@ -1,0 +1,262 @@
+package backend
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/conversation"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// testCP returns a compactParams suitable for boundary tests. The token
+// budget is generous so truncation still fires on the small fixtures
+// but doesn't interfere with boundary assertions.
+func testCP() compactParams {
+	return compactParams{
+		targetPercent:     50,
+		microKeepTurns:    3,
+		minKeepTurns:      2,
+		estimationPadding: 1.0,
+	}
+}
+
+// Small enough that CompactToTokenBudget actually drops messages on
+// these tiny fixtures, which is required for the duplication firewall
+// test to work (old keyword messages must be truncated away).
+const testContextWindow = 100
+
+// TestCompactReactive_InjectsCompactBoundary verifies the runloop swaps
+// the old triple-message scheme (system-cleared note + extracted-facts
+// message + post-compact-restore message) for a single typed
+// compact_boundary block.
+//
+// The old behaviour described in the gentle-knitting-cup plan as cause
+// #1: three overlapping bookkeeping messages per compaction. The
+// post-fix expectation: exactly one compact_boundary block at index 0.
+func TestCompactReactive_InjectsCompactBoundary(t *testing.T) {
+	b := NewApiBackend()
+	_ = captureEvents(b, "reactive-boundary")
+
+	conv := conversation.CreateConversation("reactive-boundary", "", "test-model")
+	// Seed with content that produces facts so the boundary's Summary
+	// field is non-empty (the regex path renders FormatFactsSummary).
+	conv.Messages = append(conv.Messages,
+		types.LlmMessage{Role: "user", Content: "We decided to use SQLite for storage."},
+		types.LlmMessage{Role: "assistant", Content: "Acknowledged; build failed in passing."},
+	)
+	for i := 0; i < 20; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "filler q"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "filler a"})
+	}
+
+	run := &activeRun{requestID: "reactive-boundary", conv: conv}
+	if !b.compactReactive(context.Background(), run, conv, RunHooks{}, testContextWindow, 1, testCP()) {
+		t.Fatalf("compactReactive returned false; expected true")
+	}
+
+	// Exactly one boundary at the head of the surviving slice.
+	if !conversation.IsCompactBoundary(conv.Messages[0]) {
+		t.Fatalf("first message after compaction is not a compact_boundary: %+v", conv.Messages[0])
+	}
+
+	// No other boundary blocks anywhere (we should never inject two per
+	// compaction).
+	boundaryCount := 0
+	for _, m := range conv.Messages {
+		if conversation.IsCompactBoundary(m) {
+			boundaryCount++
+		}
+	}
+	if boundaryCount != 1 {
+		t.Errorf("expected exactly 1 boundary block, got %d", boundaryCount)
+	}
+
+	// Inspect the boundary's structured fields.
+	blocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	if blocks[0].Trigger != "reactive" {
+		t.Errorf("boundary.Trigger = %q, want reactive", blocks[0].Trigger)
+	}
+	if blocks[0].MessagesBefore == 0 {
+		t.Error("boundary.MessagesBefore should be populated")
+	}
+	// The old "[SYSTEM] Context compaction cleared N older tool
+	// results" transient must NOT appear anywhere as a separate
+	// message. The cleared-block count now lives on the boundary's
+	// ClearedBlocks field. ClearedBlocks may legitimately be zero on
+	// this fixture (no tool_result blocks to clear), so we only check
+	// the absence of the prose, not the numeric field.
+	for _, m := range conv.Messages {
+		if conversation.IsCompactBoundary(m) {
+			continue
+		}
+		if s, ok := m.Content.(string); ok && strings.Contains(s, "[SYSTEM] Context compaction cleared") {
+			t.Errorf("legacy [SYSTEM] Context compaction cleared transient still present: %q", s)
+		}
+		if blocks, ok := m.Content.([]types.LlmContentBlock); ok {
+			for _, b := range blocks {
+				if strings.Contains(b.Text, "[SYSTEM] Context compaction cleared") {
+					t.Errorf("legacy [SYSTEM] Context compaction cleared transient still present in block: %q", b.Text)
+				}
+				if strings.Contains(b.Text, "[Post-compaction context restore]") {
+					t.Errorf("legacy [Post-compaction context restore] block still present: %q", b.Text)
+				}
+				if strings.Contains(b.Text, "[Extracted facts from compacted context]") {
+					t.Errorf("legacy [Extracted facts from compacted context] block still present: %q", b.Text)
+				}
+			}
+		}
+	}
+}
+
+// TestCompactReactive_HookPathShortCircuitsRegex pins the new
+// OnRequestCompactSummary hook contract: when the harness supplies a
+// non-empty summary the engine uses it verbatim and does not run its
+// regex fallback.
+func TestCompactReactive_HookPathShortCircuitsRegex(t *testing.T) {
+	b := NewApiBackend()
+	_ = captureEvents(b, "reactive-hook")
+
+	conv := conversation.CreateConversation("reactive-hook", "", "test-model")
+	// Seed content the regex extractor would pick up so we can verify
+	// the regex output is NOT what landed in Summary.
+	conv.Messages = append(conv.Messages,
+		types.LlmMessage{Role: "user", Content: "We decided to use Go."},
+	)
+	for i := 0; i < 22; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "filler q"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "filler a"})
+	}
+
+	hookCalls := 0
+	const hookSummary = "harness-generated summary"
+	hooks := RunHooks{
+		OnRequestCompactSummary: func(_ string, _ []types.LlmMessage) (string, bool) {
+			hookCalls++
+			return hookSummary, true
+		},
+	}
+
+	run := &activeRun{requestID: "reactive-hook", conv: conv}
+	if !b.compactReactive(context.Background(), run, conv, hooks, testContextWindow, 1, testCP()) {
+		t.Fatalf("compactReactive returned false")
+	}
+
+	if hookCalls != 1 {
+		t.Errorf("expected OnRequestCompactSummary to be called exactly once, got %d", hookCalls)
+	}
+
+	blocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	if !conversation.IsCompactBoundary(conv.Messages[0]) {
+		t.Fatal("first message should be a compact_boundary")
+	}
+	if blocks[0].Summary != hookSummary {
+		t.Errorf("boundary.Summary = %q, want harness-supplied %q", blocks[0].Summary, hookSummary)
+	}
+	// The regex path (FormatFactsSummary) would emit a "## Decisions"
+	// markdown header for the seeded "decided to use Go" content. Its
+	// absence proves the hook short-circuited the regex path.
+	if strings.Contains(blocks[0].Summary, "## Decisions") {
+		t.Error("boundary.Summary contains regex output; hook should have short-circuited")
+	}
+}
+
+// TestCompactReactive_HookEmptyReturnFallsBackToRegex is the negative
+// half of the hook contract: when the hook is wired but returns
+// ("", false) (or just an empty string), the engine falls back to the
+// regex pipeline. Harnesses use this when a model call fails or the
+// session shouldn't be summarised.
+func TestCompactReactive_HookEmptyReturnFallsBackToRegex(t *testing.T) {
+	b := NewApiBackend()
+	_ = captureEvents(b, "reactive-hook-empty")
+
+	conv := conversation.CreateConversation("reactive-hook-empty", "", "test-model")
+	conv.Messages = append(conv.Messages,
+		types.LlmMessage{Role: "user", Content: "We decided to use Go."},
+	)
+	for i := 0; i < 22; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "filler q"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "filler a"})
+	}
+
+	hookCalls := 0
+	hooks := RunHooks{
+		OnRequestCompactSummary: func(_ string, _ []types.LlmMessage) (string, bool) {
+			hookCalls++
+			return "", false
+		},
+	}
+
+	run := &activeRun{requestID: "reactive-hook-empty", conv: conv}
+	if !b.compactReactive(context.Background(), run, conv, hooks, testContextWindow, 1, testCP()) {
+		t.Fatalf("compactReactive returned false")
+	}
+
+	if hookCalls != 1 {
+		t.Errorf("expected hook to be called once even when it returns empty, got %d", hookCalls)
+	}
+
+	blocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	// Regex fallback should have produced a Decisions section.
+	if !strings.Contains(blocks[0].Summary, "## Decisions") {
+		t.Errorf("expected regex fallback to render Decisions section, got Summary=%q", blocks[0].Summary)
+	}
+}
+
+// TestCompactReactive_DuplicationFirewall is the headline regression
+// guard: running compaction twice must not let the second pass's
+// boundary contain facts re-extracted from the first pass's summary.
+//
+// Without MessagesAfterLastCompactBoundary the regex extractor would
+// walk the first boundary's Summary text (which carries words like
+// "decided", "failed", and file paths), emit them as facts again, and
+// the second summary would visibly compound the first. The structural
+// boundary block + the slice helper close that loop.
+func TestCompactReactive_DuplicationFirewall(t *testing.T) {
+	b := NewApiBackend()
+	_ = captureEvents(b, "firewall")
+
+	conv := conversation.CreateConversation("firewall", "", "test-model")
+	// Seed unique fact text so the first pass's Summary contains
+	// keywords that would re-trigger the regex extractor if it ever
+	// walked the boundary.
+	conv.Messages = append(conv.Messages,
+		types.LlmMessage{Role: "user", Content: "We decided to use UNIQUEKEYWORD-ALPHA for storage."},
+	)
+	for i := 0; i < 22; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "filler q"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "filler a"})
+	}
+
+	run := &activeRun{requestID: "firewall", conv: conv}
+
+	// Pass 1
+	if !b.compactReactive(context.Background(), run, conv, RunHooks{}, testContextWindow, 1, testCP()) {
+		t.Fatalf("first compactReactive returned false")
+	}
+	firstBlocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	firstSummary := firstBlocks[0].Summary
+	if !strings.Contains(firstSummary, "UNIQUEKEYWORD-ALPHA") {
+		t.Fatalf("setup failed: first summary did not capture seeded keyword: %q", firstSummary)
+	}
+
+	// Append enough filler to force a second compaction without
+	// introducing any new fact-keyword text.
+	for i := 0; i < 22; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "second pass filler"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "more filler"})
+	}
+
+	// Pass 2
+	if !b.compactReactive(context.Background(), run, conv, RunHooks{}, testContextWindow, 2, testCP()) {
+		t.Fatalf("second compactReactive returned false")
+	}
+
+	// The latest boundary (head of the slice) must NOT contain the
+	// unique keyword — that would mean the regex extractor re-mined the
+	// first boundary's Summary text and the firewall has a hole.
+	latestBlocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	if strings.Contains(latestBlocks[0].Summary, "UNIQUEKEYWORD-ALPHA") {
+		t.Errorf("duplication firewall leak: second boundary's Summary contains a fact from the first boundary: %q", latestBlocks[0].Summary)
+	}
+}

--- a/engine/internal/backend/runloop_compact_boundary_test.go
+++ b/engine/internal/backend/runloop_compact_boundary_test.go
@@ -272,3 +272,139 @@ func TestCompactReactive_DuplicationFirewall(t *testing.T) {
 		t.Errorf("duplication firewall leak: second boundary's Summary contains a fact from the first boundary: %q", latestBlocks[0].Summary)
 	}
 }
+
+// TestCompactIfNeeded_InjectsCompactBoundary is the proactive-path
+// counterpart to TestCompactReactive_InjectsCompactBoundary. The two
+// runloop sites (compactIfNeeded and compactReactive) inject the same
+// typed boundary via the shared injectCompactBoundary helper, but the
+// proactive path was uncovered until this test landed — a regression
+// that broke proactive injection while leaving reactive untouched would
+// ship green.
+//
+// Setup mirrors the reactive test: a seeded conversation with content
+// the regex extractor will pick up, plus enough filler that
+// CompactToTokenBudget actually drops messages. The two key knobs that
+// differ are LastInputTokens (so usage.Tokens > tokenLimit triggers the
+// proactive entry) and the explicit (contextWindow, tokenLimit) args
+// passed to compactIfNeeded (the reactive path infers these from
+// usageBefore on each retry).
+func TestCompactIfNeeded_InjectsCompactBoundary(t *testing.T) {
+	b := NewApiBackend()
+	_ = captureEvents(b, "proactive-boundary")
+
+	conv := conversation.CreateConversation("proactive-boundary", "", "test-model")
+	conv.Messages = append(conv.Messages,
+		types.LlmMessage{Role: "user", Content: "We decided to use SQLite for storage."},
+		types.LlmMessage{Role: "assistant", Content: "Acknowledged; build failed in passing."},
+	)
+	for i := 0; i < 20; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "filler q"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "filler a"})
+	}
+	// Prime LastInputTokens above tokenLimit so usage.Tokens > tokenLimit
+	// at the top of compactIfNeeded; without this priming the function
+	// short-circuits before reaching the boundary-injection branch.
+	conv.LastInputTokens = 180_000
+	conv.LastInputTokensMsgCount = len(conv.Messages)
+
+	run := &activeRun{requestID: "proactive-boundary", conv: conv}
+	cp := testCP()
+	cp.summaryEnabled = false // skip the LLM tier; we want the regex tail
+	b.compactIfNeeded(context.Background(), run, conv, RunHooks{}, 200_000, 100_000, cp)
+
+	if !conversation.IsCompactBoundary(conv.Messages[0]) {
+		t.Fatalf("first message after compaction is not a compact_boundary: %+v", conv.Messages[0])
+	}
+
+	boundaryCount := 0
+	for _, m := range conv.Messages {
+		if conversation.IsCompactBoundary(m) {
+			boundaryCount++
+		}
+	}
+	if boundaryCount != 1 {
+		t.Errorf("expected exactly 1 boundary block, got %d", boundaryCount)
+	}
+
+	blocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	if blocks[0].Trigger != "auto" {
+		t.Errorf("boundary.Trigger = %q, want auto", blocks[0].Trigger)
+	}
+	if blocks[0].MessagesBefore == 0 {
+		t.Error("boundary.MessagesBefore should be populated")
+	}
+
+	// Same legacy-prose absence checks as the reactive test — the
+	// runloop must NEVER emit the old AddTransientUserMessage notices,
+	// regardless of which compaction trigger fires.
+	for _, m := range conv.Messages {
+		if conversation.IsCompactBoundary(m) {
+			continue
+		}
+		if s, ok := m.Content.(string); ok && strings.Contains(s, "[SYSTEM] Context compaction") {
+			t.Errorf("legacy [SYSTEM] Context compaction transient still present: %q", s)
+		}
+		if blocks, ok := m.Content.([]types.LlmContentBlock); ok {
+			for _, blk := range blocks {
+				if strings.Contains(blk.Text, "[SYSTEM] Context compaction") {
+					t.Errorf("legacy [SYSTEM] Context compaction transient still present in block: %q", blk.Text)
+				}
+				if strings.Contains(blk.Text, "[Post-compaction context restore]") {
+					t.Errorf("legacy [Post-compaction context restore] block still present: %q", blk.Text)
+				}
+				if strings.Contains(blk.Text, "[Extracted facts from compacted context]") {
+					t.Errorf("legacy [Extracted facts from compacted context] block still present: %q", blk.Text)
+				}
+			}
+		}
+	}
+}
+
+// TestCompactIfNeeded_HookPathReceivesAutoStrategy pins the
+// proactive-path counterpart to
+// TestCompactReactive_HookPathShortCircuitsRegex's strategy assertion.
+// compactIfNeeded must pass strategy="auto" to OnRequestCompactSummary,
+// or harness summarisers that branch on strategy will misfire.
+func TestCompactIfNeeded_HookPathReceivesAutoStrategy(t *testing.T) {
+	b := NewApiBackend()
+	_ = captureEvents(b, "proactive-hook-strategy")
+
+	conv := conversation.CreateConversation("proactive-hook-strategy", "", "test-model")
+	conv.Messages = append(conv.Messages,
+		types.LlmMessage{Role: "user", Content: "We decided to use Go."},
+	)
+	for i := 0; i < 22; i++ {
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "user", Content: "filler q"})
+		conv.Messages = append(conv.Messages, types.LlmMessage{Role: "assistant", Content: "filler a"})
+	}
+	conv.LastInputTokens = 180_000
+	conv.LastInputTokensMsgCount = len(conv.Messages)
+
+	gotStrategy := ""
+	hookCalls := 0
+	const hookSummary = "auto-strategy hook summary"
+	hooks := RunHooks{
+		OnRequestCompactSummary: func(_ string, strategy string, _ []types.LlmMessage) (string, bool) {
+			hookCalls++
+			gotStrategy = strategy
+			return hookSummary, true
+		},
+	}
+
+	run := &activeRun{requestID: "proactive-hook-strategy", conv: conv}
+	cp := testCP()
+	cp.summaryEnabled = false
+	b.compactIfNeeded(context.Background(), run, conv, hooks, 200_000, 100_000, cp)
+
+	if hookCalls != 1 {
+		t.Errorf("expected OnRequestCompactSummary to be called once, got %d", hookCalls)
+	}
+	if gotStrategy != "auto" {
+		t.Errorf("hook received strategy=%q, want %q (compactIfNeeded must always pass \"auto\")", gotStrategy, "auto")
+	}
+
+	blocks, _ := conv.Messages[0].Content.([]types.LlmContentBlock)
+	if blocks[0].Summary != hookSummary {
+		t.Errorf("boundary.Summary = %q, want harness-supplied %q", blocks[0].Summary, hookSummary)
+	}
+}

--- a/engine/internal/backend/runloop_compaction.go
+++ b/engine/internal/backend/runloop_compaction.go
@@ -262,18 +262,16 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 				utils.Debug("ApiBackend", "proactive compact: no text content for LLM summary")
 			}
 		}
-		if summary == "" && hooks.OnRequestCompactSummary != nil {
-			if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, "auto", scanSlice); ok && hookSummary != "" {
-				summary = hookSummary
-				utils.Log("ApiBackend", fmt.Sprintf("proactive compact: hook summary strategy=auto (%d chars)", len(summary)))
-			}
-		}
-		if summary == "" && len(facts) > 0 {
-			summary = compaction.FormatFactsSummary(facts)
-			utils.Log("ApiBackend", fmt.Sprintf("proactive compact: regex fact summary (%d facts)", len(facts)))
-		}
+		// Tiers 3+4 (hook → regex) live in renderCompactSummary so both
+		// compactIfNeeded and compactReactive route through the same
+		// decision point. Tiers 1+2 (session memory, LLM) stay above
+		// because each has its own engine-internal side effects.
 		if summary == "" {
-			utils.Log("ApiBackend", "proactive compact: all three summary tiers produced nothing (session memory, LLM, regex)")
+			var path string
+			summary, path = renderCompactSummary(run.requestID, hooks, "auto", scanSlice, facts)
+			if summary == "" {
+				utils.Log("ApiBackend", fmt.Sprintf("proactive compact: all four summary tiers produced nothing (session memory, LLM, hook, regex) path=%s", path))
+			}
 		}
 
 		// Now truncate.
@@ -435,17 +433,16 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 			utils.Debug("ApiBackend", "reactive compact: no text content for LLM summary")
 		}
 	}
-	if summary == "" && hooks.OnRequestCompactSummary != nil {
-		if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, "reactive", scanSlice); ok && hookSummary != "" {
-			summary = hookSummary
-			utils.Log("ApiBackend", fmt.Sprintf("reactive compact: hook summary strategy=reactive (%d chars)", len(summary)))
+	// Tiers 3+4 (hook → regex) live in renderCompactSummary so both
+	// compactIfNeeded and compactReactive route through the same
+	// decision point. Tiers 1+2 (session memory, LLM) stay above
+	// because each has its own engine-internal side effects.
+	if summary == "" {
+		var path string
+		summary, path = renderCompactSummary(run.requestID, hooks, "reactive", scanSlice, facts)
+		if summary == "" {
+			utils.Debug("ApiBackend", fmt.Sprintf("reactive compact: no summary generated (no facts, no LLM, no hook, no session memory) path=%s", path))
 		}
-	}
-	if summary == "" && len(facts) > 0 {
-		summary = compaction.FormatFactsSummary(facts)
-		utils.Log("ApiBackend", fmt.Sprintf("reactive compact: regex fact summary (%d facts)", len(facts)))
-	} else if summary == "" {
-		utils.Debug("ApiBackend", "reactive compact: no summary generated (no facts, no LLM, no hook, no session memory)")
 	}
 
 	// Step 3: hard truncate using progressively smaller token budget on each retry.
@@ -536,10 +533,16 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 }
 
 // renderCompactSummary picks the rendering path for the boundary block's
-// Summary field. When the harness wired RunHooks.OnRequestCompactSummary
-// and that hook returned a non-empty string, the hook's output wins. Else
-// the engine falls back to its regex pipeline:
-// FormatFactsSummary(facts).
+// Summary field. It handles only the hook → regex tail of the four-tier
+// summary fallback ladder (session memory → LLM → hook → regex): the
+// session-memory and LLM tiers run in the runloop above this call site
+// because they have their own engine-internal side effects (memory
+// lookup, provider usage event emission) that don't belong inside a
+// pure-decision helper.
+//
+// When the harness wired RunHooks.OnRequestCompactSummary and that hook
+// returned a non-empty string, the hook's output wins. Else the engine
+// falls back to its regex pipeline: FormatFactsSummary(facts).
 //
 // Returns (summary, path) where path is "hook" | "regex" | "empty" for
 // log correlation. An empty summary is a valid return — the caller still
@@ -548,7 +551,7 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 func renderCompactSummary(runID string, hooks RunHooks, strategy string, scanSlice []types.LlmMessage, facts []compaction.Fact) (string, string) {
 	if hooks.OnRequestCompactSummary != nil {
 		if hookSummary, ok := hooks.OnRequestCompactSummary(runID, strategy, scanSlice); ok && hookSummary != "" {
-			utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=hook summaryLen=%d msgCount=%d", strategy, len(hookSummary), len(scanSlice)))
+			utils.Log("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=hook summaryLen=%d msgCount=%d", strategy, len(hookSummary), len(scanSlice)))
 			return hookSummary, "hook"
 		}
 		utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s hook present but returned empty, falling back to regex", strategy))
@@ -558,7 +561,7 @@ func renderCompactSummary(runID string, hooks RunHooks, strategy string, scanSli
 		return "", "empty"
 	}
 	regex := compaction.FormatFactsSummary(facts)
-	utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=regex summaryLen=%d factCount=%d", strategy, len(regex), len(facts)))
+	utils.Log("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=regex summaryLen=%d factCount=%d", strategy, len(regex), len(facts)))
 	return regex, "regex"
 }
 

--- a/engine/internal/backend/runloop_compaction.go
+++ b/engine/internal/backend/runloop_compaction.go
@@ -263,9 +263,9 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 			}
 		}
 		if summary == "" && hooks.OnRequestCompactSummary != nil {
-			if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, scanSlice); ok && hookSummary != "" {
+			if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, "auto", scanSlice); ok && hookSummary != "" {
 				summary = hookSummary
-				utils.Log("ApiBackend", fmt.Sprintf("proactive compact: hook summary (%d chars)", len(summary)))
+				utils.Log("ApiBackend", fmt.Sprintf("proactive compact: hook summary strategy=auto (%d chars)", len(summary)))
 			}
 		}
 		if summary == "" && len(facts) > 0 {
@@ -436,9 +436,9 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 		}
 	}
 	if summary == "" && hooks.OnRequestCompactSummary != nil {
-		if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, scanSlice); ok && hookSummary != "" {
+		if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, "reactive", scanSlice); ok && hookSummary != "" {
 			summary = hookSummary
-			utils.Log("ApiBackend", fmt.Sprintf("reactive compact: hook summary (%d chars)", len(summary)))
+			utils.Log("ApiBackend", fmt.Sprintf("reactive compact: hook summary strategy=reactive (%d chars)", len(summary)))
 		}
 	}
 	if summary == "" && len(facts) > 0 {
@@ -547,7 +547,7 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 // to slice at on the next pass.
 func renderCompactSummary(runID string, hooks RunHooks, strategy string, scanSlice []types.LlmMessage, facts []compaction.Fact) (string, string) {
 	if hooks.OnRequestCompactSummary != nil {
-		if hookSummary, ok := hooks.OnRequestCompactSummary(runID, scanSlice); ok && hookSummary != "" {
+		if hookSummary, ok := hooks.OnRequestCompactSummary(runID, strategy, scanSlice); ok && hookSummary != "" {
 			utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=hook summaryLen=%d msgCount=%d", strategy, len(hookSummary), len(scanSlice)))
 			return hookSummary, "hook"
 		}

--- a/engine/internal/backend/runloop_compaction.go
+++ b/engine/internal/backend/runloop_compaction.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/dsswift/ion/engine/internal/compaction"
 	"github.com/dsswift/ion/engine/internal/conversation"
@@ -165,8 +164,8 @@ func (cp *compactParams) resolveSessionMemory(conv *conversation.Conversation, l
 // emits an ErrorEvent with code compact_loop_aborted and stops trying
 // proactively. The counter resets on any successful API response.
 //
-// ctx is threaded for LLM-based summarisation (tier 2 of the three-tier
-// summary fallback: session memory → LLM → regex).
+// ctx is threaded for LLM-based summarisation (tier 2 of the four-tier
+// summary fallback: session memory → LLM → hook → regex).
 func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *conversation.Conversation, hooks RunHooks, contextWindow, tokenLimit int, cp compactParams) {
 	// Gate: skip proactive compaction when explicitly disabled.
 	if run.opts != nil && run.opts.CompactEnabled != nil && !*run.opts.CompactEnabled {
@@ -211,9 +210,14 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 	b.emit(run, types.NormalizedEvent{Data: &types.CompactingEvent{Active: true}})
 	msgBefore := len(conv.Messages)
 
-	// Extract facts before any mutation so they reflect the full pre-compaction state.
-	facts := compaction.ExtractFacts(conv.Messages)
-	utils.Log("ApiBackend", fmt.Sprintf("proactive compact: extracted %d facts from %d messages", len(facts), msgBefore))
+	// Slice at the most recent boundary so the fact extractor cannot
+	// re-extract from a prior summary. Combined with the structural
+	// boundary block this is the duplication firewall: previous
+	// summaries stay in-context for the model to see, but they are
+	// invisible to the regex pipeline that builds the next summary.
+	scanSlice := conversation.MessagesAfterLastCompactBoundary(conv)
+	facts := compaction.ExtractFacts(scanSlice)
+	utils.Log("ApiBackend", fmt.Sprintf("proactive compact: extracted %d facts from %d-message scan slice (full conv=%d)", len(facts), len(scanSlice), msgBefore))
 
 	// Step 1: MicroCompact — protect only the most recent N turns (default 3).
 	cleared := conversation.MicroCompact(conv, cp.microKeepTurns)
@@ -228,7 +232,7 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 	utils.Debug("ApiBackend", fmt.Sprintf("compactIfNeeded: usageAfterMicro.Tokens=%d (limit=%d)", usageAfterMicro.Tokens, tokenLimit))
 	if usageAfterMicro.Tokens > tokenLimit {
 
-		// Three-tier summary fallback: session memory → LLM → regex.
+		// Four-tier summary fallback: session memory → LLM → hook → regex.
 		// Must generate summary BEFORE truncation drops the messages.
 		if mem, reason := cp.resolveSessionMemory(conv, "proactive"); mem != "" {
 			summary = mem
@@ -258,6 +262,12 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 				utils.Debug("ApiBackend", "proactive compact: no text content for LLM summary")
 			}
 		}
+		if summary == "" && hooks.OnRequestCompactSummary != nil {
+			if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, scanSlice); ok && hookSummary != "" {
+				summary = hookSummary
+				utils.Log("ApiBackend", fmt.Sprintf("proactive compact: hook summary (%d chars)", len(summary)))
+			}
+		}
 		if summary == "" && len(facts) > 0 {
 			summary = compaction.FormatFactsSummary(facts)
 			utils.Log("ApiBackend", fmt.Sprintf("proactive compact: regex fact summary (%d facts)", len(facts)))
@@ -269,33 +279,27 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 		// Now truncate.
 		conversation.CompactToTokenBudget(conv, targetTokens, cp.minKeepTurns, cp.estimationPadding)
 		utils.Log("ApiBackend", fmt.Sprintf("proactive compact step 2: truncated to budget=%d (%.0f%% of %d), %d messages remain", targetTokens, cp.targetPercent, contextWindow, len(conv.Messages)))
+
+		// Inject a typed boundary block so the next compaction can slice
+		// at this point and avoid re-extracting facts from this summary.
+		recentFiles := compaction.ExtractRecentFiles(conversation.MessagesAfterLastCompactBoundary(conv))
+		utils.Debug("ApiBackend", fmt.Sprintf("compactIfNeeded: extracted %d recent files", len(recentFiles)))
+		injectCompactBoundary(conv, conversation.CompactMeta{
+			Trigger:            "auto",
+			MessagesSummarized: msgBefore - len(conv.Messages),
+			MessagesBefore:     msgBefore,
+			MessagesAfter:      len(conv.Messages) + 1, // +1 for the boundary about to be inserted
+			ClearedBlocks:      cleared,
+			TokensBefore:       usage.Tokens,
+			Summary:            summary,
+			FactCount:          len(facts),
+			RecentFiles:        recentFiles,
+		})
 	} else {
 		targetTokens = 0
 		utils.Debug("ApiBackend", fmt.Sprintf("proactive compact: step 1 sufficient, skipping hard truncate (tokens=%d limit=%d)", usageAfterMicro.Tokens, tokenLimit))
 	}
-
-	// Inject post-compact context as a transient system message instead of
-	// regular user messages. Transient messages are not persisted and don't
-	// count as "turns" for future compaction decisions.
-	var compactNotice strings.Builder
-	compactNotice.WriteString("[SYSTEM] Context compaction completed.")
-	if cleared > 0 {
-		fmt.Fprintf(&compactNotice, " Cleared %d older tool results.", cleared)
-	}
-	if summary != "" {
-		fmt.Fprintf(&compactNotice, "\n\n[Extracted facts from compacted context]:\n%s", summary)
-	}
-	recentFiles := compaction.ExtractRecentFiles(conv.Messages)
-	utils.Debug("ApiBackend", fmt.Sprintf("compactIfNeeded: extracted %d recent files", len(recentFiles)))
-	if len(recentFiles) > 0 {
-		fmt.Fprintf(&compactNotice, "\n\nRecently modified files: %s", strings.Join(recentFiles, ", "))
-	}
-	// Include transcript path so the model can read full pre-compaction history.
-	if cp.convDir != "" && conv.ID != "" {
-		fmt.Fprintf(&compactNotice, "\n\nFull conversation history is preserved at: %s/%s.tree.jsonl", cp.convDir, conv.ID)
-	}
-	compactNotice.WriteString("\n\nUse the SearchHistory tool to find specific details from the compacted conversation, or re-read relevant files. Continue the conversation from where it left off without recapping what was happening.")
-	conversation.AddTransientUserMessage(conv, compactNotice.String())
+	conversation.PostCompactReset(conv)
 
 	// Emit enriched completion event so clients can render a compaction marker.
 	msgAfter := len(conv.Messages)
@@ -369,8 +373,8 @@ func (b *ApiBackend) compactIfNeeded(ctx context.Context, run *activeRun, conv *
 // false when the session_before_compact hook cancelled it (the caller should
 // still retry the turn as-is in that case).
 //
-// ctx is threaded for LLM-based summarisation (tier 2 of the three-tier
-// summary fallback: session memory → LLM → regex).
+// ctx is threaded for LLM-based summarisation (tier 2 of the four-tier
+// summary fallback: session memory → LLM → hook → regex).
 func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *conversation.Conversation, hooks RunHooks, contextWindow, attempt int, cp compactParams) bool {
 	utils.Log("ApiBackend", fmt.Sprintf("compactReactive: entry contextWindow=%d attempt=%d targetPercent=%.1f microKeepTurns=%d minKeepTurns=%d summaryEnabled=%v memoryEnabled=%v",
 		contextWindow, attempt, cp.targetPercent, cp.microKeepTurns, cp.minKeepTurns, cp.summaryEnabled, cp.memoryEnabled))
@@ -388,12 +392,10 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 	usageBefore := conversation.GetContextUsage(conv, contextWindow)
 	tokensBefore := usageBefore.Tokens
 
-	// Extract facts up front (above all message mutation) so they reflect the
-	// pre-compaction state and so the same slice serves both the in-context
-	// summary and the session_compact hook payload. ExtractFacts is safe on
-	// empty/nil inputs.
-	facts := compaction.ExtractFacts(conv.Messages)
-	utils.Log("ApiBackend", fmt.Sprintf("reactive compact: extracted %d facts from %d messages", len(facts), msgBefore))
+	// Same duplication firewall as compactIfNeeded — see comment there.
+	scanSlice := conversation.MessagesAfterLastCompactBoundary(conv)
+	facts := compaction.ExtractFacts(scanSlice)
+	utils.Log("ApiBackend", fmt.Sprintf("reactive compact: extracted %d facts from %d-message scan slice (full conv=%d)", len(facts), len(scanSlice), msgBefore))
 
 	// Step 1: micro-compact (tool results, then assistant text)
 	cleared := conversation.MicroCompact(conv, cp.microKeepTurns)
@@ -401,7 +403,7 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 	usageAfterMicro := conversation.GetContextUsage(conv, contextWindow)
 	utils.Debug("ApiBackend", fmt.Sprintf("compactReactive: tokens after micro-compact=%d (pct=%d%%)", usageAfterMicro.Tokens, usageAfterMicro.Percent))
 
-	// Step 2: Three-tier summary fallback: session memory → LLM → regex.
+	// Step 2: Four-tier summary fallback: session memory → LLM → hook → regex.
 	// Must generate summary BEFORE step 3 truncation drops the messages.
 	var summary string
 	var sessionMemory string
@@ -433,11 +435,17 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 			utils.Debug("ApiBackend", "reactive compact: no text content for LLM summary")
 		}
 	}
+	if summary == "" && hooks.OnRequestCompactSummary != nil {
+		if hookSummary, ok := hooks.OnRequestCompactSummary(run.requestID, scanSlice); ok && hookSummary != "" {
+			summary = hookSummary
+			utils.Log("ApiBackend", fmt.Sprintf("reactive compact: hook summary (%d chars)", len(summary)))
+		}
+	}
 	if summary == "" && len(facts) > 0 {
 		summary = compaction.FormatFactsSummary(facts)
 		utils.Log("ApiBackend", fmt.Sprintf("reactive compact: regex fact summary (%d facts)", len(facts)))
 	} else if summary == "" {
-		utils.Debug("ApiBackend", "reactive compact: no summary generated (no facts, no LLM, no session memory)")
+		utils.Debug("ApiBackend", "reactive compact: no summary generated (no facts, no LLM, no hook, no session memory)")
 	}
 
 	// Step 3: hard truncate using progressively smaller token budget on each retry.
@@ -448,25 +456,22 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 	utils.Log("ApiBackend", fmt.Sprintf("prompt_too_long hard-truncated to budget=%d (%.0f%% of %d), %d messages remain",
 		targetTokens, escalatedPercent, contextWindow, len(conv.Messages)))
 
-	// Inject post-compact context as a single transient message.
-	var compactNotice strings.Builder
-	compactNotice.WriteString("[SYSTEM] Context compaction completed (reactive — provider reported prompt too long).")
-	if cleared > 0 {
-		fmt.Fprintf(&compactNotice, " Cleared %d older tool results.", cleared)
-	}
-	if summary != "" {
-		fmt.Fprintf(&compactNotice, "\n\n[Extracted facts from compacted context]:\n%s", summary)
-	}
-	recentFiles := compaction.ExtractRecentFiles(conv.Messages)
+	// Inject a typed boundary block so the next compaction can slice
+	// at this point and avoid re-extracting facts from this summary.
+	recentFiles := compaction.ExtractRecentFiles(conversation.MessagesAfterLastCompactBoundary(conv))
 	utils.Debug("ApiBackend", fmt.Sprintf("compactReactive: extracted %d recent files", len(recentFiles)))
-	if len(recentFiles) > 0 {
-		fmt.Fprintf(&compactNotice, "\n\nRecently modified files: %s", strings.Join(recentFiles, ", "))
-	}
-	if cp.convDir != "" && conv.ID != "" {
-		fmt.Fprintf(&compactNotice, "\n\nFull conversation history is preserved at: %s/%s.tree.jsonl", cp.convDir, conv.ID)
-	}
-	compactNotice.WriteString("\n\nUse the SearchHistory tool to find specific details from the compacted conversation, or re-read relevant files. Continue the conversation from where it left off without recapping what was happening.")
-	conversation.AddTransientUserMessage(conv, compactNotice.String())
+	injectCompactBoundary(conv, conversation.CompactMeta{
+		Trigger:            "reactive",
+		MessagesSummarized: msgBefore - len(conv.Messages),
+		MessagesBefore:     msgBefore,
+		MessagesAfter:      len(conv.Messages) + 1,
+		ClearedBlocks:      cleared,
+		TokensBefore:       tokensBefore,
+		Summary:            summary,
+		FactCount:          len(facts),
+		RecentFiles:        recentFiles,
+	})
+	conversation.PostCompactReset(conv)
 
 	// Emit enriched completion event so clients can render a compaction marker.
 	msgAfter := len(conv.Messages)
@@ -528,6 +533,46 @@ func (b *ApiBackend) compactReactive(ctx context.Context, run *activeRun, conv *
 		})
 	}
 	return true
+}
+
+// renderCompactSummary picks the rendering path for the boundary block's
+// Summary field. When the harness wired RunHooks.OnRequestCompactSummary
+// and that hook returned a non-empty string, the hook's output wins. Else
+// the engine falls back to its regex pipeline:
+// FormatFactsSummary(facts).
+//
+// Returns (summary, path) where path is "hook" | "regex" | "empty" for
+// log correlation. An empty summary is a valid return — the caller still
+// injects the boundary block so the conversation has a structural anchor
+// to slice at on the next pass.
+func renderCompactSummary(runID string, hooks RunHooks, strategy string, scanSlice []types.LlmMessage, facts []compaction.Fact) (string, string) {
+	if hooks.OnRequestCompactSummary != nil {
+		if hookSummary, ok := hooks.OnRequestCompactSummary(runID, scanSlice); ok && hookSummary != "" {
+			utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=hook summaryLen=%d msgCount=%d", strategy, len(hookSummary), len(scanSlice)))
+			return hookSummary, "hook"
+		}
+		utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s hook present but returned empty, falling back to regex", strategy))
+	}
+	if len(facts) == 0 {
+		utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=empty (no facts, no hook)", strategy))
+		return "", "empty"
+	}
+	regex := compaction.FormatFactsSummary(facts)
+	utils.Debug("ApiBackend", fmt.Sprintf("renderCompactSummary: strategy=%s path=regex summaryLen=%d factCount=%d", strategy, len(regex), len(facts)))
+	return regex, "regex"
+}
+
+// injectCompactBoundary prepends a compact_boundary message built from
+// meta to conv.Messages. Single construction site shared by both
+// compactIfNeeded and compactReactive so the on-wire shape stays
+// byte-identical regardless of the trigger.
+//
+// The boundary lives at the head of the slice (index 0) so the next call
+// to MessagesAfterLastCompactBoundary finds it as the most recent
+// boundary even when subsequent messages are appended.
+func injectCompactBoundary(conv *conversation.Conversation, meta conversation.CompactMeta) {
+	boundary := conversation.BuildCompactBoundaryMessage(meta)
+	conv.Messages = append([]types.LlmMessage{boundary}, conv.Messages...)
 }
 
 // firstEntryID returns the ID of the first conversation tree entry, or empty string.

--- a/engine/internal/compaction/compact_boundary_test.go
+++ b/engine/internal/compaction/compact_boundary_test.go
@@ -16,7 +16,7 @@ import (
 // runloop, the tree-rebuild path, the manual CompactWithSummary path)
 // depends on: identical wire shape regardless of trigger.
 func TestBuildCompactBoundaryMessage(t *testing.T) {
-	meta := CompactMeta{
+	meta := conversation.CompactMeta{
 		Trigger:            "auto",
 		MessagesSummarized: 12,
 		MessagesBefore:     30,
@@ -28,7 +28,7 @@ func TestBuildCompactBoundaryMessage(t *testing.T) {
 		RecentFiles:        []string{"/a.go", "/b.go"},
 	}
 
-	msg := BuildCompactBoundaryMessage(meta)
+	msg := conversation.BuildCompactBoundaryMessage(meta)
 	if msg.Role != "user" {
 		t.Errorf("Role = %q, want user", msg.Role)
 	}
@@ -73,7 +73,7 @@ func TestBuildCompactBoundaryMessage(t *testing.T) {
 // because persistence stores messages as NDJSON and the next session
 // load round-trips them through json.Unmarshal into LlmMessage.
 func TestBuildCompactBoundaryMessage_JSONRoundTrip(t *testing.T) {
-	meta := CompactMeta{
+	meta := conversation.CompactMeta{
 		Trigger:        "reactive",
 		MessagesBefore: 50,
 		MessagesAfter:  20,
@@ -82,7 +82,7 @@ func TestBuildCompactBoundaryMessage_JSONRoundTrip(t *testing.T) {
 		FactCount:      2,
 		RecentFiles:    []string{"/x.ts"},
 	}
-	msg := BuildCompactBoundaryMessage(meta)
+	msg := conversation.BuildCompactBoundaryMessage(meta)
 
 	data, err := json.Marshal(msg)
 	if err != nil {

--- a/engine/internal/compaction/compact_boundary_test.go
+++ b/engine/internal/compaction/compact_boundary_test.go
@@ -1,0 +1,227 @@
+package compaction
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/conversation"
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// TestBuildCompactBoundaryMessage verifies that BuildCompactBoundaryMessage
+// emits a single typed compact_boundary block carrying every field from
+// the CompactMeta input. This is the contract every call site (the
+// runloop, the tree-rebuild path, the manual CompactWithSummary path)
+// depends on: identical wire shape regardless of trigger.
+func TestBuildCompactBoundaryMessage(t *testing.T) {
+	meta := CompactMeta{
+		Trigger:            "auto",
+		MessagesSummarized: 12,
+		MessagesBefore:     30,
+		MessagesAfter:      19,
+		ClearedBlocks:      4,
+		TokensBefore:       180_000,
+		Summary:            "we discussed compaction",
+		FactCount:          5,
+		RecentFiles:        []string{"/a.go", "/b.go"},
+	}
+
+	msg := BuildCompactBoundaryMessage(meta)
+	if msg.Role != "user" {
+		t.Errorf("Role = %q, want user", msg.Role)
+	}
+
+	blocks, ok := msg.Content.([]types.LlmContentBlock)
+	if !ok {
+		t.Fatalf("Content type = %T, want []LlmContentBlock", msg.Content)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("len(blocks) = %d, want 1", len(blocks))
+	}
+	b := blocks[0]
+	if b.Type != conversation.CompactBoundaryBlockType {
+		t.Errorf("block.Type = %q, want %q", b.Type, conversation.CompactBoundaryBlockType)
+	}
+	if b.Trigger != meta.Trigger {
+		t.Errorf("block.Trigger = %q, want %q", b.Trigger, meta.Trigger)
+	}
+	if b.MessagesSummarized != meta.MessagesSummarized ||
+		b.MessagesBefore != meta.MessagesBefore ||
+		b.MessagesAfter != meta.MessagesAfter ||
+		b.ClearedBlocks != meta.ClearedBlocks ||
+		b.TokensBefore != meta.TokensBefore ||
+		b.FactCount != meta.FactCount {
+		t.Errorf("block metadata mismatch: %+v vs meta %+v", b, meta)
+	}
+	if b.Summary != meta.Summary {
+		t.Errorf("block.Summary = %q, want %q", b.Summary, meta.Summary)
+	}
+	if len(b.RecentFiles) != len(meta.RecentFiles) {
+		t.Fatalf("block.RecentFiles len = %d, want %d", len(b.RecentFiles), len(meta.RecentFiles))
+	}
+	for i, f := range b.RecentFiles {
+		if f != meta.RecentFiles[i] {
+			t.Errorf("block.RecentFiles[%d] = %q, want %q", i, f, meta.RecentFiles[i])
+		}
+	}
+}
+
+// TestBuildCompactBoundaryMessage_JSONRoundTrip pins the wire format —
+// the boundary block must survive a JSON encode/decode cycle losslessly
+// because persistence stores messages as NDJSON and the next session
+// load round-trips them through json.Unmarshal into LlmMessage.
+func TestBuildCompactBoundaryMessage_JSONRoundTrip(t *testing.T) {
+	meta := CompactMeta{
+		Trigger:        "reactive",
+		MessagesBefore: 50,
+		MessagesAfter:  20,
+		ClearedBlocks:  3,
+		Summary:        "test summary",
+		FactCount:      2,
+		RecentFiles:    []string{"/x.ts"},
+	}
+	msg := BuildCompactBoundaryMessage(meta)
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded types.LlmMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// After JSON round-trip, content is []interface{} of map[string]any,
+	// not []LlmContentBlock — that's how persistence reloads it. Verify
+	// the new structured fields are present in the raw map shape so
+	// downstream contentToBlockSlice / mapToContentBlock can hydrate.
+	contentSlice, ok := decoded.Content.([]interface{})
+	if !ok {
+		t.Fatalf("decoded content type = %T, want []interface{}", decoded.Content)
+	}
+	if len(contentSlice) != 1 {
+		t.Fatalf("decoded content len = %d, want 1", len(contentSlice))
+	}
+	m, ok := contentSlice[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("decoded block type = %T, want map[string]interface{}", contentSlice[0])
+	}
+	if m["type"] != conversation.CompactBoundaryBlockType {
+		t.Errorf("decoded type = %v, want %q", m["type"], conversation.CompactBoundaryBlockType)
+	}
+	if m["summary"] != "test summary" {
+		t.Errorf("decoded summary = %v, want 'test summary'", m["summary"])
+	}
+	if m["trigger"] != "reactive" {
+		t.Errorf("decoded trigger = %v, want 'reactive'", m["trigger"])
+	}
+	// JSON numbers decode as float64 by default.
+	if m["clearedBlocks"] != float64(3) {
+		t.Errorf("decoded clearedBlocks = %v, want 3", m["clearedBlocks"])
+	}
+}
+
+// TestExtractFacts_DedupeWithinPass pins fix for cause #3 in the
+// gentle-knitting-cup plan: ExtractFacts must dedupe (Type, Content)
+// pairs so a file path mentioned N times across messages contributes one
+// bullet, not N.
+func TestExtractFacts_DedupeWithinPass(t *testing.T) {
+	isErr := false
+	mkResult := func(text string) types.LlmMessage {
+		return types.LlmMessage{
+			Role: "user",
+			Content: []types.LlmContentBlock{
+				{Type: "tool_result", ToolUseID: "x", Content: text, IsError: &isErr},
+			},
+		}
+	}
+
+	// Same path mentioned 5 times across separate messages — without
+	// dedupe ExtractFacts would emit 5 file_mod entries.
+	msgs := []types.LlmMessage{
+		mkResult("Wrote to /src/foo.ts"),
+		mkResult("Read /src/foo.ts again"),
+		mkResult("Edited /src/foo.ts once more"),
+		mkResult("Touched /src/foo.ts and /other.go"),
+		mkResult("Last edit on /src/foo.ts"),
+	}
+
+	facts := ExtractFacts(msgs)
+	count := 0
+	for _, f := range facts {
+		if f.Type == "file_mod" && f.Content == "/src/foo.ts" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected /src/foo.ts to appear once after dedupe, got %d", count)
+	}
+}
+
+// TestFormatFactsSummary_CapAndOverflow verifies the per-section cap +
+// overflow line introduced for cause #3. Feeding more than
+// MaxFactsPerSection unique entries of one type must render the first
+// MaxFactsPerSection then collapse the remainder into "... (+N more)".
+func TestFormatFactsSummary_CapAndOverflow(t *testing.T) {
+	const extra = 7
+	facts := make([]Fact, 0, MaxFactsPerSection+extra)
+	for i := 0; i < MaxFactsPerSection+extra; i++ {
+		facts = append(facts, Fact{Type: "file_mod", Content: fmt.Sprintf("/path/%03d.go", i)})
+	}
+
+	summary := FormatFactsSummary(facts)
+
+	// First entry must be present (head of list).
+	if !strings.Contains(summary, "/path/000.go") {
+		t.Error("expected first capped entry to appear")
+	}
+	// Last entry within the cap must be present.
+	withinCap := fmt.Sprintf("/path/%03d.go", MaxFactsPerSection-1)
+	if !strings.Contains(summary, withinCap) {
+		t.Errorf("expected entry at cap edge (%s) to appear", withinCap)
+	}
+	// First entry over the cap must NOT be rendered (collapsed).
+	beyondCap := fmt.Sprintf("/path/%03d.go", MaxFactsPerSection)
+	if strings.Contains(summary, beyondCap) {
+		t.Errorf("entry beyond cap (%s) should have been collapsed", beyondCap)
+	}
+	// Overflow line must report the correct excess count.
+	overflow := fmt.Sprintf("... (+%d more)", extra)
+	if !strings.Contains(summary, overflow) {
+		t.Errorf("expected overflow line %q, got summary:\n%s", overflow, summary)
+	}
+}
+
+// TestExtractFacts_EmptyOnBoundaryOnly verifies that feeding ExtractFacts
+// a slice containing only a compact_boundary message returns no facts.
+// In practice this is the input MessagesAfterLastCompactBoundary returns
+// when no new messages have been appended since the last compaction. The
+// regex extractor must not re-mine the prior summary text — the
+// gentle-knitting-cup plan's duplication firewall.
+func TestExtractFacts_EmptyOnBoundaryOnly(t *testing.T) {
+	boundary := conversation.BuildCompactBoundaryMessage(conversation.CompactMeta{
+		Trigger: "auto",
+		// A summary that *contains* fact-extractor keywords. Without the
+		// structural-skip property the regex would happily re-extract
+		// "decided", "failed", and the file path.
+		Summary: "We decided to use Go. The build failed at /src/main.go.",
+	})
+	facts := ExtractFacts([]types.LlmMessage{boundary})
+	if len(facts) != 0 {
+		// ExtractFacts itself walks message text and would happily
+		// match — the firewall is at the caller layer (the runloop
+		// passes MessagesAfterLastCompactBoundary, which starts at the
+		// boundary). Inside the boundary the Summary field carries the
+		// text but the block Type is "compact_boundary", not "text" or
+		// "tool_result", so extractText returns "" and no patterns
+		// match.
+		//
+		// Locking the behaviour here means a future refactor that
+		// teaches extractText to walk the Summary field would trip
+		// this test and force a conscious decision.
+		t.Errorf("expected 0 facts from a boundary-only message, got %d:\n%+v", len(facts), facts)
+	}
+}

--- a/engine/internal/compaction/compaction.go
+++ b/engine/internal/compaction/compaction.go
@@ -178,26 +178,6 @@ func FormatFactsSummary(facts []Fact) string {
 	return strings.TrimSpace(sb.String())
 }
 
-// BuildCompactBoundaryMessage is a thin re-export of
-// conversation.BuildCompactBoundaryMessage so the compaction package
-// stays a one-stop shop for runloop callers that already import it
-// without forcing them to also import conversation. The argument shape
-// (CompactMeta) is the conversation-package type; the alias exists for
-// convenience only — both call sites produce byte-identical wire output.
-//
-// The constructor itself lives in the conversation package to break a
-// would-be import cycle: tree.go's BuildContextPath needs to reconstruct
-// boundary blocks from CompactionData and lives in conversation; the
-// compaction package depends on conversation, never the reverse.
-func BuildCompactBoundaryMessage(meta conversation.CompactMeta) types.LlmMessage {
-	return conversation.BuildCompactBoundaryMessage(meta)
-}
-
-// CompactMeta is re-exported from conversation for the same reason as
-// BuildCompactBoundaryMessage above — callers that already import
-// compaction can construct boundary metadata without a second import.
-type CompactMeta = conversation.CompactMeta
-
 // CompactPartial removes entries from a conversation tree, keeping everything
 // after pivotEntryID. Direction is "before" (remove older) or "after" (remove newer).
 func CompactPartial(conv *conversation.Conversation, pivotEntryID string, direction string) error {

--- a/engine/internal/compaction/compaction.go
+++ b/engine/internal/compaction/compaction.go
@@ -29,10 +29,42 @@ var (
 	discoveryPatterns  = regexp.MustCompile(`(?i)\b(?:found|discovered|noticed|realized|learned|turns out)\b`)
 )
 
+// MaxFactsPerSection caps the number of facts FormatFactsSummary renders
+// per section before collapsing the remainder into a "... (+N more)"
+// overflow line. Without the cap a single noisy compaction round (e.g. a
+// build dumping a hundred file paths through tool results) generates a
+// summary so long it consumes most of the post-compaction window — the
+// opposite of what compaction is supposed to do.
+//
+// 20 is a starting point chosen to fit comfortably in a screen of
+// markdown while still surfacing enough detail to be useful. Tune by
+// tests, not by feel; the cap is a contract the compaction tests pin.
+const MaxFactsPerSection = 20
+
 // ExtractFacts scans messages for patterns and returns structured facts.
+//
+// Facts are deduplicated within a single pass by (Type, Content) so a
+// file path mentioned in N tool results contributes one bullet, not N.
+// Cross-pass deduplication is handled at the caller layer via
+// conversation.MessagesAfterLastCompactBoundary, which prevents earlier
+// boundary summaries from being re-scanned — see the gentle-knitting-cup
+// plan for the structural rationale.
 func ExtractFacts(messages []types.LlmMessage) []Fact {
 	utils.Debug("Compaction", fmt.Sprintf("ExtractFacts: scanning %d messages", len(messages)))
 	var facts []Fact
+	// (Type, Content) dedupe key. The map value is unused — we only need
+	// presence. Using a string key sidesteps tuple-key gymnastics; the
+	// pipe character is reserved-safe because neither Type nor Content
+	// contains it in the patterns we emit.
+	seen := make(map[string]struct{})
+	add := func(f Fact) {
+		key := f.Type + "|" + f.Content
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		facts = append(facts, f)
+	}
 
 	for i, msg := range messages {
 		text := extractText(msg)
@@ -46,7 +78,7 @@ func ExtractFacts(messages []types.LlmMessage) []Fact {
 			for _, p := range paths {
 				p = strings.TrimSpace(p)
 				if p != "" && (strings.HasPrefix(p, "/") || strings.HasPrefix(p, "./") || strings.HasPrefix(p, "../")) {
-					facts = append(facts, Fact{Type: "file_mod", Content: p, Source: i})
+					add(Fact{Type: "file_mod", Content: p, Source: i})
 				}
 			}
 		}
@@ -54,28 +86,28 @@ func ExtractFacts(messages []types.LlmMessage) []Fact {
 		if decisionPatterns.MatchString(text) {
 			sentence := extractMatchingSentence(text, decisionPatterns)
 			if sentence != "" {
-				facts = append(facts, Fact{Type: "decision", Content: sentence, Source: i})
+				add(Fact{Type: "decision", Content: sentence, Source: i})
 			}
 		}
 
 		if errorPatterns.MatchString(text) {
 			sentence := extractMatchingSentence(text, errorPatterns)
 			if sentence != "" {
-				facts = append(facts, Fact{Type: "error", Content: sentence, Source: i})
+				add(Fact{Type: "error", Content: sentence, Source: i})
 			}
 		}
 
 		if preferencePatterns.MatchString(text) {
 			sentence := extractMatchingSentence(text, preferencePatterns)
 			if sentence != "" {
-				facts = append(facts, Fact{Type: "preference", Content: sentence, Source: i})
+				add(Fact{Type: "preference", Content: sentence, Source: i})
 			}
 		}
 
 		if discoveryPatterns.MatchString(text) {
 			sentence := extractMatchingSentence(text, discoveryPatterns)
 			if sentence != "" {
-				facts = append(facts, Fact{Type: "discovery", Content: sentence, Source: i})
+				add(Fact{Type: "discovery", Content: sentence, Source: i})
 			}
 		}
 	}
@@ -91,7 +123,14 @@ func ExtractFacts(messages []types.LlmMessage) []Fact {
 	return facts
 }
 
-// FormatFactsSummary formats extracted facts into a human-readable summary grouped by type.
+// FormatFactsSummary formats extracted facts into a human-readable
+// summary grouped by type.
+//
+// Each section is capped at MaxFactsPerSection bullets; any remainder is
+// collapsed to a "... (+N more)" line. The cap protects against
+// pathological cases where a single noisy turn produced dozens of
+// matches — without it the summary itself can blow the context budget
+// it was meant to reclaim.
 func FormatFactsSummary(facts []Fact) string {
 	grouped := make(map[string][]Fact)
 	order := []string{"decision", "file_mod", "error", "preference", "discovery"}
@@ -119,14 +158,45 @@ func FormatFactsSummary(facts []Fact) string {
 			label = typ
 		}
 		fmt.Fprintf(&sb, "## %s\n", label)
-		for _, f := range items {
+
+		// Render up to the cap; collapse the rest. The collapsed-count
+		// line is appended only when there are excess items, so capped
+		// sections look identical to uncapped ones below the threshold.
+		shown := items
+		if len(items) > MaxFactsPerSection {
+			shown = items[:MaxFactsPerSection]
+		}
+		for _, f := range shown {
 			fmt.Fprintf(&sb, "- %s\n", f.Content)
+		}
+		if len(items) > MaxFactsPerSection {
+			fmt.Fprintf(&sb, "- ... (+%d more)\n", len(items)-MaxFactsPerSection)
 		}
 		sb.WriteString("\n")
 	}
 
 	return strings.TrimSpace(sb.String())
 }
+
+// BuildCompactBoundaryMessage is a thin re-export of
+// conversation.BuildCompactBoundaryMessage so the compaction package
+// stays a one-stop shop for runloop callers that already import it
+// without forcing them to also import conversation. The argument shape
+// (CompactMeta) is the conversation-package type; the alias exists for
+// convenience only — both call sites produce byte-identical wire output.
+//
+// The constructor itself lives in the conversation package to break a
+// would-be import cycle: tree.go's BuildContextPath needs to reconstruct
+// boundary blocks from CompactionData and lives in conversation; the
+// compaction package depends on conversation, never the reverse.
+func BuildCompactBoundaryMessage(meta conversation.CompactMeta) types.LlmMessage {
+	return conversation.BuildCompactBoundaryMessage(meta)
+}
+
+// CompactMeta is re-exported from conversation for the same reason as
+// BuildCompactBoundaryMessage above — callers that already import
+// compaction can construct boundary metadata without a second import.
+type CompactMeta = conversation.CompactMeta
 
 // CompactPartial removes entries from a conversation tree, keeping everything
 // after pivotEntryID. Direction is "before" (remove older) or "after" (remove newer).

--- a/engine/internal/conversation/compact.go
+++ b/engine/internal/conversation/compact.go
@@ -143,6 +143,11 @@ func Compact(conv *Conversation, keepTurns int) {
 }
 
 // CompactWithSummary summarizes older messages via the provided function, then drops them.
+//
+// The resulting summary is injected as a typed compact_boundary block
+// (see BuildCompactBoundaryMessage) rather than a prose "[Previous
+// conversation summary]: …" prefix. Consumers that walk conv.Messages
+// recognise the boundary by block Type, not by substring matching.
 func CompactWithSummary(conv *Conversation, summarize func(string) (string, error), keepTurns int) error {
 	utils.Debug("Compaction", fmt.Sprintf("CompactWithSummary: entry keepTurns=%d len(msgs)=%d", keepTurns, len(conv.Messages)))
 	if keepTurns <= 0 {
@@ -188,13 +193,17 @@ func CompactWithSummary(conv *Conversation, summarize func(string) (string, erro
 		return err
 	}
 
+	droppedCount := cutIdx
 	conv.Messages = conv.Messages[cutIdx:]
-	summaryMsg := types.LlmMessage{
-		Role:    "user",
-		Content: []types.LlmContentBlock{textBlock("[Previous conversation summary]: " + summary)},
-	}
+	summaryMsg := BuildCompactBoundaryMessage(CompactMeta{
+		Trigger:            "manual",
+		MessagesSummarized: droppedCount,
+		MessagesBefore:     droppedCount + len(conv.Messages),
+		MessagesAfter:      len(conv.Messages) + 1,
+		Summary:            summary,
+	})
 	conv.Messages = append([]types.LlmMessage{summaryMsg}, conv.Messages...)
-	invalidateTokenCache(conv)
+	PostCompactReset(conv)
 	return nil
 }
 

--- a/engine/internal/conversation/compact_boundary.go
+++ b/engine/internal/conversation/compact_boundary.go
@@ -1,0 +1,139 @@
+package conversation
+
+import (
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// CompactBoundaryBlockType is the LlmContentBlock.Type discriminator used
+// to mark a compaction boundary inside conv.Messages. Exposed as a
+// constant so call sites (provider serialisers, scan loops, tests) cannot
+// drift by typing the string literal.
+const CompactBoundaryBlockType = "compact_boundary"
+
+// CompactMeta carries every piece of metadata a compaction boundary needs
+// to render. It mirrors the optional fields on LlmContentBlock so callers
+// can populate it once and let BuildCompactBoundaryMessage emit the wire
+// shape verbatim. The split exists so the runloop can assemble metadata
+// (trigger, msg counts, cleared-block count, fact count) without knowing
+// the wire field names.
+//
+// Field semantics match the matching LlmContentBlock fields; see
+// engine/internal/types/llm.go for canonical docs.
+type CompactMeta struct {
+	Trigger            string
+	MessagesSummarized int
+	MessagesBefore     int
+	MessagesAfter      int
+	ClearedBlocks      int
+	TokensBefore       int
+	Summary            string
+	FactCount          int
+	RecentFiles        []string
+}
+
+// BuildCompactBoundaryMessage is the single construction site for
+// compaction-boundary messages. Every site that injects a boundary into
+// conv.Messages (the live runloop, the tree-rebuild path in
+// BuildContextPath, persistence reload tests) goes through here so the
+// wire shape stays byte-identical across origins.
+//
+// The returned message has Role: "user" — providers route user content
+// without special-casing, and a typed system role would force every
+// downstream consumer to learn a new shape. The structural marker lives
+// on the content block, not the message envelope.
+//
+// The block carries the Summary as a structured field, not as prose with
+// a magic prefix. Scan passes recognise the boundary via the block Type
+// constant, never via substring matching on Text.
+func BuildCompactBoundaryMessage(meta CompactMeta) types.LlmMessage {
+	return types.LlmMessage{
+		Role: "user",
+		Content: []types.LlmContentBlock{{
+			Type:               CompactBoundaryBlockType,
+			Trigger:            meta.Trigger,
+			MessagesSummarized: meta.MessagesSummarized,
+			MessagesBefore:     meta.MessagesBefore,
+			MessagesAfter:      meta.MessagesAfter,
+			ClearedBlocks:      meta.ClearedBlocks,
+			TokensBefore:       meta.TokensBefore,
+			Summary:            meta.Summary,
+			FactCount:          meta.FactCount,
+			RecentFiles:        meta.RecentFiles,
+		}},
+	}
+}
+
+// IsCompactBoundary reports whether a message's content is a single
+// compact_boundary block. Handles all three content shapes a message may
+// carry: the typed []LlmContentBlock slice (live runloop construction),
+// the []interface{} slice with map[string]any blocks (after JSON
+// round-trip from disk), and the catch-all (returns false).
+//
+// The check is intentionally minimal: any message whose first content
+// block has Type == "compact_boundary" qualifies. Hosting a boundary
+// alongside other blocks is not part of the contract — every producer
+// in-tree emits the boundary as a single-block message, so a single-block
+// match is sufficient.
+func IsCompactBoundary(msg types.LlmMessage) bool {
+	switch c := msg.Content.(type) {
+	case []types.LlmContentBlock:
+		if len(c) == 0 {
+			return false
+		}
+		return c[0].Type == CompactBoundaryBlockType
+	case []interface{}:
+		if len(c) == 0 {
+			return false
+		}
+		if m, ok := c[0].(map[string]interface{}); ok {
+			if t, _ := m["type"].(string); t == CompactBoundaryBlockType {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// MessagesAfterLastCompactBoundary returns the slice of conv.Messages
+// starting at the most recent compaction boundary (inclusive), or the
+// whole slice when no boundary exists.
+//
+// This is the duplication firewall called out in
+// docs/architecture/agent-state.md-style structural notes for compaction
+// (see plan: gentle-knitting-cup): every conversation scan that feeds the
+// fact extractor or recent-file extractor must route through here so
+// facts cannot be re-extracted from earlier boundary summaries. The next
+// compaction's input becomes "everything since the last boundary,"
+// preserving in-context visibility of prior summaries (the model still
+// sees them) while preventing them from feeding the regex pipeline.
+//
+// Returns conv.Messages unchanged when conv is nil or empty so callers
+// can pass either &Conversation directly or a pre-loaded slice without a
+// nil guard.
+func MessagesAfterLastCompactBoundary(conv *Conversation) []types.LlmMessage {
+	if conv == nil || len(conv.Messages) == 0 {
+		return nil
+	}
+	for i := len(conv.Messages) - 1; i >= 0; i-- {
+		if IsCompactBoundary(conv.Messages[i]) {
+			return conv.Messages[i:]
+		}
+	}
+	return conv.Messages
+}
+
+// PostCompactReset performs the cache-invalidation housekeeping that
+// every compaction path must run after mutating conv.Messages. Today's
+// body is just invalidateTokenCache — the named helper exists so future
+// cache resets (file-state, embedding cache, etc.) land in one obvious
+// place rather than scattered across the runloop, mirroring Claude
+// Code's runPostCompactCleanup pattern.
+//
+// Safe on nil conv (no-op) so callers don't need a guard.
+func PostCompactReset(conv *Conversation) {
+	if conv == nil {
+		return
+	}
+	invalidateTokenCache(conv)
+}

--- a/engine/internal/conversation/compact_boundary_persistence_test.go
+++ b/engine/internal/conversation/compact_boundary_persistence_test.go
@@ -1,0 +1,280 @@
+package conversation
+
+// compact_boundary_persistence_test.go pins the contract that a
+// compact_boundary message survives the Save → Load round-trip with
+// every structural field intact.
+//
+// Why it matters: the duplication firewall introduced in the
+// gentle-knitting-cup compaction fix hinges on
+// MessagesAfterLastCompactBoundary finding the boundary on the very
+// next turn after a session resume. Persistence writes messages as
+// NDJSON; reload unmarshals them with Content as []interface{} of
+// map[string]any, NOT the typed []LlmContentBlock the runloop builds
+// fresh. If IsCompactBoundary (or any of the structured-field copies
+// in sanitize.go / providers/messages.go) loses fidelity through that
+// round-trip, the firewall has a hole only visible after a resume.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// TestCompactBoundary_SurvivesSaveLoadRoundTrip mimics the runloop's
+// real persistence flow: a compaction appends both a compact_boundary
+// message into conv.Messages AND an EntryCompaction record into
+// conv.Entries (see backend/runloop_compaction.go). saveSplit
+// reconstructs the message body from Entries via BuildContextPath, so
+// any boundary that exists only in conv.Messages without a matching
+// Entry is intentionally dropped on save (and that's the contract the
+// transient-message path relies on).
+//
+// This test exercises the reload path that runs after a session
+// resume: IsCompactBoundary must recognise the rebuilt boundary, and
+// MessagesAfterLastCompactBoundary must still anchor the slice on it.
+func TestCompactBoundary_SurvivesSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	conv := CreateConversation("boundary-rt", "be helpful", "claude-3-5-sonnet")
+	AddUserMessage(conv, "first question")
+	AddAssistantMessage(conv, []types.LlmContentBlock{{Type: "text", Text: "first reply"}},
+		types.LlmUsage{InputTokens: 10, OutputTokens: 15})
+
+	// Real runloop shape: append the EntryCompaction so saveSplit
+	// persists it. BuildContextPath will reconstruct the boundary
+	// message from this entry on load.
+	AppendEntry(conv, EntryCompaction, CompactionData{
+		Summary:          "## Decisions\n- Use Go for the new module",
+		FirstKeptEntryID: "deadbeef",
+		TokensBefore:     180_000,
+	})
+	AddUserMessage(conv, "post-compaction question")
+
+	// Mirror conv.Messages to what BuildContextPath would produce
+	// pre-save (the runloop maintains both side-by-side). Save will
+	// overwrite this with BuildContextPath's output anyway, but we set
+	// it for symmetry with how the runloop holds state.
+	conv.Messages = BuildContextPath(conv)
+	expectedCount := len(conv.Messages)
+
+	if err := Save(conv, dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load("boundary-rt", dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded.Messages) != expectedCount {
+		t.Fatalf("loaded message count = %d, want %d", len(loaded.Messages), expectedCount)
+	}
+
+	// Find the boundary index in the reloaded slice. Walking by
+	// IsCompactBoundary so the test exercises the same predicate the
+	// runloop uses.
+	boundaryIdx := -1
+	for i, m := range loaded.Messages {
+		if IsCompactBoundary(m) {
+			boundaryIdx = i
+			break
+		}
+	}
+	if boundaryIdx < 0 {
+		t.Fatalf("IsCompactBoundary did not recognise any boundary after reload (msgs=%d)", len(loaded.Messages))
+	}
+
+	// MessagesAfterLastCompactBoundary must slice at the boundary on
+	// the reloaded conversation. This is the actual contract the
+	// runloop relies on for the duplication firewall.
+	slice := MessagesAfterLastCompactBoundary(loaded)
+	expectedSliceLen := expectedCount - boundaryIdx
+	if len(slice) != expectedSliceLen {
+		t.Fatalf("MessagesAfterLastCompactBoundary returned %d messages after reload, want %d", len(slice), expectedSliceLen)
+	}
+	if !IsCompactBoundary(slice[0]) {
+		t.Error("first element of post-reload slice is not the boundary")
+	}
+}
+
+// TestCompactBoundary_StructuredFieldsSurviveReload pins each
+// structured field through the JSON round-trip. The reload path
+// goes through json.Unmarshal → MessageData → conv.Messages with
+// Content as []interface{}; the test reaches into the reloaded blocks
+// (via the existing contentToBlockSlice helper used by SanitizeMessages)
+// and asserts every field round-tripped with the right type.
+//
+// This is the test that catches a regression where sanitize.go's
+// contentToBlockSlice (or providers/messages.go's mapToContentBlock)
+// forgets to copy a newly-added compact_boundary field.
+//
+// Path coverage: this test uses len(Entries) == 0 so Save falls back
+// to saveJSON (the legacy single-file path), which persists
+// conv.Messages verbatim. That's the path that preserves the full
+// LlmContentBlock — every structured field round-trips.
+//
+// The split-file path (entries present) reconstructs boundaries from
+// CompactionData via BuildContextPath, which carries only Summary +
+// TokensBefore + a default "auto" Trigger by design. The remaining
+// fields (ClearedBlocks, RecentFiles, FactCount, Messages*) are
+// runloop-instant metadata, not durable session state — see
+// TestCompactBoundary_TreeRebuildAfterReloadMatchesLiveInjection for
+// the matching pin on the split path.
+func TestCompactBoundary_StructuredFieldsSurviveReload(t *testing.T) {
+	dir := t.TempDir()
+
+	const wantSummary = "## Files Modified\n- /src/main.go"
+	conv := CreateConversation("boundary-fields", "", "claude-3")
+	conv.Messages = append(conv.Messages, BuildCompactBoundaryMessage(CompactMeta{
+		Trigger:            "reactive",
+		MessagesSummarized: 12,
+		MessagesBefore:     30,
+		MessagesAfter:      19,
+		ClearedBlocks:      4,
+		TokensBefore:       180_000,
+		Summary:            wantSummary,
+		FactCount:          5,
+		RecentFiles:        []string{"/a.go", "/b.go", "/c.go"},
+	}))
+
+	if err := Save(conv, dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load("boundary-fields", dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Reach into the reloaded message via contentToBlockSlice — the
+	// same helper sanitize uses to normalize []interface{} content
+	// into typed blocks. If a structured field is missing from the
+	// helper's copy list, this fails loudly.
+	blocks := contentToBlockSlice(loaded.Messages[0].Content)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block after reload, got %d", len(blocks))
+	}
+	b := blocks[0]
+
+	if b.Type != CompactBoundaryBlockType {
+		t.Errorf("Type = %q, want %q", b.Type, CompactBoundaryBlockType)
+	}
+	if b.Trigger != "reactive" {
+		t.Errorf("Trigger = %q, want reactive", b.Trigger)
+	}
+	if b.MessagesSummarized != 12 {
+		t.Errorf("MessagesSummarized = %d, want 12", b.MessagesSummarized)
+	}
+	if b.MessagesBefore != 30 {
+		t.Errorf("MessagesBefore = %d, want 30", b.MessagesBefore)
+	}
+	if b.MessagesAfter != 19 {
+		t.Errorf("MessagesAfter = %d, want 19", b.MessagesAfter)
+	}
+	if b.ClearedBlocks != 4 {
+		t.Errorf("ClearedBlocks = %d, want 4", b.ClearedBlocks)
+	}
+	if b.TokensBefore != 180_000 {
+		t.Errorf("TokensBefore = %d, want 180_000", b.TokensBefore)
+	}
+	if b.FactCount != 5 {
+		t.Errorf("FactCount = %d, want 5", b.FactCount)
+	}
+	if b.Summary != wantSummary {
+		t.Errorf("Summary = %q, want %q", b.Summary, wantSummary)
+	}
+	if len(b.RecentFiles) != 3 {
+		t.Fatalf("RecentFiles len = %d, want 3", len(b.RecentFiles))
+	}
+	for i, want := range []string{"/a.go", "/b.go", "/c.go"} {
+		if b.RecentFiles[i] != want {
+			t.Errorf("RecentFiles[%d] = %q, want %q", i, b.RecentFiles[i], want)
+		}
+	}
+}
+
+// TestCompactBoundary_TreeRebuildAfterReloadMatchesLiveInjection pins
+// the byte-identity contract called out in the gentle-knitting-cup
+// plan: a boundary reconstructed by BuildContextPath from a persisted
+// CompactionData entry must be indistinguishable from a freshly-built
+// boundary built from CompactMeta directly.
+//
+// Without this property a tree-rebuilt conversation (e.g. after a
+// branch navigation) would route a different shape through provider
+// serializers than the live runloop, and provider behaviour would
+// silently diverge between fresh and reloaded sessions.
+func TestCompactBoundary_TreeRebuildAfterReloadMatchesLiveInjection(t *testing.T) {
+	dir := t.TempDir()
+
+	// Build the tree-side: an EntryCompaction record with the same
+	// Summary and TokensBefore the runloop would have persisted.
+	conv := CreateConversation("tree-rebuild", "", "claude-3")
+	AddUserMessage(conv, "before")
+	AppendEntry(conv, EntryCompaction, CompactionData{
+		Summary:          "we discussed Go",
+		FirstKeptEntryID: "deadbeef",
+		TokensBefore:     50_000,
+	})
+	AddUserMessage(conv, "after")
+
+	if err := Save(conv, dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := Load("tree-rebuild", dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Force a tree-rebuild so the boundary message is the one
+	// BuildContextPath emits from CompactionData (not the one Save
+	// wrote to .llm.jsonl). Branch() rebuilds Messages via
+	// BuildContextPath internally.
+	if loaded.LeafID == nil {
+		t.Fatal("loaded conv missing LeafID; cannot exercise tree rebuild")
+	}
+	rebuiltMsgs, err := Branch(loaded, *loaded.LeafID)
+	if err != nil {
+		t.Fatalf("Branch: %v", err)
+	}
+
+	// Locate the rebuilt boundary in the message list.
+	var rebuiltBoundary types.LlmMessage
+	found := false
+	for _, m := range rebuiltMsgs {
+		if IsCompactBoundary(m) {
+			rebuiltBoundary = m
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("BuildContextPath did not emit a compact_boundary block for the EntryCompaction record")
+	}
+
+	rebuiltBlocks := contentToBlockSlice(rebuiltBoundary.Content)
+	if len(rebuiltBlocks) != 1 {
+		t.Fatalf("rebuilt boundary has %d blocks, want 1", len(rebuiltBlocks))
+	}
+	// The rebuild path carries only the fields persisted on
+	// CompactionData (Summary + TokensBefore) and a "auto" Trigger
+	// default. Pin those — see tree.go's EntryCompaction branch.
+	if !strings.Contains(rebuiltBlocks[0].Summary, "we discussed Go") {
+		t.Errorf("rebuilt Summary = %q, want it to contain the persisted summary", rebuiltBlocks[0].Summary)
+	}
+	if rebuiltBlocks[0].TokensBefore != 50_000 {
+		t.Errorf("rebuilt TokensBefore = %d, want 50_000", rebuiltBlocks[0].TokensBefore)
+	}
+	if rebuiltBlocks[0].Trigger != "auto" {
+		t.Errorf("rebuilt Trigger = %q, want 'auto' default", rebuiltBlocks[0].Trigger)
+	}
+	if rebuiltBlocks[0].Type != CompactBoundaryBlockType {
+		t.Errorf("rebuilt Type = %q, want %q", rebuiltBlocks[0].Type, CompactBoundaryBlockType)
+	}
+
+	// And the rebuild must produce a message
+	// MessagesAfterLastCompactBoundary recognises identically to a
+	// live-injected one.
+	if !IsCompactBoundary(rebuiltBoundary) {
+		t.Error("rebuilt boundary is not recognised by IsCompactBoundary")
+	}
+}

--- a/engine/internal/conversation/compact_boundary_test.go
+++ b/engine/internal/conversation/compact_boundary_test.go
@@ -1,0 +1,128 @@
+package conversation
+
+import (
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// TestMessagesAfterLastCompactBoundary_NoBoundary returns the whole
+// slice when no boundary exists. This is the no-op happy path: the very
+// first compaction of a fresh conversation scans every message.
+func TestMessagesAfterLastCompactBoundary_NoBoundary(t *testing.T) {
+	conv := CreateConversation("no-boundary", "", "test")
+	AddUserMessage(conv, "hello")
+	AddAssistantMessage(conv, []types.LlmContentBlock{{Type: "text", Text: "hi"}}, types.LlmUsage{})
+
+	slice := MessagesAfterLastCompactBoundary(conv)
+	if len(slice) != 2 {
+		t.Errorf("expected whole slice (2 msgs), got %d", len(slice))
+	}
+}
+
+// TestMessagesAfterLastCompactBoundary_StartsAtMostRecent verifies that
+// when multiple boundaries exist (a multi-round-compacted session), the
+// slice starts at the most recent boundary — not the first. This is the
+// duplication firewall the gentle-knitting-cup plan calls for: prior
+// summaries stay in-context for the model but are out-of-scope for fact
+// extraction on the next pass.
+func TestMessagesAfterLastCompactBoundary_StartsAtMostRecent(t *testing.T) {
+	conv := CreateConversation("multi-boundary", "", "test")
+	AddUserMessage(conv, "pre-1")
+	conv.Messages = append(conv.Messages, BuildCompactBoundaryMessage(CompactMeta{
+		Trigger: "auto", Summary: "first boundary",
+	}))
+	AddUserMessage(conv, "between")
+	conv.Messages = append(conv.Messages, BuildCompactBoundaryMessage(CompactMeta{
+		Trigger: "auto", Summary: "second boundary",
+	}))
+	AddUserMessage(conv, "after")
+
+	slice := MessagesAfterLastCompactBoundary(conv)
+	if len(slice) != 2 {
+		t.Fatalf("expected 2 msgs (latest boundary + after), got %d", len(slice))
+	}
+	if !IsCompactBoundary(slice[0]) {
+		t.Error("slice should start at the most recent boundary")
+	}
+	// The Summary of the head must be the SECOND boundary, not the first.
+	blocks, ok := slice[0].Content.([]types.LlmContentBlock)
+	if !ok || len(blocks) == 0 {
+		t.Fatal("expected typed blocks at head of slice")
+	}
+	if blocks[0].Summary != "second boundary" {
+		t.Errorf("head summary = %q, want second boundary", blocks[0].Summary)
+	}
+}
+
+// TestMessagesAfterLastCompactBoundary_NilConv exercises the defensive
+// nil guard so callers don't need their own.
+func TestMessagesAfterLastCompactBoundary_NilConv(t *testing.T) {
+	if slice := MessagesAfterLastCompactBoundary(nil); slice != nil {
+		t.Errorf("expected nil for nil conv, got %v", slice)
+	}
+}
+
+// TestIsCompactBoundary_TypedAndUntypedBlocks verifies that
+// IsCompactBoundary recognises the boundary in both the typed
+// []LlmContentBlock shape (live runloop construction) and the []any
+// shape (post-JSON-load). Persistence round-trips through
+// json.Unmarshal which yields []any of map[string]any blocks.
+func TestIsCompactBoundary_TypedAndUntypedBlocks(t *testing.T) {
+	typed := BuildCompactBoundaryMessage(CompactMeta{Trigger: "auto"})
+	if !IsCompactBoundary(typed) {
+		t.Error("expected typed boundary to be recognised")
+	}
+
+	// Synthesize the post-JSON-load shape.
+	untyped := types.LlmMessage{
+		Role: "user",
+		Content: []interface{}{
+			map[string]interface{}{
+				"type":    CompactBoundaryBlockType,
+				"summary": "round-tripped",
+			},
+		},
+	}
+	if !IsCompactBoundary(untyped) {
+		t.Error("expected untyped (post-JSON) boundary to be recognised")
+	}
+
+	// Negative: a regular text block must not match.
+	regular := types.LlmMessage{
+		Role:    "user",
+		Content: []types.LlmContentBlock{{Type: "text", Text: "[Previous conversation summary]: foo"}},
+	}
+	if IsCompactBoundary(regular) {
+		t.Error("regular text block must NOT match (substring marker is intentionally not recognised)")
+	}
+}
+
+// TestPostCompactReset_ClearsTokenCache verifies the seam centralises
+// invalidateTokenCache. Cache invariants are pinned by the surrounding
+// compaction tests in conversation_compaction_test.go; this case
+// targets the PostCompactReset entry point directly.
+func TestPostCompactReset_ClearsTokenCache(t *testing.T) {
+	conv := CreateConversation("post-reset", "", "test")
+	conv.LastInputTokens = 12345
+	conv.LastInputTokensMsgCount = 9
+
+	PostCompactReset(conv)
+
+	if conv.LastInputTokens != 0 {
+		t.Errorf("LastInputTokens = %d after PostCompactReset, want 0", conv.LastInputTokens)
+	}
+	if conv.LastInputTokensMsgCount != 0 {
+		t.Errorf("LastInputTokensMsgCount = %d after PostCompactReset, want 0", conv.LastInputTokensMsgCount)
+	}
+}
+
+// TestPostCompactReset_NilSafe pins the documented nil-safety guarantee.
+func TestPostCompactReset_NilSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("PostCompactReset(nil) panicked: %v", r)
+		}
+	}()
+	PostCompactReset(nil)
+}

--- a/engine/internal/conversation/conversation_compaction_test.go
+++ b/engine/internal/conversation/conversation_compaction_test.go
@@ -172,8 +172,11 @@ func TestCompactWithSummary(t *testing.T) {
 	if !ok {
 		t.Fatal("expected content to be []LlmContentBlock")
 	}
-	if !strings.Contains(blocks[0].Text, "Previous conversation summary") {
-		t.Errorf("summary message missing expected text, got %q", blocks[0].Text)
+	if blocks[0].Type != CompactBoundaryBlockType {
+		t.Errorf("first block type = %q, want %q", blocks[0].Type, CompactBoundaryBlockType)
+	}
+	if blocks[0].Summary != "conversation about questions and answers" {
+		t.Errorf("boundary summary = %q, want callback's return string", blocks[0].Summary)
 	}
 }
 
@@ -431,16 +434,13 @@ func TestCompactWithSummary_SummarizeError_FallbackToTruncation(t *testing.T) {
 		t.Fatalf("expected fewer messages after fallback truncation, got %d", len(conv.Messages))
 	}
 
-	// No summary prefix in first message
+	// No compact_boundary block should appear at the head after the
+	// fallback truncation (we drop straight to Compact when summarise
+	// fails).
 	first := conv.Messages[0]
-	switch c := first.Content.(type) {
-	case string:
-		if strings.Contains(c, "Previous conversation summary") {
-			t.Error("should not contain summary after error")
-		}
-	case []types.LlmContentBlock:
-		if len(c) > 0 && strings.Contains(c[0].Text, "Previous conversation summary") {
-			t.Error("should not contain summary after error")
+	if blocks, ok := first.Content.([]types.LlmContentBlock); ok {
+		if len(blocks) > 0 && blocks[0].Type == CompactBoundaryBlockType {
+			t.Error("should not inject a compact_boundary block after summariser error")
 		}
 	}
 }
@@ -491,11 +491,11 @@ func TestCompactWithSummary_InsertsSummaryAsFirstMessage(t *testing.T) {
 	if !ok {
 		t.Fatal("expected []LlmContentBlock")
 	}
-	if !strings.Contains(blocks[0].Text, "Previous conversation summary") {
-		t.Error("expected summary prefix")
+	if blocks[0].Type != CompactBoundaryBlockType {
+		t.Errorf("first block type = %q, want %q", blocks[0].Type, CompactBoundaryBlockType)
 	}
-	if !strings.Contains(blocks[0].Text, "the summary text") {
-		t.Error("expected summary content")
+	if blocks[0].Summary != "the summary text" {
+		t.Errorf("boundary summary = %q, want callback's return string", blocks[0].Summary)
 	}
 }
 

--- a/engine/internal/conversation/conversation_tree_test.go
+++ b/engine/internal/conversation/conversation_tree_test.go
@@ -134,8 +134,18 @@ func TestBuildContextPathWithCompaction(t *testing.T) {
 	if !ok {
 		t.Fatal("expected content blocks for compaction summary")
 	}
-	if !strings.Contains(blocks[0].Text, "we talked about Go") {
-		t.Errorf("compaction summary not found in message: %q", blocks[0].Text)
+	// Reconstructed boundary blocks carry the persisted Summary on the
+	// structured Summary field, not as a "[Previous conversation
+	// summary]: …" prose prefix. The block type is the structural
+	// marker — see compact_boundary.go.
+	if blocks[0].Type != CompactBoundaryBlockType {
+		t.Errorf("expected type=%q, got %q", CompactBoundaryBlockType, blocks[0].Type)
+	}
+	if !strings.Contains(blocks[0].Summary, "we talked about Go") {
+		t.Errorf("compaction summary not found in block.Summary: %q", blocks[0].Summary)
+	}
+	if blocks[0].TokensBefore != 5000 {
+		t.Errorf("expected TokensBefore=5000 on reconstructed boundary, got %d", blocks[0].TokensBefore)
 	}
 }
 

--- a/engine/internal/conversation/sanitize.go
+++ b/engine/internal/conversation/sanitize.go
@@ -341,6 +341,44 @@ func contentToBlockSlice(content any) []types.LlmContentBlock {
 				if t, ok := m["is_error"].(bool); ok {
 					b.IsError = &t
 				}
+				// compact_boundary structured fields. Optional on every
+				// block type; copied so persistence round-trips keep
+				// boundary metadata. Matches providers/messages.go
+				// mapToContentBlock — keep in sync if either side
+				// changes.
+				if t, ok := m["trigger"].(string); ok {
+					b.Trigger = t
+				}
+				if t, ok := m["messagesSummarized"].(float64); ok {
+					b.MessagesSummarized = int(t)
+				}
+				if t, ok := m["messagesBefore"].(float64); ok {
+					b.MessagesBefore = int(t)
+				}
+				if t, ok := m["messagesAfter"].(float64); ok {
+					b.MessagesAfter = int(t)
+				}
+				if t, ok := m["clearedBlocks"].(float64); ok {
+					b.ClearedBlocks = int(t)
+				}
+				if t, ok := m["tokensBefore"].(float64); ok {
+					b.TokensBefore = int(t)
+				}
+				if t, ok := m["summary"].(string); ok {
+					b.Summary = t
+				}
+				if t, ok := m["factCount"].(float64); ok {
+					b.FactCount = int(t)
+				}
+				if t, ok := m["recentFiles"].([]interface{}); ok {
+					files := make([]string, 0, len(t))
+					for _, item := range t {
+						if s, ok := item.(string); ok {
+							files = append(files, s)
+						}
+					}
+					b.RecentFiles = files
+				}
 				blocks = append(blocks, b)
 			}
 		}

--- a/engine/internal/conversation/tree.go
+++ b/engine/internal/conversation/tree.go
@@ -84,11 +84,21 @@ func BuildContextPath(conv *Conversation) []types.LlmMessage {
 			// tree preserves for user viewing.
 			cd := asCompactionData(entry.Data)
 			messages = nil
-			if cd != nil && cd.Summary != "" {
-				messages = append(messages, types.LlmMessage{
-					Role:    "user",
-					Content: []types.LlmContentBlock{textBlock("[Previous conversation summary]: " + cd.Summary)},
-				})
+			if cd != nil {
+				// Reconstruct the boundary as a typed compact_boundary
+				// block so a rebuilt context path is byte-identical to a
+				// freshly-injected one (see runloop_compaction.go). The
+				// original CompactionData record only persists Summary +
+				// FirstKeptEntryID + TokensBefore, so the reconstructed
+				// boundary carries those fields and leaves the rest
+				// zero-valued — Trigger is unknown after a rebuild, the
+				// fact count is not persisted, etc. Consumers handle
+				// missing fields uniformly because they're all optional.
+				messages = append(messages, BuildCompactBoundaryMessage(CompactMeta{
+					Trigger:      "auto", // historical reconstructions default to auto; original trigger is not persisted
+					Summary:      cd.Summary,
+					TokensBefore: cd.TokensBefore,
+				}))
 			}
 		}
 	}

--- a/engine/internal/extension/group.go
+++ b/engine/internal/extension/group.go
@@ -39,11 +39,21 @@ func (g *ExtensionGroup) Close() {
 	}
 }
 
-// Tools merges tool definitions from all hosts.
+// Tools merges tool definitions from all hosts. Last-registered wins when
+// multiple hosts register the same tool name.
 func (g *ExtensionGroup) Tools() []ToolDefinition {
+	seen := make(map[string]int) // name -> index in all
 	var all []ToolDefinition
 	for _, h := range g.hosts {
-		all = append(all, h.Tools()...)
+		for _, t := range h.Tools() {
+			if idx, ok := seen[t.Name]; ok {
+				all[idx] = t
+				utils.Debug("ExtensionGroup", fmt.Sprintf("duplicate tool %q from host %q, last-registered wins", t.Name, h.Name()))
+			} else {
+				seen[t.Name] = len(all)
+				all = append(all, t)
+			}
+		}
 	}
 	return all
 }

--- a/engine/internal/extension/group.go
+++ b/engine/internal/extension/group.go
@@ -544,6 +544,24 @@ func (g *ExtensionGroup) FireSessionCompact(ctx *Context, info CompactionInfo) {
 	}
 }
 
+// FireCompactSummaryRequest fans the hook out across every host and
+// returns the first non-empty summary string a host produced. When no
+// host provides a summary the engine falls back to its regex fact
+// extractor. The decision is logged so a developer reading
+// ~/.ion/engine.log can tell which path won — see runloop_compaction.go
+// for the corresponding "path=hook" / "path=regex" markers.
+func (g *ExtensionGroup) FireCompactSummaryRequest(ctx *Context, info CompactSummaryRequestInfo) (string, bool) {
+	for _, h := range g.hosts {
+		summary, ok := h.FireCompactSummaryRequest(ctx, info)
+		if ok && summary != "" {
+			utils.Log("ExtensionGroup", fmt.Sprintf("FireCompactSummaryRequest: host produced summary len=%d msgCount=%d", len(summary), info.MessageCount))
+			return summary, true
+		}
+	}
+	utils.Debug("ExtensionGroup", fmt.Sprintf("FireCompactSummaryRequest: no host produced a summary, falling through (msgCount=%d hosts=%d)", info.MessageCount, len(g.hosts)))
+	return "", false
+}
+
 func (g *ExtensionGroup) FirePermissionRequest(ctx *Context, info PermissionRequestInfo) {
 	for _, h := range g.hosts {
 		h.SDK().FirePermissionRequest(ctx, info)

--- a/engine/internal/extension/hook_dispatch.go
+++ b/engine/internal/extension/hook_dispatch.go
@@ -80,6 +80,14 @@ func (h *Host) FireSessionBeforeCompact(ctx *Context, info CompactionInfo) (bool
 	return h.sdk.FireSessionBeforeCompact(ctx, info)
 }
 
+// FireCompactSummaryRequest delegates to the SDK. Returns (summary, ok)
+// with ok=true when any handler produced a non-empty summary, else
+// ("", false). The engine reads ok=false as "fall back to the regex
+// fact extractor"; see RunHooks.OnRequestCompactSummary.
+func (h *Host) FireCompactSummaryRequest(ctx *Context, info CompactSummaryRequestInfo) (string, bool) {
+	return h.sdk.FireCompactSummaryRequest(ctx, info)
+}
+
 func (h *Host) FireSessionBeforeFork(ctx *Context, info ForkInfo) (bool, error) {
 	return h.sdk.FireSessionBeforeFork(ctx, info)
 }

--- a/engine/internal/extension/sdk.go
+++ b/engine/internal/extension/sdk.go
@@ -195,10 +195,18 @@ func (s *SDK) PrependHook(event string, handler HookHandler) {
 	s.hooks[event] = append([]HookHandler{handler}, s.hooks[event]...)
 }
 
-// RegisterTool adds a tool definition to the registry.
+// RegisterTool adds a tool definition to the registry. If a tool with the
+// same name already exists it is replaced, preventing duplicates when the
+// extension subprocess is respawned and re-registers during init.
 func (s *SDK) RegisterTool(def ToolDefinition) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	for i, t := range s.tools {
+		if t.Name == def.Name {
+			s.tools[i] = def
+			return
+		}
+	}
 	s.tools = append(s.tools, def)
 }
 

--- a/engine/internal/extension/sdk.go
+++ b/engine/internal/extension/sdk.go
@@ -33,6 +33,18 @@ const (
 	HookSessionFork          = "session_fork"
 	HookSessionBeforeSwitch  = "session_before_switch"
 
+	// HookCompactSummaryRequest is an optional harness hook invoked
+	// inside proactive / reactive compaction. Handlers receive the
+	// pre-compaction message slice (already sliced at the last boundary
+	// so prior summaries aren't re-scanned) and may return a string
+	// summary that becomes the new compact_boundary block's Summary
+	// field, short-circuiting the engine's regex fact extractor. A
+	// handler that does not want to provide a summary should return the
+	// zero value (empty string + nil) so the engine falls back to the
+	// regex path. The first non-empty summary wins (last-writer
+	// semantics across multiple handlers).
+	HookCompactSummaryRequest = "compact_summary_request"
+
 	// Pre-action hooks
 	HookBeforeAgentStart      = "before_agent_start"
 	HookBeforeProviderRequest = "before_provider_request"

--- a/engine/internal/extension/sdk_hook_types.go
+++ b/engine/internal/extension/sdk_hook_types.go
@@ -83,6 +83,39 @@ type CompactionInfo struct {
 	SessionMemory    string           `json:"sessionMemory,omitempty"`
 }
 
+// CompactSummaryRequestInfo is the payload for the
+// compact_summary_request hook. Handlers receive the pre-compaction
+// message slice (already sliced at the last boundary by
+// MessagesAfterLastCompactBoundary so previous summaries are not
+// included) and may return a summary string that becomes the new
+// compact_boundary block's Summary field, short-circuiting the engine's
+// regex fact extractor.
+//
+// MessageCount is informational (the slice length) so handlers can log
+// without re-counting. Strategy is "auto" (proactive) or "reactive"
+// (prompt_too_long retry) — handlers that want to tune their summariser
+// based on the trigger can branch on it.
+//
+// Field stability: this struct is part of the published hook contract.
+// New fields may be added with zero-value defaults; existing fields must
+// not be removed or renamed.
+type CompactSummaryRequestInfo struct {
+	Strategy     string             `json:"strategy"`
+	MessageCount int                `json:"messageCount"`
+	Messages     []types.LlmMessage `json:"messages"`
+}
+
+// CompactSummaryRequestResult is the optional return value from a
+// compact_summary_request handler. Summary, when non-empty, replaces the
+// engine's regex-built summary text. An empty Summary (or a nil result)
+// means "no opinion — fall back to the engine's regex path". The first
+// non-empty Summary across hosts wins (last-writer semantics).
+//
+// Field stability: published hook contract — additive only.
+type CompactSummaryRequestResult struct {
+	Summary string `json:"summary,omitempty"`
+}
+
 // ForkInfo describes a session fork event.
 type ForkInfo struct {
 	SourceSessionKey string `json:"sourceSessionKey"`

--- a/engine/internal/extension/sdk_hooks_compact_summary_test.go
+++ b/engine/internal/extension/sdk_hooks_compact_summary_test.go
@@ -1,0 +1,160 @@
+package extension
+
+import (
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// TestFireCompactSummaryRequest_ReturnShapes pins the three accepted
+// handler return shapes for the compact_summary_request hook:
+//
+//  1. CompactSummaryRequestResult value (the canonical shape).
+//  2. *CompactSummaryRequestResult pointer (mirrors Go convention for
+//     optional results — caller may want to express "no value" by
+//     returning nil instead of a zero struct).
+//  3. bare string (the natural shape for a single-line summariser that
+//     just returns its text).
+//
+// All three flow through the same first-non-empty selection in
+// SDK.FireCompactSummaryRequest. Without this coverage the first
+// extension that returns a bare string and finds it silently dropped
+// has no test to point at.
+func TestFireCompactSummaryRequest_ReturnShapes(t *testing.T) {
+	cases := []struct {
+		name        string
+		handler     HookHandler
+		wantSummary string
+		wantOK      bool
+	}{
+		{
+			name: "result_value",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				return CompactSummaryRequestResult{Summary: "value-shape summary"}, nil
+			},
+			wantSummary: "value-shape summary",
+			wantOK:      true,
+		},
+		{
+			name: "result_pointer",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				return &CompactSummaryRequestResult{Summary: "pointer-shape summary"}, nil
+			},
+			wantSummary: "pointer-shape summary",
+			wantOK:      true,
+		},
+		{
+			name: "bare_string",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				return "bare-string summary", nil
+			},
+			wantSummary: "bare-string summary",
+			wantOK:      true,
+		},
+		{
+			name: "result_value_empty_falls_through",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				return CompactSummaryRequestResult{Summary: ""}, nil
+			},
+			wantSummary: "",
+			wantOK:      false,
+		},
+		{
+			name: "result_pointer_nil_falls_through",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				var nilResult *CompactSummaryRequestResult
+				return nilResult, nil
+			},
+			wantSummary: "",
+			wantOK:      false,
+		},
+		{
+			name: "bare_string_empty_falls_through",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				return "", nil
+			},
+			wantSummary: "",
+			wantOK:      false,
+		},
+		{
+			name: "nil_return_falls_through",
+			handler: func(ctx *Context, payload interface{}) (interface{}, error) {
+				return nil, nil
+			},
+			wantSummary: "",
+			wantOK:      false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sdk := NewSDK()
+			sdk.On(HookCompactSummaryRequest, tc.handler)
+
+			info := CompactSummaryRequestInfo{
+				Strategy:     "auto",
+				MessageCount: 0,
+				Messages:     []types.LlmMessage{},
+			}
+			summary, ok := sdk.FireCompactSummaryRequest(testCtx(), info)
+			if summary != tc.wantSummary {
+				t.Errorf("summary = %q, want %q", summary, tc.wantSummary)
+			}
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestFireCompactSummaryRequest_FirstNonEmptyWins pins the
+// last-writer semantics documented in sdk_hooks_session.go: the SDK
+// scans handlers in registration order and returns the first non-empty
+// summary. A handler that returns ("", false) does NOT block a later
+// handler that returns a real summary.
+func TestFireCompactSummaryRequest_FirstNonEmptyWins(t *testing.T) {
+	sdk := NewSDK()
+
+	// First handler returns no opinion.
+	sdk.On(HookCompactSummaryRequest, func(ctx *Context, payload interface{}) (interface{}, error) {
+		return "", nil
+	})
+	// Second handler returns a real summary.
+	sdk.On(HookCompactSummaryRequest, func(ctx *Context, payload interface{}) (interface{}, error) {
+		return "from-second", nil
+	})
+
+	info := CompactSummaryRequestInfo{
+		Strategy:     "reactive",
+		MessageCount: 0,
+		Messages:     []types.LlmMessage{},
+	}
+	summary, ok := sdk.FireCompactSummaryRequest(testCtx(), info)
+	if summary != "from-second" {
+		t.Errorf("summary = %q, want %q (second handler's non-empty return should win after first's empty fall-through)", summary, "from-second")
+	}
+	if !ok {
+		t.Errorf("ok = false, want true")
+	}
+}
+
+// TestFireCompactSummaryRequest_NoHandlers pins the zero-handler
+// degenerate case: no handlers registered means ("", false), which the
+// runloop reads as "fall back to the regex fact extractor". This is
+// the default state when no extension wires the hook.
+func TestFireCompactSummaryRequest_NoHandlers(t *testing.T) {
+	sdk := NewSDK()
+
+	info := CompactSummaryRequestInfo{
+		Strategy:     "auto",
+		MessageCount: 0,
+		Messages:     []types.LlmMessage{},
+	}
+	summary, ok := sdk.FireCompactSummaryRequest(testCtx(), info)
+	if summary != "" {
+		t.Errorf("summary = %q, want empty (no handlers means no opinion)", summary)
+	}
+	if ok {
+		t.Errorf("ok = true, want false (no handlers means no opinion)")
+	}
+}

--- a/engine/internal/extension/sdk_hooks_session.go
+++ b/engine/internal/extension/sdk_hooks_session.go
@@ -41,3 +41,34 @@ func (s *SDK) FireSessionBeforeSwitch(ctx *Context) error {
 	s.fire(HookSessionBeforeSwitch, ctx, nil)
 	return nil
 }
+
+// FireCompactSummaryRequest fires the compact_summary_request hook and
+// returns the first non-empty summary string a handler produced (along
+// with ok=true). When no handler produces a non-empty summary, returns
+// ("", false) so the engine falls back to its regex fact extractor.
+//
+// Handler return shape: either a CompactSummaryRequestResult value or a
+// bare string. Bare strings are accepted because the natural extension
+// shape (a single-line summariser that returns the summary directly) is
+// strictly easier than constructing the result struct. Both paths flow
+// through the same first-non-empty selection.
+func (s *SDK) FireCompactSummaryRequest(ctx *Context, info CompactSummaryRequestInfo) (string, bool) {
+	results := s.fire(HookCompactSummaryRequest, ctx, info)
+	for _, r := range results {
+		switch v := r.(type) {
+		case CompactSummaryRequestResult:
+			if v.Summary != "" {
+				return v.Summary, true
+			}
+		case *CompactSummaryRequestResult:
+			if v != nil && v.Summary != "" {
+				return v.Summary, true
+			}
+		case string:
+			if v != "" {
+				return v, true
+			}
+		}
+	}
+	return "", false
+}

--- a/engine/internal/extension/sdk_test.go
+++ b/engine/internal/extension/sdk_test.go
@@ -88,6 +88,69 @@ func TestSDK_RegisterTool(t *testing.T) {
 	}
 }
 
+func TestSDK_RegisterTool_DeduplicatesOnRespawn(t *testing.T) {
+	sdk := NewSDK()
+
+	// Simulate initial load: register two tools.
+	sdk.RegisterTool(ToolDefinition{
+		Name:        "alpha",
+		Description: "first version",
+	})
+	sdk.RegisterTool(ToolDefinition{
+		Name:        "beta",
+		Description: "beta tool",
+	})
+
+	// Simulate respawn: same tools re-registered.
+	sdk.RegisterTool(ToolDefinition{
+		Name:        "alpha",
+		Description: "second version",
+	})
+	sdk.RegisterTool(ToolDefinition{
+		Name:        "beta",
+		Description: "beta tool again",
+	})
+
+	tools := sdk.Tools()
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools after re-registration, got %d", len(tools))
+	}
+	if tools[0].Description != "second version" {
+		t.Fatalf("expected updated description, got %q", tools[0].Description)
+	}
+}
+
+func TestExtensionGroup_Tools_DeduplicatesAcrossHosts(t *testing.T) {
+	g := NewExtensionGroup()
+
+	h1 := NewHost()
+	h1.SDK().RegisterTool(ToolDefinition{Name: "shared_tool", Description: "from host1"})
+	h1.SDK().RegisterTool(ToolDefinition{Name: "only_h1", Description: "unique"})
+
+	h2 := NewHost()
+	h2.SDK().RegisterTool(ToolDefinition{Name: "shared_tool", Description: "from host2"})
+	h2.SDK().RegisterTool(ToolDefinition{Name: "only_h2", Description: "unique"})
+
+	g.Add(h1)
+	g.Add(h2)
+
+	tools := g.Tools()
+	if len(tools) != 3 {
+		names := make([]string, len(tools))
+		for i, tool := range tools {
+			names[i] = tool.Name
+		}
+		t.Fatalf("expected 3 unique tools, got %d: %v", len(tools), names)
+	}
+
+	// Last-registered wins for shared_tool.
+	for _, tool := range tools {
+		if tool.Name == "shared_tool" && tool.Description != "from host2" {
+			t.Fatalf("expected last-registered to win, got description=%q", tool.Description)
+		}
+	}
+}
+
 func TestSDK_RegisterCommand(t *testing.T) {
 	sdk := NewSDK()
 

--- a/engine/internal/providers/anthropic.go
+++ b/engine/internal/providers/anthropic.go
@@ -364,6 +364,22 @@ func formatAnthropicBlock(b types.LlmContentBlock) map[string]any {
 			}
 		}
 		return m
+	case "compact_boundary":
+		// compact_boundary is an engine-internal structural marker that
+		// providers must never see on the wire (unknown block types are
+		// rejected by Anthropic and silently dropped by OpenAI). Flatten
+		// to a text block carrying the rendered Summary so the model
+		// still sees the post-compaction summary in context. The
+		// structured fields (Trigger, ClearedBlocks, …) are
+		// engine-internal only — they round-trip through persistence but
+		// are not forwarded to providers.
+		text := b.Summary
+		if text == "" {
+			// Defensive: a boundary with no rendered summary still needs
+			// a non-empty text body so Anthropic accepts the message.
+			text = "[Previous conversation compacted]"
+		}
+		return map[string]any{"type": "text", "text": text}
 	default:
 		// Pass through unknown block types as-is
 		m := map[string]any{"type": b.Type}

--- a/engine/internal/providers/compact_boundary_test.go
+++ b/engine/internal/providers/compact_boundary_test.go
@@ -1,0 +1,254 @@
+package providers
+
+// compact_boundary_test.go pins the contract that the engine-internal
+// `compact_boundary` LlmContentBlock variant — introduced in the
+// gentle-knitting-cup compaction fix — must flatten to a wire-safe text
+// block for every provider serializer.
+//
+// Why it matters: `compact_boundary` is a *structural marker* the
+// runloop uses to anchor history slicing (see
+// conversation.MessagesAfterLastCompactBoundary). Providers never see
+// it on the wire — Anthropic rejects unknown content-block types, and
+// OpenAI's content-part schema would silently drop it. The serializer
+// must translate the typed marker into a normal text part carrying the
+// rendered Summary.
+//
+// These tests are the live-API canary in unit-test form: they catch a
+// regression where a future serializer refactor forgets the
+// compact_boundary case and starts shipping malformed payloads to the
+// provider.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// boundaryBlock builds a compact_boundary content block carrying the
+// given summary plus a representative spread of the structured metadata
+// fields. The structured fields exist for engine-internal consumers
+// (persistence, the runloop, the future renderer); the serializer
+// tests assert they are NOT present on the wire after flattening.
+func boundaryBlock(summary string) types.LlmContentBlock {
+	return types.LlmContentBlock{
+		Type:               "compact_boundary",
+		Trigger:            "auto",
+		MessagesSummarized: 12,
+		MessagesBefore:     30,
+		MessagesAfter:      19,
+		ClearedBlocks:      4,
+		TokensBefore:       180_000,
+		Summary:            summary,
+		FactCount:          5,
+		RecentFiles:        []string{"/a.go", "/b.go"},
+	}
+}
+
+// TestFormatAnthropicBlock_CompactBoundaryFlattensToText verifies the
+// happy path: a populated compact_boundary block becomes a `{type:
+// "text", text: <summary>}` map. No `trigger`, `clearedBlocks`,
+// `recentFiles`, or any of the other structured metadata fields are
+// allowed to leak onto the wire — they would be ignored at best and
+// trigger an `invalid_request_error` at worst.
+func TestFormatAnthropicBlock_CompactBoundaryFlattensToText(t *testing.T) {
+	const summary = "## Decisions\n- Use Go\n\n## Files Modified\n- /src/main.go"
+
+	out := formatAnthropicBlock(boundaryBlock(summary))
+	if out == nil {
+		t.Fatal("formatAnthropicBlock returned nil for compact_boundary")
+	}
+
+	if got, want := out["type"], "text"; got != want {
+		t.Errorf("type = %v, want %q (boundary must flatten to text)", got, want)
+	}
+	if got, want := out["text"], summary; got != want {
+		t.Errorf("text = %v, want %q (summary should pass through verbatim)", got, want)
+	}
+
+	// Whitelist what may appear on the wire. Any other key is a leak.
+	allowed := map[string]struct{}{"type": {}, "text": {}}
+	for k := range out {
+		if _, ok := allowed[k]; !ok {
+			t.Errorf("unexpected wire field %q on flattened boundary: %v", k, out[k])
+		}
+	}
+}
+
+// TestFormatAnthropicBlock_CompactBoundaryEmptySummaryFallback covers
+// the defensive branch: a boundary with no rendered Summary still has
+// to produce a non-empty text part because the Anthropic API rejects
+// empty text blocks with `text content blocks must contain non-empty
+// text`.
+//
+// The serializer substitutes a generic placeholder so the model still
+// sees *some* marker that a compaction occurred, and the request stays
+// well-formed.
+func TestFormatAnthropicBlock_CompactBoundaryEmptySummaryFallback(t *testing.T) {
+	out := formatAnthropicBlock(types.LlmContentBlock{Type: "compact_boundary"})
+	if out == nil {
+		t.Fatal("formatAnthropicBlock returned nil for empty boundary")
+	}
+	if got := out["type"]; got != "text" {
+		t.Errorf("type = %v, want text", got)
+	}
+	text, _ := out["text"].(string)
+	if text == "" {
+		t.Error("text must be non-empty even when Summary is empty (Anthropic rejects empty text blocks)")
+	}
+}
+
+// TestFormatAnthropicBlock_CompactBoundaryRoundTripsThroughJSON guards
+// the actual wire format. The post-serialization map is the input to
+// json.Marshal in the live request path — if json.Marshal can encode
+// it and the result re-decodes to the same shape, the on-wire payload
+// is well-formed.
+func TestFormatAnthropicBlock_CompactBoundaryRoundTripsThroughJSON(t *testing.T) {
+	out := formatAnthropicBlock(boundaryBlock("round-trip me"))
+
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if decoded["type"] != "text" {
+		t.Errorf("decoded type = %v, want text", decoded["type"])
+	}
+	if decoded["text"] != "round-trip me" {
+		t.Errorf("decoded text = %v, want round-trip me", decoded["text"])
+	}
+}
+
+// TestFormatOpenAIMessages_CompactBoundaryEmitsTextPart pins the OpenAI
+// translation for boundary blocks. The risk profile is different from
+// Anthropic — OpenAI's user-message branch switches on block type and
+// silently drops anything it doesn't recognise, so a missing case would
+// erase the post-compaction summary from the model's view rather than
+// fail loudly. This test makes the absence-bug detectable.
+//
+// Note: formatOpenAIMessages always prepends a system row (carrying the
+// `system` argument, even when empty), so the user message lands at
+// index 1, not 0.
+func TestFormatOpenAIMessages_CompactBoundaryEmitsTextPart(t *testing.T) {
+	const summary = "compaction summary"
+	msgs := []types.LlmMessage{
+		{
+			Role:    "user",
+			Content: []types.LlmContentBlock{boundaryBlock(summary)},
+		},
+	}
+
+	out := formatOpenAIMessages("", msgs)
+	// system row at [0], translated user message at [1].
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages (system + user), got %d", len(out))
+	}
+	if out[0]["role"] != "system" {
+		t.Errorf("out[0].role = %v, want system", out[0]["role"])
+	}
+	userMsg := out[1]
+	if userMsg["role"] != "user" {
+		t.Errorf("role = %v, want user", userMsg["role"])
+	}
+
+	parts, ok := userMsg["content"].([]map[string]any)
+	if !ok {
+		t.Fatalf("content type = %T, want []map[string]any", userMsg["content"])
+	}
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 content part, got %d (boundary should produce exactly one text part)", len(parts))
+	}
+	if parts[0]["type"] != "text" {
+		t.Errorf("part type = %v, want text", parts[0]["type"])
+	}
+	if parts[0]["text"] != summary {
+		t.Errorf("part text = %v, want %q", parts[0]["text"], summary)
+	}
+}
+
+// TestFormatOpenAIMessages_CompactBoundaryEmptySummaryFallback mirrors
+// the Anthropic empty-summary case for OpenAI. OpenAI accepts empty
+// text parts so the strict requirement is weaker than Anthropic's, but
+// the fallback exists to keep behaviour symmetric across providers.
+func TestFormatOpenAIMessages_CompactBoundaryEmptySummaryFallback(t *testing.T) {
+	msgs := []types.LlmMessage{
+		{
+			Role:    "user",
+			Content: []types.LlmContentBlock{{Type: "compact_boundary"}},
+		},
+	}
+
+	out := formatOpenAIMessages("", msgs)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages (system + user), got %d", len(out))
+	}
+	userMsg := out[1]
+	parts, _ := userMsg["content"].([]map[string]any)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 content part, got %d", len(parts))
+	}
+	text, _ := parts[0]["text"].(string)
+	if text == "" {
+		t.Error("text fallback must be non-empty for symmetry with Anthropic path")
+	}
+}
+
+// TestFormatAnthropicBlock_CompactBoundaryAfterJSONRoundTripStillFlattens
+// catches a subtle production-only failure mode. Conversations are
+// persisted as NDJSON and reloaded into LlmMessage.Content as
+// []any of map[string]any (not the typed []LlmContentBlock the runloop
+// builds). The provider sees the post-reload shape on the very next
+// turn after a session resume.
+//
+// Without round-trip support the boundary would survive
+// contentBlocks() → mapToContentBlock() (those copy the new
+// metadata fields, verified by the existing TestBuildCompactBoundaryMessage_JSONRoundTrip)
+// but the Summary field needs to actually arrive at formatAnthropicBlock.
+// This test pins that wire of the pipeline end-to-end.
+func TestFormatAnthropicBlock_CompactBoundaryAfterJSONRoundTripStillFlattens(t *testing.T) {
+	const summary = "post-reload summary"
+	original := types.LlmMessage{
+		Role:    "user",
+		Content: []types.LlmContentBlock{boundaryBlock(summary)},
+	}
+
+	// Encode + decode the way persistence does — the result is the
+	// shape contentBlocks() sees on the first turn after a resume.
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded types.LlmMessage
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	// Walk the same code path the live serializer uses.
+	blocks := contentBlocks(decoded)
+	if len(blocks) != 1 {
+		t.Fatalf("contentBlocks: expected 1, got %d", len(blocks))
+	}
+	if blocks[0].Type != "compact_boundary" {
+		t.Errorf("post-reload block type = %q, want compact_boundary", blocks[0].Type)
+	}
+	if blocks[0].Summary != summary {
+		t.Errorf("post-reload Summary = %q, want %q", blocks[0].Summary, summary)
+	}
+
+	out := formatAnthropicBlock(blocks[0])
+	if out == nil {
+		t.Fatal("formatAnthropicBlock returned nil after JSON round-trip")
+	}
+	if out["type"] != "text" {
+		t.Errorf("post-reload flattened type = %v, want text", out["type"])
+	}
+	if text, _ := out["text"].(string); !strings.Contains(text, summary) {
+		t.Errorf("post-reload flattened text = %q, want it to contain %q", text, summary)
+	}
+}

--- a/engine/internal/providers/messages.go
+++ b/engine/internal/providers/messages.go
@@ -83,6 +83,45 @@ func mapToContentBlock(m map[string]any) types.LlmContentBlock {
 		}
 		b.Source = src
 	}
+	// --- compact_boundary fields. Round-trip the structured metadata so
+	// boundary blocks reconstructed from on-disk JSON keep the same shape
+	// as freshly-built ones. Only meaningful when m["type"] ==
+	// "compact_boundary" but we copy unconditionally — the fields are
+	// zero-valued for every other block type, so the cost is negligible
+	// and the code stays free of a per-type switch.
+	if v, ok := m["trigger"].(string); ok {
+		b.Trigger = v
+	}
+	if v, ok := m["messagesSummarized"].(float64); ok {
+		b.MessagesSummarized = int(v)
+	}
+	if v, ok := m["messagesBefore"].(float64); ok {
+		b.MessagesBefore = int(v)
+	}
+	if v, ok := m["messagesAfter"].(float64); ok {
+		b.MessagesAfter = int(v)
+	}
+	if v, ok := m["clearedBlocks"].(float64); ok {
+		b.ClearedBlocks = int(v)
+	}
+	if v, ok := m["tokensBefore"].(float64); ok {
+		b.TokensBefore = int(v)
+	}
+	if v, ok := m["summary"].(string); ok {
+		b.Summary = v
+	}
+	if v, ok := m["factCount"].(float64); ok {
+		b.FactCount = int(v)
+	}
+	if v, ok := m["recentFiles"].([]any); ok {
+		files := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				files = append(files, s)
+			}
+		}
+		b.RecentFiles = files
+	}
 	return b
 }
 

--- a/engine/internal/providers/openai.go
+++ b/engine/internal/providers/openai.go
@@ -418,6 +418,16 @@ func formatOpenAIMessages(system string, messages []types.LlmMessage) []map[stri
 							"image_url": map[string]any{"url": url},
 						})
 					}
+				case "compact_boundary":
+					// Flatten the engine-internal compaction marker to a
+					// plain text part so the model still sees the
+					// rendered summary in context. See the matching case
+					// in anthropic.go formatAnthropicBlock for rationale.
+					text := b.Summary
+					if text == "" {
+						text = "[Previous conversation compacted]"
+					}
+					parts = append(parts, map[string]any{"type": "text", "text": text})
 				}
 			}
 			if len(parts) > 0 {

--- a/engine/internal/session/dispatch_rehydrate.go
+++ b/engine/internal/session/dispatch_rehydrate.go
@@ -94,6 +94,11 @@ func (m *Manager) rehydrateDispatchState(s *engineSession, key string) {
 			existing.Metadata["task"] = d.Task
 			existing.Metadata["model"] = d.Model
 			existing.Metadata["elapsed"] = d.Elapsed
+			// Later entries may carry a corrected displayName (e.g. "Comms Director"
+			// instead of the raw "comms-director" from an early buggy persist).
+			if d.DisplayName != "" && d.DisplayName != d.AgentName {
+				existing.Metadata["displayName"] = d.DisplayName
+			}
 			if d.ConversationID != "" {
 				existing.Metadata["conversationId"] = d.ConversationID
 			}

--- a/engine/internal/session/prompt_runconfig.go
+++ b/engine/internal/session/prompt_runconfig.go
@@ -291,19 +291,20 @@ func (m *Manager) wireExtensionHooks(s *engineSession, key string, requestID str
 		cancel, _ := extGroup.FireSessionBeforeCompact(ctx, extension.CompactionInfo{})
 		return cancel
 	}
-	runCfg.Hooks.OnRequestCompactSummary = func(_ string, messages []types.LlmMessage) (string, bool) {
+	runCfg.Hooks.OnRequestCompactSummary = func(_ string, strategy string, messages []types.LlmMessage) (string, bool) {
 		// Fan out to the extension group. The hook is observe+respond:
 		// returning ("", false) means "no opinion", which the runloop
 		// reads as a signal to fall back to the regex fact extractor.
-		// Strategy is not currently known at this bridge layer (the
-		// runloop chooses auto vs reactive); leaving it empty is fine
-		// for the contract — handlers that need to differentiate can
-		// look at MessageCount or branch on conversation patterns.
+		// Strategy is "auto" (proactive token-limit driven) or "reactive"
+		// (prompt_too_long retry) — handlers branch on it to tune their
+		// summariser to the trigger (e.g. shorter output on reactive
+		// because the provider just rejected the prompt).
 		summary, ok := extGroup.FireCompactSummaryRequest(ctx, extension.CompactSummaryRequestInfo{
+			Strategy:     strategy,
 			MessageCount: len(messages),
 			Messages:     messages,
 		})
-		utils.Debug("Session", fmt.Sprintf("compact_summary_request bridge: msgCount=%d hookProvided=%v summaryLen=%d", len(messages), ok, len(summary)))
+		utils.Debug("Session", fmt.Sprintf("compact_summary_request bridge: strategy=%s msgCount=%d hookProvided=%v summaryLen=%d", strategy, len(messages), ok, len(summary)))
 		return summary, ok
 	}
 	runCfg.Hooks.OnSessionCompact = func(_ string, info interface{}) {

--- a/engine/internal/session/prompt_runconfig.go
+++ b/engine/internal/session/prompt_runconfig.go
@@ -291,6 +291,21 @@ func (m *Manager) wireExtensionHooks(s *engineSession, key string, requestID str
 		cancel, _ := extGroup.FireSessionBeforeCompact(ctx, extension.CompactionInfo{})
 		return cancel
 	}
+	runCfg.Hooks.OnRequestCompactSummary = func(_ string, messages []types.LlmMessage) (string, bool) {
+		// Fan out to the extension group. The hook is observe+respond:
+		// returning ("", false) means "no opinion", which the runloop
+		// reads as a signal to fall back to the regex fact extractor.
+		// Strategy is not currently known at this bridge layer (the
+		// runloop chooses auto vs reactive); leaving it empty is fine
+		// for the contract — handlers that need to differentiate can
+		// look at MessageCount or branch on conversation patterns.
+		summary, ok := extGroup.FireCompactSummaryRequest(ctx, extension.CompactSummaryRequestInfo{
+			MessageCount: len(messages),
+			Messages:     messages,
+		})
+		utils.Debug("Session", fmt.Sprintf("compact_summary_request bridge: msgCount=%d hookProvided=%v summaryLen=%d", len(messages), ok, len(summary)))
+		return summary, ok
+	}
 	runCfg.Hooks.OnSessionCompact = func(_ string, info interface{}) {
 		if ci, ok := info.(map[string]interface{}); ok {
 			payload := extension.CompactionInfo{

--- a/engine/internal/types/contract_test.go
+++ b/engine/internal/types/contract_test.go
@@ -97,6 +97,11 @@ func buildManifest() contractManifest {
 		// so consumers can populate a routing-hint cache without parsing
 		// engine internals. Snapshot semantics — see types.go comment.
 		"EngineCommandListing": reflect.TypeOf(EngineCommandListing{}),
+		// LlmContentBlock is the wire shape for every block carried inside
+		// an LlmMessage. Tracked so cross-language mirrors stay in sync as
+		// new block variants land (most recently the "compact_boundary"
+		// variant — see internal/conversation/compact_boundary.go).
+		"LlmContentBlock": reflect.TypeOf(LlmContentBlock{}),
 	}
 	for name, typ := range shared {
 		m.SharedTypes[name] = jsonFieldNames(typ)

--- a/engine/internal/types/llm.go
+++ b/engine/internal/types/llm.go
@@ -21,6 +21,26 @@ type LlmMessage struct {
 }
 
 // LlmContentBlock is a union type for message content blocks.
+//
+// Most fields are scoped to a single block-type variant (e.g. ToolUseID +
+// Content + IsError describe a "tool_result" block). The block is the wire
+// shape for both provider-bound content and engine-internal markers.
+//
+// New variant: "compact_boundary"
+//
+// The block-type "compact_boundary" marks a compaction boundary inside the
+// conversation history. It is the structural alternative to the legacy
+// "[Previous conversation summary]: …" prose-prefix marker and exists so
+// the engine can slice history at a typed seam (see
+// conversation.MessagesAfterLastCompactBoundary). The Summary field carries
+// the human-readable summary text the model should see; provider
+// serialisers translate the block to a normal text block on the wire so
+// that providers never see an unknown block type. The remaining fields
+// (Trigger, MessagesBefore/After, ClearedBlocks, TokensBefore, FactCount,
+// RecentFiles, MessagesSummarized) are structured metadata mirrored from
+// CompactingEvent + the compaction extractor output. All are optional and
+// emitted with omitempty so older consumers continue to round-trip the
+// block without loss.
 type LlmContentBlock struct {
 	Type      string         `json:"type"`
 	Text      string         `json:"text,omitempty"`
@@ -32,6 +52,43 @@ type LlmContentBlock struct {
 	IsError   *bool          `json:"is_error,omitempty"`
 	Thinking  string         `json:"thinking,omitempty"`
 	Source    *ImageSource   `json:"source,omitempty"`
+
+	// --- compact_boundary fields ---
+	// All optional; only meaningful when Type == "compact_boundary".
+
+	// Trigger is the compaction strategy that produced this boundary.
+	// One of "auto" (proactive token-limit driven), "reactive" (provider
+	// prompt_too_long retry), or "manual" (user-initiated). Empty when
+	// unknown.
+	Trigger string `json:"trigger,omitempty"`
+	// MessagesSummarized is the number of source messages folded into the
+	// Summary field. Zero when not tracked.
+	MessagesSummarized int `json:"messagesSummarized,omitempty"`
+	// MessagesBefore is the conversation message count at the moment the
+	// boundary fired (pre-compaction).
+	MessagesBefore int `json:"messagesBefore,omitempty"`
+	// MessagesAfter is the conversation message count after the boundary
+	// (post-compaction, including the boundary message itself).
+	MessagesAfter int `json:"messagesAfter,omitempty"`
+	// ClearedBlocks is the number of tool-result / large-text blocks
+	// cleared by step-1 micro-compaction. Zero when no clears happened.
+	ClearedBlocks int `json:"clearedBlocks,omitempty"`
+	// TokensBefore is the reported context-token count at the moment the
+	// boundary fired. Zero when not available (reactive path does not
+	// always know this).
+	TokensBefore int `json:"tokensBefore,omitempty"`
+	// Summary is the rendered human-readable summary body the model sees
+	// in place of the compacted region. Empty when no facts were
+	// extracted and no harness summarizer ran.
+	Summary string `json:"summary,omitempty"`
+	// FactCount is the number of distinct structured facts the engine
+	// extracted from the compacted region (post-dedupe).
+	FactCount int `json:"factCount,omitempty"`
+	// RecentFiles is the set of file paths surfaced by ExtractRecentFiles
+	// at the moment of compaction. Provided as structured data so
+	// consumers (and the model) can re-attach them without re-parsing
+	// the Summary prose.
+	RecentFiles []string `json:"recentFiles,omitempty"`
 }
 
 // ImageSource carries base64-encoded image data for vision.

--- a/engine/internal/types/testdata/contracts.json
+++ b/engine/internal/types/testdata/contracts.json
@@ -215,6 +215,27 @@
       "workingDirectory",
       "workspaceWatchIgnore"
     ],
+    "LlmContentBlock": [
+      "clearedBlocks",
+      "content",
+      "factCount",
+      "id",
+      "input",
+      "is_error",
+      "messagesAfter",
+      "messagesBefore",
+      "messagesSummarized",
+      "name",
+      "recentFiles",
+      "source",
+      "summary",
+      "text",
+      "thinking",
+      "tokensBefore",
+      "tool_use_id",
+      "trigger",
+      "type"
+    ],
     "McpServerInfo": [
       "name",
       "status"

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		A1B2C3D4E5F600010000A4AA /* RemoteTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000A5AA /* RemoteTerminalView.swift */; };
 		A1B2C3D4E5F600010000A6AA /* TerminalInstanceBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000A7AA /* TerminalInstanceBar.swift */; };
 		A1B2C3D4E5F600010000B0AA /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F600010000B1AA /* SwiftTerm */; };
+		A1B2C3D4E5F60001FF0003AA /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F60001FF0001AA /* Markdown */; };
+		A1B2C3D4E5F60001FF0005AA /* MarkdownFormatterFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001FF0004AA /* MarkdownFormatterFixtures.swift */; };
+		A1B2C3D4E5F60001FF0007AA /* MarkdownFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001FF0006AA /* MarkdownFormatterTests.swift */; };
 		A1B2C3D4E5F600010000C0AA /* JetBrainsMonoNLNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000C1AA /* JetBrainsMonoNLNerdFontMono-Regular.ttf */; };
 		A1B2C3D4E5F600010000C2AA /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000C3AA /* OFL.txt */; };
 		A1B2C3D4E5F600010000D0AA /* EngineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000D1AA /* EngineView.swift */; };
@@ -203,6 +206,8 @@
 		A1B2C3D4E5F60001000022AA /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000024AA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000028AA /* E2ECryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2ECryptoTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001FF0004AA /* MarkdownFormatterFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatterFixtures.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001FF0006AA /* MarkdownFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatterTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100002AAA /* TransportManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100002CAA /* RelayClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayClientTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100002EAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -332,6 +337,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A1B2C3D4E5F600010000B0AA /* SwiftTerm in Frameworks */,
+				A1B2C3D4E5F60001FF0003AA /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -538,6 +544,8 @@
 				A1B2C3D4E5F60001E80007AA /* DesktopSettingsContractTests.swift */,
 				A1B2C3D4E5F60001F00007AA /* ContractSyncEngineEventsTests.swift */,
 				A1B2C3D4E5F60001000028AA /* E2ECryptoTests.swift */,
+				A1B2C3D4E5F60001FF0004AA /* MarkdownFormatterFixtures.swift */,
+				A1B2C3D4E5F60001FF0006AA /* MarkdownFormatterTests.swift */,
 				A1B2C3D4E5F6000100002AAA /* TransportManagerTests.swift */,
 				A1B2C3D4E5F6000100002CAA /* RelayClientTests.swift */,
 			);
@@ -618,6 +626,7 @@
 			name = IonRemote;
 			packageProductDependencies = (
 				A1B2C3D4E5F600010000B1AA /* SwiftTerm */,
+				A1B2C3D4E5F60001FF0001AA /* Markdown */,
 			);
 			productName = IonRemote;
 			productReference = A1B2C3D4E5F60001000032AA /* IonRemote.app */;
@@ -670,6 +679,7 @@
 			mainGroup = A1B2C3D4E5F60001000050AA;
 			packageReferences = (
 				A1B2C3D4E5F600010000B2AA /* XCRemoteSwiftPackageReference "SwiftTerm" */,
+				A1B2C3D4E5F60001FF0002AA /* XCRemoteSwiftPackageReference "swift-markdown" */,
 			);
 			productRefGroup = A1B2C3D4E5F60001000060AA /* Products */;
 			projectDirPath = "";
@@ -871,6 +881,8 @@
 				A1B2C3D4E5F60001E80006AA /* DesktopSettingsContractTests.swift in Sources */,
 				A1B2C3D4E5F60001F00006AA /* ContractSyncEngineEventsTests.swift in Sources */,
 				A1B2C3D4E5F60001000027AA /* E2ECryptoTests.swift in Sources */,
+				A1B2C3D4E5F60001FF0005AA /* MarkdownFormatterFixtures.swift in Sources */,
+				A1B2C3D4E5F60001FF0007AA /* MarkdownFormatterTests.swift in Sources */,
 				A1B2C3D4E5F60001000029AA /* TransportManagerTests.swift in Sources */,
 				A1B2C3D4E5F6000100002BAA /* RelayClientTests.swift in Sources */,
 			);
@@ -1147,6 +1159,14 @@
 				minimumVersion = 1.2.0;
 			};
 		};
+		A1B2C3D4E5F60001FF0002AA /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/swiftlang/swift-markdown";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.8.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1154,6 +1174,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A1B2C3D4E5F600010000B2AA /* XCRemoteSwiftPackageReference "SwiftTerm" */;
 			productName = SwiftTerm;
+		};
+		A1B2C3D4E5F60001FF0001AA /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A1B2C3D4E5F60001FF0002AA /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -29,6 +29,12 @@
 		A1B2C3D4E5F6000100001BAA /* PermissionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000100001CAA /* PermissionCardView.swift */; };
 		A1B2C3D4E5F6000100001DAA /* PairingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000100001EAA /* PairingView.swift */; };
 		A1B2C3D4E5F6000100001FAA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000020AA /* SettingsView.swift */; };
+		A1B2C3D4E5F60001009301AA /* SettingsAppearanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009300AA /* SettingsAppearanceView.swift */; };
+		A1B2C3D4E5F60001009303AA /* SettingsDesktopsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009302AA /* SettingsDesktopsView.swift */; };
+		A1B2C3D4E5F60001009305AA /* SettingsDiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009304AA /* SettingsDiagnosticsView.swift */; };
+		A1B2C3D4E5F60001009307AA /* SettingsInterfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009306AA /* SettingsInterfaceView.swift */; };
+		A1B2C3D4E5F60001009309AA /* SettingsModelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009308AA /* SettingsModelsView.swift */; };
+		A1B2C3D4E5F6000100930BAA /* SettingsVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6000100930AAA /* SettingsVoiceView.swift */; };
 		A1B2C3D4E5F60001000021AA /* SessionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000022AA /* SessionViewModel.swift */; };
 		A1B2C3D4E5F60001000023AA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000024AA /* Assets.xcassets */; };
 		A1B2C3D4E5F60001000027AA /* E2ECryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000028AA /* E2ECryptoTests.swift */; };
@@ -187,6 +193,12 @@
 		A1B2C3D4E5F6000100001CAA /* PermissionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCardView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100001EAA /* PairingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000020AA /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001009300AA /* SettingsAppearanceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAppearanceView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001009302AA /* SettingsDesktopsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDesktopsView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001009304AA /* SettingsDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDiagnosticsView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001009306AA /* SettingsInterfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsInterfaceView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001009308AA /* SettingsModelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsModelsView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000100930AAA /* SettingsVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsVoiceView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000022AA /* SessionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionViewModel.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000024AA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000028AA /* E2ECryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2ECryptoTests.swift; sourceTree = "<group>"; };
@@ -443,6 +455,12 @@
 				A1B2C3D4E5F6000100001EAA /* PairingView.swift */,
 				A1B2C3D4E5F60001000020AA /* SettingsView.swift */,
 				A1B2C3D4E5F60001D80007AA /* DesktopSettingsView.swift */,
+				A1B2C3D4E5F60001009300AA /* SettingsAppearanceView.swift */,
+				A1B2C3D4E5F60001009302AA /* SettingsDesktopsView.swift */,
+				A1B2C3D4E5F60001009304AA /* SettingsDiagnosticsView.swift */,
+				A1B2C3D4E5F60001009306AA /* SettingsInterfaceView.swift */,
+				A1B2C3D4E5F60001009308AA /* SettingsModelsView.swift */,
+				A1B2C3D4E5F6000100930AAA /* SettingsVoiceView.swift */,
 				A1B2C3D4E5F60001000095AA /* InputBar.swift */,
 				A1B2C3D4E5F600010000F3AA /* KeyboardUtilityBar.swift */,
 				A1B2C3D4E5F600010000A3AA /* SwiftTermWrapper.swift */,
@@ -729,6 +747,12 @@
 				A1B2C3D4E5F60001000098AA /* PlanApprovalCardView.swift in Sources */,
 				A1B2C3D4E5F6000100001DAA /* PairingView.swift in Sources */,
 				A1B2C3D4E5F6000100001FAA /* SettingsView.swift in Sources */,
+				A1B2C3D4E5F60001009301AA /* SettingsAppearanceView.swift in Sources */,
+				A1B2C3D4E5F60001009303AA /* SettingsDesktopsView.swift in Sources */,
+				A1B2C3D4E5F60001009305AA /* SettingsDiagnosticsView.swift in Sources */,
+				A1B2C3D4E5F60001009307AA /* SettingsInterfaceView.swift in Sources */,
+				A1B2C3D4E5F60001009309AA /* SettingsModelsView.swift in Sources */,
+				A1B2C3D4E5F6000100930BAA /* SettingsVoiceView.swift in Sources */,
 				A1B2C3D4E5F60001000094AA /* InputBar.swift in Sources */,
 				A1B2C3D4E5F60001000021AA /* SessionViewModel.swift in Sources */,
 				A1B2C3D4E5F60001000200AA /* SessionViewModel+Lifecycle.swift in Sources */,

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		A1B2C3D4E5F60001005302AA /* AttachmentImagePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001005303AA /* AttachmentImagePreview.swift */; };
 		A1B2C3D4E5F60001005304AA /* RemoteImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001005305AA /* RemoteImageFetcher.swift */; };
 		A1B2C3D4E5F60001009000AA /* TabSearchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009001AA /* TabSearchHelper.swift */; };
+		A1B2C3D4E5F60001F1000BAA /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001F1000CAA /* FuzzyMatch.swift */; };
 		A1B2C3D4E5F60001009D01AA /* SafeDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009D00AA /* SafeDecodable.swift */; };
 		A1B2C3D4E5F60001009E01AA /* TabRowContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001009E00AA /* TabRowContextMenu.swift */; };
 /* End PBXBuildFile section */
@@ -320,6 +321,7 @@
 		A1B2C3D4E5F60001006001AA /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001005305AA /* RemoteImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteImageFetcher.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001009001AA /* TabSearchHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSearchHelper.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001F1000CAA /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001009D00AA /* SafeDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeDecodable.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001009E00AA /* TabRowContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabRowContextMenu.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -579,6 +581,7 @@
 				A1B2C3D4E5F60001005305AA /* RemoteImageFetcher.swift */,
 				A1B2C3D4E5F60001009001AA /* TabSearchHelper.swift */,
 				A1B2C3D4E5F60001009D00AA /* SafeDecodable.swift */,
+				A1B2C3D4E5F60001F1000CAA /* FuzzyMatch.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -852,6 +855,7 @@
 				A1B2C3D4E5F60001F1000AAA /* ThinkingScanLine.swift in Sources */,
 				A1B2C3D4E5F60001009000AA /* TabSearchHelper.swift in Sources */,
 				A1B2C3D4E5F60001009D01AA /* SafeDecodable.swift in Sources */,
+				A1B2C3D4E5F60001F1000BAA /* FuzzyMatch.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IonRemote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/IonRemote.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4d9d9af82f23f3c708bdd502fed3939413b4f2a95a79ae568364cc92bca1527e",
+  "originHash" : "",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,24 @@
       "state" : {
         "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
         "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown",
+      "state" : {
+        "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
+        "version" : "0.8.0"
       }
     },
     {
@@ -22,3 +40,4 @@
   ],
   "version" : 3
 }
+

--- a/ios/IonRemote/Utilities/FuzzyMatch.swift
+++ b/ios/IonRemote/Utilities/FuzzyMatch.swift
@@ -1,0 +1,97 @@
+/// Fuzzy matching utility for slash command autocomplete.
+/// Algorithm mirrors `desktop/src/shared/fuzzy-match.ts` for cross-platform parity.
+enum FuzzyMatch {
+
+    // MARK: - Separators
+
+    private static let separators: Set<Character> = ["-", "_", ":"]
+
+    // MARK: - Public API
+
+    /// Returns `nil` if the query is not a subsequence of the candidate.
+    /// Otherwise returns the fuzzy score (higher = better match).
+    ///
+    /// Scoring:
+    /// - Exact prefix match: **+20** bonus (once, if entire query matches start of candidate)
+    /// - Match at start of string: **+10** bonus per character
+    /// - Match after separator (`-`, `_`, `:`): **+8** bonus per character
+    /// - Consecutive matches: **+5** bonus per consecutive character after the first
+    /// - Base: **1** point per matched character
+    static func score(query: String, candidate: String) -> Int? {
+        // 1. Strip leading "/" and lowercase both strings.
+        let q = stripped(query)
+        let c = stripped(candidate)
+
+        // 2. Empty query matches everything with score 0.
+        if q.isEmpty { return 0 }
+
+        // 3. Subsequence gate – every character in q must appear in order in c.
+        //    While checking, record the matching indices for scoring.
+        let cChars = Array(c)
+        let qChars = Array(q)
+
+        var matchIndices = [Int]()
+        matchIndices.reserveCapacity(qChars.count)
+
+        var ci = 0
+        for qChar in qChars {
+            var found = false
+            while ci < cChars.count {
+                if cChars[ci] == qChar {
+                    matchIndices.append(ci)
+                    ci += 1
+                    found = true
+                    break
+                }
+                ci += 1
+            }
+            if !found {
+                return nil  // not a subsequence
+            }
+        }
+
+        // 4. Compute score from the matched indices.
+        var total = 0
+
+        for (i, matchIndex) in matchIndices.enumerated() {
+            // Base: +1 per matched character
+            total += 1
+
+            // Start-of-string bonus: +10 per character matched at index 0
+            if matchIndex == 0 {
+                total += 10
+            }
+
+            // After-separator bonus: +8 per character immediately following a separator
+            if matchIndex > 0 && separators.contains(cChars[matchIndex - 1]) {
+                total += 8
+            }
+
+            // Consecutive bonus: +5 for each character that is consecutive with the
+            // previous match (only the 2nd, 3rd, … in a streak get the bonus).
+            if i > 0 && matchIndex == matchIndices[i - 1] + 1 {
+                total += 5
+            }
+        }
+
+        // Exact prefix bonus: +20 if the entire query matches the start of the candidate.
+        if matchIndices.count == qChars.count
+            && matchIndices.first == 0
+            && matchIndices.last == qChars.count - 1 {
+            total += 20
+        }
+
+        return total
+    }
+
+    // MARK: - Helpers
+
+    /// Strip a leading `/` and lowercase the string.
+    private static func stripped(_ s: String) -> String {
+        var result = s
+        if result.hasPrefix("/") {
+            result = String(result.dropFirst())
+        }
+        return result.lowercased()
+    }
+}

--- a/ios/IonRemote/Utilities/MarkdownFormatter.swift
+++ b/ios/IonRemote/Utilities/MarkdownFormatter.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Markdown
 
 /// Column alignment parsed from a markdown table.
 enum TableColumnAlignment {
@@ -46,48 +47,66 @@ enum MarkdownBlock: Identifiable {
 /// Parses Markdown into `[MarkdownBlock]` for rich composite rendering, or
 /// into a single `AttributedString` for compact inline previews.
 ///
-/// Uses Apple's `AttributedString` with `.full` interpretation and walks the
-/// `presentationIntent` runs to classify blocks. No third-party dependency.
+/// Uses `apple/swift-markdown` (CommonMark + GFM) as the parser. Walks the
+/// resulting AST to emit our flat `[MarkdownBlock]` representation. The
+/// rendering layer (`MarkdownContentView`) is unchanged.
+///
+/// Robustness contract: `parse(_:)` never throws. For any input string `s`,
+/// it returns a non-empty `[MarkdownBlock]`. A three-tier fallback (walker →
+/// raw paragraph) guarantees no content is silently dropped at the document
+/// level, even for malformed or partial markdown (e.g. an LLM cut off
+/// mid-stream). See `docs/architecture/file-organization.md` for context.
 @MainActor
 enum MarkdownFormatter {
 
     // MARK: - Rich block API (full-screen viewer)
 
     static func parse(_ markdown: String) -> [MarkdownBlock] {
-        guard let parsed = try? AttributedString(
-            markdown: markdown,
-            options: .init(
-                allowsExtendedAttributes: true,
-                interpretedSyntax: .full,
-                failurePolicy: .returnPartiallyParsedIfPossible
-            )
-        ) else {
-            return [.paragraph(text: fallback(markdown))]
+        let inputLen = markdown.count
+        DiagnosticLog.log("markdown.parse: input_len=\(inputLen)")
+
+        // Empty / whitespace input: return a single empty paragraph. This
+        // preserves the previous formatter's behavior so call sites that
+        // assume parse(...) returns at least one block don't need updating.
+        if markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            DiagnosticLog.log("markdown.parse: empty input → single empty paragraph")
+            return [.paragraph(text: AttributedString(""))]
         }
 
-        var blocks: [MarkdownBlock] = []
-        var accum = AttributedString()
-        var currentKind: BlockKind?
-        var tableCells: [TableCellEntry] = []
+        // Normalize line endings. swift-markdown handles CRLF/LF/CR per the
+        // CommonMark spec, but we normalize once on entry so any subsequent
+        // string manipulation (table rendering, plain-text fallbacks) sees
+        // a single canonical form.
+        let normalized = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
 
-        for run in parsed.runs {
-            let segment = AttributedString(parsed[run.range])
-            let kind = classify(run.presentationIntent)
-
-            if kind != currentKind {
-                flush(
-                    currentKind, text: &accum,
-                    into: &blocks, tableCells: &tableCells
-                )
-                currentKind = kind
-            }
-            accum.append(segment)
+        // The Document(parsing:) initializer itself does not throw — it
+        // always returns *some* Document, however degenerate. The do/try
+        // here is defensive: if a future swift-markdown release changes
+        // the contract (or a walker throws), we degrade to a single
+        // paragraph rather than losing the whole message.
+        let blocks: [MarkdownBlock]
+        do {
+            let document = Markdown.Document(parsing: normalized)
+            blocks = try walkDocument(document, raw: normalized)
+        } catch {
+            DiagnosticLog.log("markdown.parse: walker failed err=\(error) → raw paragraph fallback")
+            return [.paragraph(text: AttributedString(normalized))]
         }
-        flush(
-            currentKind, text: &accum,
-            into: &blocks, tableCells: &tableCells
-        )
-        flushTable(&tableCells, into: &blocks)
+
+        // Final safety net: if the walker produced no blocks for non-empty
+        // input (should never happen for well-formed swift-markdown output,
+        // but if a future spec change makes it possible we don't want to
+        // surface an empty message), fall back to a raw paragraph so the
+        // user still sees their content.
+        if blocks.isEmpty {
+            DiagnosticLog.log("markdown.parse: walker emitted 0 blocks → raw paragraph fallback")
+            return [.paragraph(text: AttributedString(normalized))]
+        }
+
+        let summary = summarize(blocks)
+        DiagnosticLog.log("markdown.parse: emitted blocks=\(blocks.count) kinds=[\(summary)]")
         return blocks
     }
 
@@ -134,199 +153,354 @@ enum MarkdownFormatter {
         return result
     }
 
-    // MARK: - Block classification
+    // MARK: - Document walker
 
-    /// Internal block kind used to group consecutive runs that belong to
-    /// the same logical block. Equality is by kind + identity so that
-    /// two distinct paragraphs are flushed separately.
-    private enum BlockKind: Equatable {
-        case heading(Int, Int)      // level, identity
-        case paragraph(Int)         // identity
-        case code(String?, Int)     // language, identity
-        case blockQuote(Int)        // identity
-        case listItem(Int, Bool, Int) // ordinal, ordered, identity
-        case thematicBreak(Int)     // identity
-        case tableCell(Int, Bool, Int, Int, Int) // tableID, isHeader, row, col, cellID
-        case unknown
+    /// Walk the swift-markdown `Document` AST and emit our flat block list.
+    /// The walker is non-throwing in practice — every CommonMark block kind
+    /// has a mapping. The `throws` signature exists only to let future
+    /// extensions throw without restructuring `parse(_:)`.
+    private static func walkDocument(
+        _ document: Markdown.Document,
+        raw: String
+    ) throws -> [MarkdownBlock] {
+        var out: [MarkdownBlock] = []
+        for child in document.blockChildren {
+            walkBlock(child, into: &out)
+        }
+        return out
     }
 
-    private static func classify(
-        _ intent: PresentationIntent?
-    ) -> BlockKind {
-        guard let intent else { return .unknown }
+    /// Walk one block-level AST node and append zero or more `MarkdownBlock`s
+    /// to `out`. Lists fan out internally via `walkListItem`.
+    private static func walkBlock(
+        _ block: any Markup,
+        into out: inout [MarkdownBlock]
+    ) {
+        switch block {
+        case let heading as Markdown.Heading:
+            out.append(.heading(
+                level: heading.level,
+                text: renderInline(heading.inlineChildren)
+            ))
 
-        // Table detection — components contain the full nesting path:
-        // [.table(columns:), .tableHeaderRow/.tableRow(rowIndex:),
-        //  .tableCell(columnIndex:)]
-        var tableID: Int?
-        var isHeader = false
-        var rowIndex = -1
-        var colIndex = 0
-        var cellID = 0
+        case let paragraph as Markdown.Paragraph:
+            out.append(.paragraph(text: renderInline(paragraph.inlineChildren)))
 
-        for component in intent.components {
-            switch component.kind {
-            case .table:
-                tableID = component.identity
-            case .tableHeaderRow:
-                isHeader = true
-                rowIndex = -1
-            case .tableRow(let idx):
-                isHeader = false
-                rowIndex = idx
-            case .tableCell(let col):
-                colIndex = col
-                cellID = component.identity
-            default:
-                break
+        case let codeBlock as Markdown.CodeBlock:
+            // CodeBlock.code retains the trailing newline that cmark inserts;
+            // trim it so the rendered code view doesn't show a phantom empty
+            // last line.
+            var code = codeBlock.code
+            if code.hasSuffix("\n") { code.removeLast() }
+            let lang = codeBlock.language?.trimmingCharacters(
+                in: .whitespacesAndNewlines)
+            out.append(.code(
+                language: (lang?.isEmpty == true) ? nil : lang,
+                text: code
+            ))
+
+        case is Markdown.ThematicBreak:
+            out.append(.thematicBreak)
+
+        case let blockQuote as Markdown.BlockQuote:
+            // Flatten quoted content. We render every nested block's plain
+            // text into one attributed string with newlines, preserving the
+            // current MarkdownBlock.blockQuote contract (single AttributedString).
+            let inner = flattenBlocksToAttributed(blockQuote.blockChildren)
+            out.append(.blockQuote(text: inner))
+
+        case let orderedList as Markdown.OrderedList:
+            // CommonMark stores the starting ordinal on the list itself.
+            var ordinal = Int(orderedList.startIndex)
+            for item in orderedList.listItems {
+                walkListItem(item, into: &out, ordinal: ordinal, ordered: true)
+                ordinal += 1
+            }
+
+        case let unorderedList as Markdown.UnorderedList:
+            // Unordered lists carry no ordinal; we pass 0 (the renderer ignores
+            // it when `ordered == false`).
+            for item in unorderedList.listItems {
+                walkListItem(item, into: &out, ordinal: 0, ordered: false)
+            }
+
+        case let table as Markdown.Table:
+            walkTable(table, into: &out)
+
+        case let htmlBlock as Markdown.HTMLBlock:
+            // Raw HTML has no SwiftUI rendering path; surface it as a
+            // monospaced code-like paragraph so the user at least sees the
+            // text rather than losing it silently.
+            out.append(.paragraph(text: AttributedString(htmlBlock.rawHTML)))
+
+        default:
+            // CustomBlock, BlockDirective, Doxygen commands, and any future
+            // block kinds fall through to plain text. format(_:) is the
+            // canonical "give me the text" helper for any Markup node.
+            let text = block.format()
+            if !text.isEmpty {
+                out.append(.paragraph(text: AttributedString(text)))
             }
         }
-        if let tid = tableID {
-            return .tableCell(tid, isHeader, rowIndex, colIndex, cellID)
-        }
+    }
 
-        for component in intent.components {
-            switch component.kind {
-            case .header(let level):
-                return .heading(level, component.identity)
-            case .codeBlock(let lang):
-                return .code(lang, component.identity)
-            case .blockQuote:
-                return .blockQuote(component.identity)
-            case .thematicBreak:
-                return .thematicBreak(component.identity)
-            case .listItem(let ordinal):
-                let ordered = intent.components.contains {
-                    $0.kind == .orderedList
-                }
-                return .listItem(ordinal, ordered, component.identity)
-            default:
+    /// Walk a single list item. Each item becomes one `.listItem` block, and
+    /// any nested blocks (paragraphs, code blocks, sublists) inside the item
+    /// are flattened: the first paragraph becomes the item text, and any
+    /// subsequent nested blocks (e.g. nested lists, code) are emitted as
+    /// their own top-level blocks. This matches the current renderer's
+    /// flat-list assumption — nested lists render visually as additional
+    /// items rather than as a true tree, same behavior as the previous
+    /// Foundation-based formatter.
+    private static func walkListItem(
+        _ item: Markdown.ListItem,
+        into out: inout [MarkdownBlock],
+        ordinal: Int,
+        ordered: Bool
+    ) {
+        // Reserve the position where the list-item block will land. Any
+        // nested blocks (sublists, code, blockquotes) emitted by the loop
+        // below append to `out` *after* this index so the visual order is:
+        // [item, nested-block, nested-block, ...].
+        let insertIndex = out.count
+        var itemText = AttributedString()
+        var didCaptureFirst = false
+        for child in item.blockChildren {
+            if !didCaptureFirst, let para = child as? Markdown.Paragraph {
+                itemText = renderInline(para.inlineChildren)
+                didCaptureFirst = true
                 continue
             }
+            // Any other nested blocks (code, sublists, blockquotes) are
+            // emitted as their own top-level blocks after the item.
+            walkBlock(child, into: &out)
         }
-        // Fall back to paragraph, keyed by the outermost identity.
-        let pid = intent.components.last?.identity ?? 0
-        return .paragraph(pid)
+        if !didCaptureFirst {
+            // Empty list item (rare) — emit an empty item so list numbering
+            // stays consistent.
+            itemText = AttributedString("")
+        }
+        out.insert(
+            .listItem(ordinal: ordinal, ordered: ordered, text: itemText),
+            at: insertIndex
+        )
     }
 
-    // MARK: - Table cell entry
+    // MARK: - Table walker
 
-    private struct TableCellEntry {
-        let tableID: Int
-        let isHeader: Bool
-        let rowIndex: Int
-        let columnIndex: Int
-        let text: AttributedString
-    }
-
-    // MARK: - Flushing
-
-    private static func flush(
-        _ kind: BlockKind?,
-        text: inout AttributedString,
-        into blocks: inout [MarkdownBlock],
-        tableCells: inout [TableCellEntry]
+    /// Convert a swift-markdown `Table` into our flat `.table(...)` block.
+    /// Reuses the existing renderer contract: headers as a `[AttributedString]`,
+    /// rows as `[[AttributedString]]`, alignments as `[TableColumnAlignment]`
+    /// padded to the column count.
+    private static func walkTable(
+        _ table: Markdown.Table,
+        into out: inout [MarkdownBlock]
     ) {
-        guard let kind, !text.characters.isEmpty else {
-            text = AttributedString()
-            return
+        // Header
+        var headers: [AttributedString] = []
+        for cell in table.head.cells {
+            headers.append(renderInline(cell.inlineChildren))
         }
-        let captured = text
-        text = AttributedString()
 
-        if case .tableCell(let tid, let hdr, let row, let col, _) = kind {
-            // Flush any pending table from a *different* table first.
-            if let first = tableCells.first, first.tableID != tid {
-                flushTable(&tableCells, into: &blocks)
+        // Body rows
+        var rows: [[AttributedString]] = []
+        for row in table.body.rows {
+            var cells: [AttributedString] = []
+            for cell in row.cells {
+                cells.append(renderInline(cell.inlineChildren))
             }
-            tableCells.append(TableCellEntry(
-                tableID: tid, isHeader: hdr,
-                rowIndex: row, columnIndex: col, text: captured
-            ))
-            return
+            rows.append(cells)
         }
 
-        // Transitioning away from table → assemble pending table.
-        flushTable(&tableCells, into: &blocks)
+        // Alignments. GFM's spec allows nil (default left). Pad to the wider
+        // of header/first-row column count so the renderer's bounded index
+        // access stays in range.
+        let colCount = max(headers.count, rows.first?.count ?? 0)
+        var alignments: [TableColumnAlignment] = []
+        for col in 0..<colCount {
+            if col < table.columnAlignments.count,
+               let a = table.columnAlignments[col]
+            {
+                alignments.append(convertAlignment(a))
+            } else {
+                alignments.append(.left)
+            }
+        }
 
-        switch kind {
-        case .heading(let level, _):
-            blocks.append(.heading(level: level, text: captured))
-        case .paragraph:
-            blocks.append(.paragraph(text: captured))
-        case .code(let lang, _):
-            blocks.append(.code(language: lang, text: plain(captured)))
-        case .blockQuote:
-            blocks.append(.blockQuote(text: captured))
-        case .listItem(let ordinal, let ordered, _):
-            blocks.append(.listItem(
-                ordinal: ordinal, ordered: ordered, text: captured
-            ))
-        case .thematicBreak:
-            blocks.append(.thematicBreak)
-        case .tableCell:
-            break // handled above
-        case .unknown:
-            blocks.append(.paragraph(text: captured))
+        out.append(.table(
+            headers: headers,
+            rows: rows,
+            alignments: alignments
+        ))
+    }
+
+    private static func convertAlignment(
+        _ a: Markdown.Table.ColumnAlignment
+    ) -> TableColumnAlignment {
+        switch a {
+        case .left:   return .left
+        case .center: return .center
+        case .right:  return .right
         }
     }
 
-    // MARK: - Table assembly
+    // MARK: - Inline rendering
 
-    private static func flushTable(
-        _ cells: inout [TableCellEntry],
-        into blocks: inout [MarkdownBlock]
-    ) {
-        guard !cells.isEmpty else { return }
-        blocks.append(assembleTable(cells))
-        cells.removeAll()
+    /// Render a sequence of inline markup nodes into a single `AttributedString`
+    /// with the appropriate per-run styling. SwiftUI's `Text(AttributedString)`
+    /// honors `font`, `foregroundColor`, and inline links automatically.
+    private static func renderInline(
+        _ inlines: some Sequence<InlineMarkup>
+    ) -> AttributedString {
+        var result = AttributedString()
+        for inline in inlines {
+            result.append(renderInlineNode(inline))
+        }
+        return result
     }
 
-    private static func assembleTable(
-        _ cells: [TableCellEntry]
-    ) -> MarkdownBlock {
-        let headerCells = cells.filter(\.isHeader)
-            .sorted { $0.columnIndex < $1.columnIndex }
-        let headers = headerCells.map(\.text)
+    /// Render one inline AST node. Recurses through containers (Emphasis,
+    /// Strong, Link, Strikethrough) so nested styles compose (e.g. bold
+    /// inside a link).
+    private static func renderInlineNode(_ inline: any Markup) -> AttributedString {
+        switch inline {
+        case let text as Markdown.Text:
+            return AttributedString(text.string)
 
-        let bodyCells = cells.filter { !$0.isHeader }
-        let grouped = Dictionary(grouping: bodyCells) { $0.rowIndex }
-        let rows = grouped.keys.sorted().map { rowIdx in
-            grouped[rowIdx]!
-                .sorted { $0.columnIndex < $1.columnIndex }
-                .map(\.text)
+        case let code as Markdown.InlineCode:
+            var a = AttributedString(code.code)
+            a.font = .system(.body, design: .monospaced)
+            a.backgroundColor = Color(.tertiarySystemFill)
+            return a
+
+        case let emphasis as Markdown.Emphasis:
+            var inner = renderInline(emphasis.inlineChildren)
+            // Apply italic to every existing run by setting the font on the
+            // attribute container. AttributedString lacks a direct "merge
+            // italic into existing font" API, so we walk the runs and
+            // promote each to an italic variant. For runs that already have
+            // a code (monospace) font, italic is purely a visual hint —
+            // SwiftUI's `Text` honors `.italic` independently of the font.
+            inner.runs.forEach { run in
+                let range = run.range
+                inner[range].font = (inner[range].font ?? .body).italic()
+            }
+            return inner
+
+        case let strong as Markdown.Strong:
+            var inner = renderInline(strong.inlineChildren)
+            inner.runs.forEach { run in
+                let range = run.range
+                inner[range].font = (inner[range].font ?? .body).bold()
+            }
+            return inner
+
+        case let strike as Markdown.Strikethrough:
+            var inner = renderInline(strike.inlineChildren)
+            inner.runs.forEach { run in
+                let range = run.range
+                inner[range].strikethroughStyle = .single
+            }
+            return inner
+
+        case let link as Markdown.Link:
+            var inner = renderInline(link.inlineChildren)
+            if let dest = link.destination, let url = URL(string: dest) {
+                inner.runs.forEach { run in
+                    let range = run.range
+                    inner[range].link = url
+                }
+            }
+            return inner
+
+        case let image as Markdown.Image:
+            // No inline image rendering yet — surface the alt text + URL so
+            // the content isn't lost. Future work: inline image preview.
+            let alt = image.plainText
+            if let src = image.source {
+                return AttributedString("[image: \(alt.isEmpty ? src : alt)]")
+            }
+            return AttributedString(alt.isEmpty ? "[image]" : "[image: \(alt)]")
+
+        case is Markdown.LineBreak:
+            return AttributedString("\n")
+
+        case is Markdown.SoftBreak:
+            // CommonMark soft breaks render as a space in HTML; we mirror
+            // that so prose reflows naturally on small screens.
+            return AttributedString(" ")
+
+        case let inlineHTML as Markdown.InlineHTML:
+            // Raw inline HTML: surface as plain text rather than dropping.
+            return AttributedString(inlineHTML.rawHTML)
+
+        case let symbolLink as Markdown.SymbolLink:
+            // Disabled by default (we don't pass .parseSymbolLinks), but
+            // handle it anyway so a future config flip doesn't lose content.
+            return AttributedString("`\(symbolLink.destination ?? "")`")
+
+        case let attrs as Markdown.InlineAttributes:
+            // We don't honor the attributes themselves; render the children.
+            return renderInline(attrs.inlineChildren)
+
+        default:
+            // CustomInline and any future inline kinds: render plain text.
+            return AttributedString(inline.format())
         }
-
-        let colCount = max(
-            headers.count,
-            rows.first?.count ?? 0
-        )
-        let alignments = Array(
-            repeating: TableColumnAlignment.left, count: colCount
-        )
-
-        return .table(
-            headers: headers, rows: rows, alignments: alignments
-        )
     }
 
     // MARK: - Helpers
 
-    private static func plain(_ attr: AttributedString) -> String {
-        String(attr.characters)
+    /// Flatten a sequence of blocks (e.g. the contents of a BlockQuote) into
+    /// a single attributed string, joining nested blocks with newlines. This
+    /// preserves the current `MarkdownBlock.blockQuote` contract, which holds
+    /// a single `AttributedString` rather than nested blocks.
+    private static func flattenBlocksToAttributed(
+        _ blocks: some Sequence<BlockMarkup>
+    ) -> AttributedString {
+        var result = AttributedString()
+        var first = true
+        for block in blocks {
+            if !first {
+                result.append(AttributedString("\n"))
+            }
+            first = false
+            switch block {
+            case let p as Markdown.Paragraph:
+                result.append(renderInline(p.inlineChildren))
+            case let h as Markdown.Heading:
+                result.append(renderInline(h.inlineChildren))
+            case let cb as Markdown.CodeBlock:
+                var a = AttributedString(cb.code)
+                a.font = .system(.body, design: .monospaced)
+                result.append(a)
+            default:
+                result.append(AttributedString(block.format()))
+            }
+        }
+        return result
     }
 
-    private static func fallback(
-        _ markdown: String
-    ) -> AttributedString {
-        if let inline = try? AttributedString(
-            markdown: markdown,
-            options: .init(
-                interpretedSyntax: .inlineOnlyPreservingWhitespace
-            )
-        ) {
-            return inline
+    /// Build a "kind:count" summary string for the diagnostic log so we can
+    /// audit parser output without grepping the full block list.
+    private static func summarize(_ blocks: [MarkdownBlock]) -> String {
+        var counts: [String: Int] = [:]
+        for b in blocks {
+            let key: String
+            switch b {
+            case .heading:       key = "heading"
+            case .paragraph:     key = "paragraph"
+            case .code:          key = "code"
+            case .blockQuote:    key = "blockQuote"
+            case .listItem:      key = "listItem"
+            case .thematicBreak: key = "thematicBreak"
+            case .table:         key = "table"
+            }
+            counts[key, default: 0] += 1
         }
-        return AttributedString(markdown)
+        return counts
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key):\($0.value)" }
+            .joined(separator: ", ")
     }
 }

--- a/ios/IonRemote/ViewModels/SessionViewModel+EngineWorkflowEvents.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EngineWorkflowEvents.swift
@@ -82,20 +82,24 @@ extension SessionViewModel {
     }
 
     @MainActor
-    func handleEngineCommandRegistry() {
-        // Complete snapshot of slash commands exposed by the session's
-        // loaded extensions. Desktop's prompt pipeline uses this as a
-        // routing-hint cache (engine-command names take precedence over
-        // local .md template lookups). iOS does not yet consume the
-        // registry for autocomplete — Phase 0.5 of the unified slash-
-        // pipeline plan intentionally left the iOS UI out of scope.
-        //
-        // Snapshot semantics: when iOS does start consuming this, the
-        // payload is a REPLACE-style snapshot, not an incremental
-        // update. Empty `commands: []` is the authoritative "no
-        // extension commands for this session" signal — not a no-op.
+    func handleEngineCommandRegistry(tabId: String, instanceId: String?, commands: [EngineCommandListing]) {
+        // Complete snapshot of slash commands exposed by the session's loaded
+        // extensions. Snapshot semantics: the payload is a REPLACE-style
+        // snapshot, not an incremental update. Empty `commands: []` is the
+        // authoritative "no extension commands for this session" signal.
         // See docs/architecture/agent-state.md for the canonical
         // snapshot-replace pattern.
+        let key: String
+        if let instId = instanceId, !instId.isEmpty {
+            key = "\(tabId):\(instId)"
+        } else {
+            key = tabId
+        }
+        if commands.isEmpty {
+            extensionCommands.removeValue(forKey: key)
+        } else {
+            extensionCommands[key] = commands
+        }
     }
 
     @MainActor

--- a/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel+EventHandlers.swift
@@ -315,8 +315,8 @@ extension SessionViewModel {
         case .engineEarlyStopDecisionRequest:
             handleEngineEarlyStopDecisionRequest()
 
-        case .engineCommandRegistry:
-            handleEngineCommandRegistry()
+        case .engineCommandRegistry(let tabId, let instanceId, let commands):
+            handleEngineCommandRegistry(tabId: tabId, instanceId: instanceId, commands: commands)
 
         case .engineCommandResult:
             handleEngineCommandResult()

--- a/ios/IonRemote/ViewModels/SessionViewModel.swift
+++ b/ios/IonRemote/ViewModels/SessionViewModel.swift
@@ -223,6 +223,12 @@ final class SessionViewModel {
     // Discovered slash commands (per working directory)
     var discoveredCommands: [String: [DiscoveredSlashCommand]] = [:]
 
+    /// Extension-registered slash commands from engine_command_registry events.
+    /// Keyed by engine session key (tabId or "tabId:instanceId") — mirrors the
+    /// desktop's `extensionCommandsByKey` in engine-event-slice.ts.
+    /// Snapshot semantics: every event REPLACES the prior entry for that key.
+    var extensionCommands: [String: [EngineCommandListing]] = [:]
+
     // Upload attachment results (consumed by InputBar / EngineView)
     var pendingUploadResults: [UploadAttachmentResult] = []
 

--- a/ios/IonRemote/Views/InputBar.swift
+++ b/ios/IonRemote/Views/InputBar.swift
@@ -59,7 +59,34 @@ struct InputBar: View {
     }
 
     private var slashCommands: [DiscoveredSlashCommand] {
-        viewModel.discoveredCommands[workingDirectory] ?? []
+        var cmds = viewModel.discoveredCommands[workingDirectory] ?? []
+
+        // Inject the /clear builtin (matches desktop's SLASH_COMMANDS constant).
+        let clearCmd = DiscoveredSlashCommand(
+            name: "clear", description: "Clear conversation history",
+            scope: "builtin", source: "builtin"
+        )
+        if !cmds.contains(where: { $0.name == "clear" }) {
+            cmds.insert(clearCmd, at: 0)
+        }
+
+        // Merge extension-registered commands from engine_command_registry.
+        let tab = viewModel.tab(for: tabId)
+        let extKey: String? = {
+            guard let t = tab else { return nil }
+            return (t.isEngine == true) ? viewModel.engineCompoundKey(tabId: t.id) : t.id
+        }()
+        if let key = extKey, let extCmds = viewModel.extensionCommands[key] {
+            for ec in extCmds where !cmds.contains(where: { $0.name == ec.name }) {
+                cmds.append(DiscoveredSlashCommand(
+                    name: ec.name,
+                    description: ec.description ?? ec.name,
+                    scope: "extension",
+                    source: "extension"
+                ))
+            }
+        }
+        return cmds
     }
 
     private var hasUploading: Bool {

--- a/ios/IonRemote/Views/SettingsAppearanceView.swift
+++ b/ios/IonRemote/Views/SettingsAppearanceView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct SettingsAppearanceView: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Environment(\.appTheme) private var theme
+
+    var body: some View {
+        List {
+            Section {
+                Picker("Theme", selection: Binding(
+                    get: { theme.selectedThemeId },
+                    set: { newValue in
+                        theme.selectedThemeId = newValue
+                        DiagnosticLog.log("[SettingsView] theme picker set to: \(newValue)")
+                    }
+                )) {
+                    ForEach(ThemeRegistry.themes, id: \.id) { t in
+                        Text(t.displayName).tag(t.id)
+                    }
+                }
+                .onChange(of: theme.selectedThemeId) { oldVal, newVal in
+                    DiagnosticLog.log("[SettingsView] theme picker changed: \(oldVal) -> \(newVal)")
+                    DiagnosticLog.log("[SettingsView] theme.accent is now: \(theme.accent)")
+                }
+            } header: {
+                Text("Appearance")
+            } footer: {
+                Text("Arc Reactor forces dark mode. Ion Default follows system settings.")
+            }
+        }
+        .navigationTitle("Appearance")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/IonRemote/Views/SettingsDesktopsView.swift
+++ b/ios/IonRemote/Views/SettingsDesktopsView.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+struct SettingsDesktopsView: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Environment(\.appTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showPairingSheet = false
+    @State private var editingDevice: PairedDevice? = nil
+
+    var body: some View {
+        List {
+            Section("Connection") {
+                HStack {
+                    Text("Status")
+                    Spacer()
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(viewModel.connectionState.color)
+                            .frame(width: 8, height: 8)
+                        Text(statusLabel)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                HStack {
+                    Text("Relay URL")
+                    Spacer()
+                    Text(viewModel.relayURL.isEmpty ? "Not configured" : viewModel.relayURL)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+
+            if viewModel.desktopSettings != nil, viewModel.connectionState == .connected {
+                Section {
+                    NavigationLink {
+                        DesktopSettingsView()
+                            .environment(viewModel)
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "slider.horizontal.3")
+                                .font(.body)
+                                .foregroundStyle(theme.accent)
+                                .frame(width: 28, height: 28)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Desktop Settings")
+                                    .font(.body)
+                                Text(viewModel.activeDevice?.displayName ?? "Connected desktop")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                } footer: {
+                    Text("Preferences for the currently-connected desktop. Each paired desktop keeps its own values.")
+                }
+            }
+
+            Section {
+                if viewModel.pairedDevices.isEmpty {
+                    Text("No paired devices")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.pairedDevices) { device in
+                        let isActive = device.id == viewModel.activeDevice?.id
+                        Button {
+                            editingDevice = device
+                            Haptic.light()
+                        } label: {
+                            HStack {
+                                Image(systemName: device.displayIcon)
+                                    .font(.title3)
+                                    .foregroundStyle(theme.accent)
+                                    .frame(width: 28, height: 28)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack(spacing: 6) {
+                                        Text(device.displayName)
+                                            .font(.headline)
+                                            .foregroundStyle(.primary)
+                                        if device.customName != nil || device.customIcon != nil {
+                                            Image(systemName: "pencil.circle.fill")
+                                                .font(.caption2)
+                                                .foregroundStyle(.tertiary)
+                                                .help("Custom name/icon set")
+                                        }
+                                        if isActive {
+                                            Text("Active")
+                                                .font(.caption2)
+                                                .foregroundStyle(.green)
+                                                .padding(.horizontal, 6)
+                                                .padding(.vertical, 2)
+                                                .background(
+                                                    Capsule().stroke(Color.green, lineWidth: 1)
+                                                )
+                                        }
+                                    }
+                                    // When a custom name is in use, show the original host
+                                    // name in small text so users can still identify the
+                                    // underlying machine.
+                                    if let custom = device.customName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                                       !custom.isEmpty,
+                                       custom != device.name {
+                                        Text(device.name)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Text("Paired \(device.pairedAt.formatted(date: .abbreviated, time: .shortened))")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                    if let lastSeen = device.lastSeen {
+                                        Text("Last seen \(lastSeen.formatted(.relative(presentation: .named)))")
+                                            .font(.caption2)
+                                            .foregroundStyle(.tertiary)
+                                    }
+                                }
+                                Spacer()
+                                if !isActive {
+                                    Button {
+                                        DiagnosticLog.log("[SettingsView] Connect tapped for device: \(device.id)")
+                                        viewModel.switchToDevice(id: device.id)
+                                        Haptic.success()
+                                        dismiss()
+                                    } label: {
+                                        Text("Connect")
+                                            .font(.caption.weight(.medium))
+                                            .padding(.horizontal, 10)
+                                            .padding(.vertical, 4)
+                                            .background(theme.accent.opacity(0.15))
+                                            .foregroundStyle(theme.accent)
+                                            .clipShape(Capsule())
+                                    }
+                                    .buttonStyle(.borderless)
+                                }
+                                Image(systemName: "chevron.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                                Circle()
+                                    .fill(isActive && viewModel.connectionState == .connected ? Color.green : Color(.tertiaryLabel))
+                                    .frame(width: 8, height: 8)
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                            if !isActive {
+                                Button {
+                                    viewModel.switchToDevice(id: device.id)
+                                    Haptic.success()
+                                    dismiss()
+                                } label: {
+                                    Label("Switch to", systemImage: "arrow.right.arrow.left")
+                                }
+                                .tint(theme.accent)
+                            }
+                        }
+                    }
+                    .onDelete { offsets in
+                        let devices = offsets.map { viewModel.pairedDevices[$0] }
+                        for device in devices {
+                            viewModel.unpairDevice(device)
+                        }
+                    }
+                }
+
+                Button {
+                    showPairingSheet = true
+                } label: {
+                    Label("Pair New Desktop…", systemImage: "plus")
+                }
+            } header: {
+                Text("Paired Desktops")
+            } footer: {
+                Text("Tap a desktop to set a custom name and icon. Changes sync to all paired iPhones.")
+            }
+        }
+        .navigationTitle("Desktops & Connection")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showPairingSheet) {
+            PairingView()
+        }
+        .sheet(item: $editingDevice) { device in
+            DeviceCustomizationSheet(device: device)
+                .environment(viewModel)
+        }
+    }
+
+    private var statusLabel: String {
+        guard viewModel.connectionState == .connected else {
+            return viewModel.connectionState.label
+        }
+        switch viewModel.transportState {
+        case .lanPreferred: return "Connected (LAN)"
+        case .relayOnly: return "Connected (Relay)"
+        case .disconnected: return "Connected"
+        }
+    }
+}

--- a/ios/IonRemote/Views/SettingsDiagnosticsView.swift
+++ b/ios/IonRemote/Views/SettingsDiagnosticsView.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct SettingsDiagnosticsView: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Environment(\.appTheme) private var theme
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        List {
+            Section("Diagnostics") {
+                HStack {
+                    Label("Transport", systemImage: "antenna.radiowaves.left.and.right")
+                    Spacer()
+                    Text(transportLabel)
+                        .foregroundStyle(.secondary)
+                }
+                if let latency = viewModel.connectionQuality.latencyLabel {
+                    HStack {
+                        Label("Latency", systemImage: "timer")
+                        Spacer()
+                        Text(latency)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                HStack {
+                    Label("Buffered", systemImage: "tray.full")
+                    Spacer()
+                    Text("\(viewModel.connectionQuality.lastBuffered)")
+                        .foregroundStyle(.secondary)
+                }
+                HStack {
+                    Label("Signal", systemImage: "wifi")
+                    Spacer()
+                    Text(viewModel.connectionQuality.signalLevel.label)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Section("About") {
+                HStack {
+                    Spacer()
+                    VStack(spacing: 8) {
+                        Image(systemName: "bolt.shield.fill")
+                            .font(.system(size: 40))
+                            .foregroundStyle(theme.accent)
+                        Text("Ion Remote")
+                            .font(.headline)
+                        Text(appVersionString)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+                .listRowBackground(Color.clear)
+
+                NavigationLink("Diagnostic Log") {
+                    DiagnosticLogView()
+                }
+
+                Button(role: .destructive) {
+                    dismiss()
+                    viewModel.resetAll()
+                } label: {
+                    HStack {
+                        Spacer()
+                        Text("Unpair All Devices")
+                            .font(.subheadline.weight(.medium))
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .listRowBackground(Color.clear)
+            }
+        }
+        .navigationTitle("Diagnostics & About")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var transportLabel: String {
+        switch viewModel.transportState {
+        case .lanPreferred: return "LAN (Bonjour)"
+        case .relayOnly: return "Relay (WebSocket)"
+        case .disconnected: return "Disconnected"
+        }
+    }
+
+    private var appVersionString: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        let hash = info?["IonBuildHash"] as? String ?? "?"
+        return "v\(version) (\(build).\(hash))"
+    }
+}

--- a/ios/IonRemote/Views/SettingsInterfaceView.swift
+++ b/ios/IonRemote/Views/SettingsInterfaceView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct SettingsInterfaceView: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Environment(\.appTheme) private var theme
+
+    var body: some View {
+        List {
+            Section("New Tab") {
+                Picker("Default Directory", selection: Binding<String?>(
+                    get: { viewModel.defaultBaseDirectory },
+                    set: { viewModel.defaultBaseDirectory = $0 }
+                )) {
+                    Text("None (desktop default)").tag(nil as String?)
+                    ForEach(viewModel.recentDirectories, id: \.self) { dir in
+                        Text((dir as NSString).lastPathComponent).tag(dir as String?)
+                    }
+                }
+            }
+
+            Section {
+                Toggle(isOn: Binding(
+                    get: { viewModel.showGitInfoInTabList },
+                    set: { viewModel.showGitInfoInTabList = $0 }
+                )) {
+                    Label("Show Git Info", systemImage: "arrow.triangle.branch")
+                }
+            } header: {
+                Text("Tab List")
+            } footer: {
+                Text("Shows the current branch and commit counts on each tab.")
+            }
+
+            Section {
+                Toggle(isOn: Binding(
+                    get: { viewModel.agentPanelFullScreenPopup },
+                    set: { viewModel.agentPanelFullScreenPopup = $0 }
+                )) {
+                    Label("Full-Screen Agent Detail", systemImage: "rectangle.expand.vertical")
+                }
+            } header: {
+                Text("Agent Panel")
+            } footer: {
+                Text("When enabled, tapping an agent opens a full-screen detail view instead of expanding inline.")
+            }
+
+            Section {
+                Picker("Grouping", selection: Binding<String>(
+                    get: { viewModel.tabGroupMode == "manual" ? "manual" : "auto" },
+                    set: { newValue in viewModel.setTabGroupMode(newValue) }
+                )) {
+                    Text("Auto (by directory)").tag("auto")
+                    Text("Manual (custom groups)").tag("manual")
+                }
+
+                if viewModel.tabGroupMode == "manual" {
+                    let sorted = viewModel.tabGroups.sorted { $0.order < $1.order }
+                    ForEach(sorted) { group in
+                        HStack {
+                            Text(group.label)
+                            Spacer()
+                            if group.isDefault {
+                                Image(systemName: "star.fill")
+                                    .font(.caption)
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                    }
+                    .onMove { source, destination in
+                        var reordered = sorted
+                        reordered.move(fromOffsets: source, toOffset: destination)
+                        let orderedIds = reordered.map(\.id)
+                        viewModel.reorderTabGroups(orderedIds: orderedIds)
+                    }
+                }
+            } header: {
+                Text("Tab Groups")
+            } footer: {
+                if viewModel.tabGroupMode == "manual" {
+                    Text("Drag to reorder groups. Create or delete groups from the desktop settings.")
+                }
+            }
+        }
+        .navigationTitle("Interface")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/IonRemote/Views/SettingsModelsView.swift
+++ b/ios/IonRemote/Views/SettingsModelsView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct SettingsModelsView: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Environment(\.appTheme) private var theme
+
+    var body: some View {
+        let models = viewModel.availableModels
+        List {
+            Section("Models") {
+                Picker("Conversation", selection: Binding<String>(
+                    get: { viewModel.preferredModel },
+                    set: { newValue in viewModel.setPreferredModelDefault(newValue) }
+                )) {
+                    ForEach(models) { model in
+                        Text(model.label).tag(model.id)
+                    }
+                }
+                Picker("Engine", selection: Binding<String>(
+                    get: { viewModel.engineDefaultModel },
+                    set: { newValue in viewModel.setEngineDefaultModelDefault(newValue) }
+                )) {
+                    Text("Same as Conversation").tag("")
+                    ForEach(models) { model in
+                        Text(model.label).tag(model.id)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Models")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/IonRemote/Views/SettingsView.swift
+++ b/ios/IonRemote/Views/SettingsView.swift
@@ -1,33 +1,73 @@
 import SwiftUI
 
+/// Top-level settings screen. Shows category rows that push into
+/// dedicated detail views, matching the iOS Settings.app pattern.
+/// All section logic now lives in the per-category files:
+/// - SettingsDesktopsView (connection, desktop settings, paired devices)
+/// - SettingsAppearanceView (theme)
+/// - SettingsInterfaceView (new tab, tab list, agent panel, tab groups)
+/// - SettingsModelsView (conversation/engine model pickers)
+/// - SettingsVoiceView (voice toggle, API key, mode, prompt)
+/// - SettingsDiagnosticsView (transport info, diagnostic log, about)
 struct SettingsView: View {
     @Environment(SessionViewModel.self) private var viewModel
     @Environment(\.appTheme) private var theme
     @Environment(\.dismiss) private var dismiss
-    @State private var showPairingSheet = false
-    @State private var elevenLabsKey: String = ""
-    @State private var keySaved = false
-    @State private var voiceTestInProgress = false
-    @State private var voiceTestResult: VoiceService.TestResult?
-    @State private var showVoiceTestAlert = false
-    @State private var voicePromptText: String = ""
-    @State private var editingDevice: PairedDevice? = nil
 
     var body: some View {
         NavigationStack {
             List {
-                themeSection
-                connectionSection
-                desktopSettingsSection
-                voiceSection
-                diagnosticsSection
-                newTabSection
-                tabListSection
-                agentPanelSection
-                modelsSection
-                tabGroupsSection
-                pairedDevicesSection
-                aboutSection
+                categoryLink(
+                    "Desktops & Connection",
+                    icon: "desktopcomputer",
+                    color: .blue,
+                    detail: viewModel.activeDevice?.displayName
+                ) {
+                    SettingsDesktopsView()
+                }
+
+                categoryLink(
+                    "Appearance",
+                    icon: "paintbrush",
+                    color: .purple,
+                    detail: currentThemeName
+                ) {
+                    SettingsAppearanceView()
+                }
+
+                categoryLink(
+                    "Interface",
+                    icon: "square.grid.2x2",
+                    color: .indigo
+                ) {
+                    SettingsInterfaceView()
+                }
+
+                categoryLink(
+                    "Models",
+                    icon: "cpu",
+                    color: .orange,
+                    detail: currentModelLabel
+                ) {
+                    SettingsModelsView()
+                }
+
+                categoryLink(
+                    "Voice",
+                    icon: "waveform",
+                    color: .green,
+                    detail: viewModel.voiceService.isEnabled ? "On" : "Off"
+                ) {
+                    SettingsVoiceView()
+                }
+
+                categoryLink(
+                    "Diagnostics & About",
+                    icon: "stethoscope",
+                    color: .gray
+                ) {
+                    SettingsDiagnosticsView()
+                }
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
@@ -36,546 +76,46 @@ struct SettingsView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .sheet(isPresented: $showPairingSheet) {
-                PairingView()
-            }
-            .sheet(item: $editingDevice) { device in
-                DeviceCustomizationSheet(device: device)
-                    .environment(viewModel)
-            }
         }
     }
 
-    private var statusLabel: String {
-        guard viewModel.connectionState == .connected else {
-            return viewModel.connectionState.label
-        }
-        switch viewModel.transportState {
-        case .lanPreferred: return "Connected (LAN)"
-        case .relayOnly: return "Connected (Relay)"
-        case .disconnected: return "Connected"
-        }
+    // MARK: - Helpers
+
+    private var currentThemeName: String {
+        ThemeRegistry.themes.first { $0.id == theme.selectedThemeId }?.displayName ?? "Default"
     }
 
-    private var transportLabel: String {
-        switch viewModel.transportState {
-        case .lanPreferred: return "LAN (Bonjour)"
-        case .relayOnly: return "Relay (WebSocket)"
-        case .disconnected: return "Disconnected"
-        }
+    private var currentModelLabel: String {
+        viewModel.availableModels.first { $0.id == viewModel.preferredModel }?.label ?? viewModel.preferredModel
     }
 
-    // MARK: - Sections
+    /// Reusable category row with icon, label, optional detail, and chevron.
+    private func categoryLink<Destination: View>(
+        _ title: String,
+        icon: String,
+        color: Color,
+        detail: String? = nil,
+        @ViewBuilder destination: () -> Destination
+    ) -> some View {
+        NavigationLink(destination: destination) {
+            HStack(spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 28, height: 28)
+                    .background(color, in: RoundedRectangle(cornerRadius: 6))
 
-    private var themeSection: some View {
-        Section {
-            Picker("Theme", selection: Binding(
-                get: { theme.selectedThemeId },
-                set: { newValue in
-                    theme.selectedThemeId = newValue
-                    DiagnosticLog.log("[SettingsView] theme picker set to: \(newValue)")
-                }
-            )) {
-                ForEach(ThemeRegistry.themes, id: \.id) { t in
-                    Text(t.displayName).tag(t.id)
-                }
-            }
-            .onChange(of: theme.selectedThemeId) { oldVal, newVal in
-                DiagnosticLog.log("[SettingsView] theme picker changed: \(oldVal) -> \(newVal)")
-                DiagnosticLog.log("[SettingsView] theme.accent is now: \(theme.accent)")
-            }
-        } header: {
-            Text("Appearance")
-        } footer: {
-            Text("Arc Reactor forces dark mode. Ion Default follows system settings.")
-        }
-    }
+                Text(title)
 
-    private var voiceSection: some View {
-        Section {
-            Toggle(isOn: Binding(
-                get: { viewModel.voiceService.isEnabled },
-                set: {
-                    viewModel.voiceService.isEnabled = $0
-                    viewModel.sendVoiceConfig()
-                }
-            )) {
-                Label("Voice Responses", systemImage: "waveform")
-            }
-            SecureField("ElevenLabs API Key", text: $elevenLabsKey)
-                .textContentType(.password)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
-            Button {
-                if elevenLabsKey.trimmingCharacters(in: .whitespaces).isEmpty {
-                    KeychainHelper.delete("com.ion.remote.elevenlabs")
-                } else {
-                    KeychainHelper.set(elevenLabsKey, service: "com.ion.remote.elevenlabs")
-                }
-                withAnimation { keySaved = true }
-                Haptic.success()
-                Task {
-                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                    withAnimation { keySaved = false }
-                }
-            } label: {
-                HStack {
-                    Text(keySaved ? "Key Saved ✓" : "Save Key")
-                    if keySaved {
-                        Spacer()
-                    }
-                }
-                .foregroundStyle(keySaved ? .green : theme.accent)
-            }
-            Button {
-                voiceTestInProgress = true
-                Task {
-                    let result = await viewModel.voiceService.testVoice()
-                    voiceTestInProgress = false
-                    voiceTestResult = result
-                    showVoiceTestAlert = true
-                    if result.isSuccess { Haptic.success() } else { Haptic.error() }
-                }
-            } label: {
-                HStack {
-                    Text("Test Voice")
-                    if voiceTestInProgress {
-                        Spacer()
-                        ProgressView()
-                    }
-                }
-            }
-            .disabled(voiceTestInProgress)
-            Picker(selection: Binding(
-                get: { viewModel.voiceService.voiceMode },
-                set: {
-                    viewModel.voiceService.voiceMode = $0
-                    viewModel.sendVoiceConfig()
-                }
-            )) {
-                Text("Client-Only").tag(VoiceService.VoiceMode.clientOnly)
-                Text("Desktop-Assisted").tag(VoiceService.VoiceMode.desktopAssisted)
-            } label: {
-                Label("Processing", systemImage: "cpu")
-            }
-            if viewModel.voiceService.voiceMode == .desktopAssisted {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Voice System Prompt")
-                        .font(.subheadline.weight(.medium))
-                    TextEditor(text: $voicePromptText)
-                        .font(.caption)
-                        .frame(minHeight: 120, maxHeight: 200)
-                        .scrollContentBackground(.hidden)
-                        .background(Color(.systemGray6))
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                    HStack {
-                        Button("Save Prompt") {
-                            viewModel.voiceService.voiceSystemPrompt = voicePromptText
-                            viewModel.sendVoiceConfig()
-                            Haptic.success()
-                        }
+                Spacer()
+
+                if let detail {
+                    Text(detail)
+                        .foregroundStyle(.secondary)
                         .font(.subheadline)
-                        Spacer()
-                        Button("Reset to Default") {
-                            voicePromptText = VoiceService.defaultVoicePrompt
-                            viewModel.voiceService.voiceSystemPrompt = voicePromptText
-                            viewModel.sendVoiceConfig()
-                        }
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    }
+                        .lineLimit(1)
                 }
             }
-        } header: {
-            Text("Voice")
-        } footer: {
-            if !viewModel.voiceService.isEnabled {
-                Text("Voice is off.")
-            } else if viewModel.voiceService.voiceMode == .desktopAssisted {
-                Text("Desktop shapes LLM output for voice before iOS speaks it.")
-            } else {
-                Text("iOS speaks assistant responses with client-side filtering.")
-            }
-        }
-        .onAppear {
-            elevenLabsKey = KeychainHelper.get("com.ion.remote.elevenlabs") ?? ""
-            voicePromptText = viewModel.voiceService.voiceSystemPrompt
-        }
-        .alert(
-            voiceTestResult?.isSuccess == true ? "Voice Test Passed" : "Voice Test Failed",
-            isPresented: $showVoiceTestAlert
-        ) {
-            Button("OK", role: .cancel) { }
-        } message: {
-            Text(voiceTestResult?.message ?? "")
-        }
-    }
-
-    @ViewBuilder
-    private var connectionSection: some View {
-        Section("Connection") {
-            HStack {
-                Text("Status")
-                Spacer()
-                HStack(spacing: 6) {
-                    Circle()
-                        .fill(viewModel.connectionState.color)
-                        .frame(width: 8, height: 8)
-                    Text(statusLabel)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            HStack {
-                Text("Relay URL")
-                Spacer()
-                Text(viewModel.relayURL.isEmpty ? "Not configured" : viewModel.relayURL)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-        }
-    }
-
-    /// "Desktop Settings" entry-point row. A single NavigationLink that
-    /// pushes the per-desktop projection editor when the current pairing
-    /// has a snapshot loaded. Mirrors Apple's own Settings.app pattern
-    /// of a one-row section with secondary detail text and a chevron —
-    /// the row is the discoverable handle to a richer detail screen
-    /// rather than a soup of inline toggles at the top level.
-    ///
-    /// The section is hidden entirely when no pairing is active or the
-    /// initial snapshot hasn't arrived yet (`desktopSettings == nil`).
-    /// This keeps the Settings screen looking intentional rather than
-    /// showing a placeholder row that the user can't interact with.
-    @ViewBuilder
-    private var desktopSettingsSection: some View {
-        if viewModel.desktopSettings != nil, viewModel.connectionState == .connected {
-            Section {
-                NavigationLink {
-                    DesktopSettingsView()
-                        .environment(viewModel)
-                } label: {
-                    HStack(spacing: 12) {
-                        Image(systemName: "slider.horizontal.3")
-                            .font(.body)
-                            .foregroundStyle(theme.accent)
-                            .frame(width: 28, height: 28)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Desktop Settings")
-                                .font(.body)
-                            Text(viewModel.activeDevice?.displayName ?? "Connected desktop")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            } footer: {
-                Text("Preferences for the currently-connected desktop. Each paired desktop keeps its own values.")
-            }
-        }
-    }
-
-    private var diagnosticsSection: some View {
-        Section("Diagnostics") {
-            HStack {
-                Label("Transport", systemImage: "antenna.radiowaves.left.and.right")
-                Spacer()
-                Text(transportLabel)
-                    .foregroundStyle(.secondary)
-            }
-            if let latency = viewModel.connectionQuality.latencyLabel {
-                HStack {
-                    Label("Latency", systemImage: "timer")
-                    Spacer()
-                    Text(latency)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            HStack {
-                Label("Buffered", systemImage: "tray.full")
-                Spacer()
-                Text("\(viewModel.connectionQuality.lastBuffered)")
-                    .foregroundStyle(.secondary)
-            }
-            HStack {
-                Label("Signal", systemImage: "wifi")
-                Spacer()
-                Text(viewModel.connectionQuality.signalLevel.label)
-                    .foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    private var newTabSection: some View {
-        Section("New Tab") {
-            Picker("Default Directory", selection: Binding<String?>(
-                get: { viewModel.defaultBaseDirectory },
-                set: { viewModel.defaultBaseDirectory = $0 }
-            )) {
-                Text("None (desktop default)").tag(nil as String?)
-                ForEach(viewModel.recentDirectories, id: \.self) { dir in
-                    Text((dir as NSString).lastPathComponent).tag(dir as String?)
-                }
-            }
-        }
-    }
-
-    private var tabListSection: some View {
-        Section {
-            Toggle(isOn: Binding(
-                get: { viewModel.showGitInfoInTabList },
-                set: { viewModel.showGitInfoInTabList = $0 }
-            )) {
-                Label("Show Git Info", systemImage: "arrow.triangle.branch")
-            }
-        } header: {
-            Text("Tab List")
-        } footer: {
-            Text("Shows the current branch and commit counts on each tab.")
-        }
-    }
-
-    private var agentPanelSection: some View {
-        Section {
-            Toggle(isOn: Binding(
-                get: { viewModel.agentPanelFullScreenPopup },
-                set: { viewModel.agentPanelFullScreenPopup = $0 }
-            )) {
-                Label("Full-Screen Agent Detail", systemImage: "rectangle.expand.vertical")
-            }
-        } header: {
-            Text("Agent Panel")
-        } footer: {
-            Text("When enabled, tapping an agent opens a full-screen detail view instead of expanding inline.")
-        }
-    }
-
-    private var modelsSection: some View {
-        let models = viewModel.availableModels
-        return Section("Models") {
-            Picker("Conversation", selection: Binding<String>(
-                get: { viewModel.preferredModel },
-                set: { newValue in viewModel.setPreferredModelDefault(newValue) }
-            )) {
-                ForEach(models) { model in
-                    Text(model.label).tag(model.id)
-                }
-            }
-            Picker("Engine", selection: Binding<String>(
-                get: { viewModel.engineDefaultModel },
-                set: { newValue in viewModel.setEngineDefaultModelDefault(newValue) }
-            )) {
-                Text("Same as Conversation").tag("")
-                ForEach(models) { model in
-                    Text(model.label).tag(model.id)
-                }
-            }
-        }
-    }
-
-    private var tabGroupsSection: some View {
-        Section {
-            Picker("Grouping", selection: Binding<String>(
-                get: { viewModel.tabGroupMode == "manual" ? "manual" : "auto" },
-                set: { newValue in viewModel.setTabGroupMode(newValue) }
-            )) {
-                Text("Auto (by directory)").tag("auto")
-                Text("Manual (custom groups)").tag("manual")
-            }
-
-            if viewModel.tabGroupMode == "manual" {
-                let sorted = viewModel.tabGroups.sorted { $0.order < $1.order }
-                ForEach(sorted) { group in
-                    HStack {
-                        Text(group.label)
-                        Spacer()
-                        if group.isDefault {
-                            Image(systemName: "star.fill")
-                                .font(.caption)
-                                .foregroundStyle(.yellow)
-                        }
-                    }
-                }
-                .onMove { source, destination in
-                    var reordered = sorted
-                    reordered.move(fromOffsets: source, toOffset: destination)
-                    let orderedIds = reordered.map(\.id)
-                    viewModel.reorderTabGroups(orderedIds: orderedIds)
-                }
-            }
-        } header: {
-            Text("Tab Groups")
-        } footer: {
-            if viewModel.tabGroupMode == "manual" {
-                Text("Drag to reorder groups. Create or delete groups from the desktop settings.")
-            }
-        }
-    }
-
-    private var pairedDevicesSection: some View {
-        Section {
-            if viewModel.pairedDevices.isEmpty {
-                Text("No paired devices")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(viewModel.pairedDevices) { device in
-                    let isActive = device.id == viewModel.activeDevice?.id
-                    Button {
-                        editingDevice = device
-                        Haptic.light()
-                    } label: {
-                        HStack {
-                            Image(systemName: device.displayIcon)
-                                .font(.title3)
-                                .foregroundStyle(theme.accent)
-                                .frame(width: 28, height: 28)
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack(spacing: 6) {
-                                    Text(device.displayName)
-                                        .font(.headline)
-                                        .foregroundStyle(.primary)
-                                    if device.customName != nil || device.customIcon != nil {
-                                        Image(systemName: "pencil.circle.fill")
-                                            .font(.caption2)
-                                            .foregroundStyle(.tertiary)
-                                            .help("Custom name/icon set")
-                                    }
-                                    if isActive {
-                                        Text("Active")
-                                            .font(.caption2)
-                                            .foregroundStyle(.green)
-                                            .padding(.horizontal, 6)
-                                            .padding(.vertical, 2)
-                                            .background(
-                                                Capsule().stroke(Color.green, lineWidth: 1)
-                                            )
-                                    }
-                                }
-                                // When a custom name is in use, show the original host
-                                // name in small text so users can still identify the
-                                // underlying machine.
-                                if let custom = device.customName?.trimmingCharacters(in: .whitespacesAndNewlines),
-                                   !custom.isEmpty,
-                                   custom != device.name {
-                                    Text(device.name)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                Text("Paired \(device.pairedAt.formatted(date: .abbreviated, time: .shortened))")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                if let lastSeen = device.lastSeen {
-                                    Text("Last seen \(lastSeen.formatted(.relative(presentation: .named)))")
-                                        .font(.caption2)
-                                        .foregroundStyle(.tertiary)
-                                }
-                            }
-                            Spacer()
-                            if !isActive {
-                                Button {
-                                    DiagnosticLog.log("[SettingsView] Connect tapped for device: \(device.id)")
-                                    viewModel.switchToDevice(id: device.id)
-                                    Haptic.success()
-                                    dismiss()
-                                } label: {
-                                    Text("Connect")
-                                        .font(.caption.weight(.medium))
-                                        .padding(.horizontal, 10)
-                                        .padding(.vertical, 4)
-                                        .background(theme.accent.opacity(0.15))
-                                        .foregroundStyle(theme.accent)
-                                        .clipShape(Capsule())
-                                }
-                                .buttonStyle(.borderless)
-                            }
-                            Image(systemName: "chevron.right")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
-                            Circle()
-                                .fill(isActive && viewModel.connectionState == .connected ? Color.green : Color(.tertiaryLabel))
-                                .frame(width: 8, height: 8)
-                        }
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                        if !isActive {
-                            Button {
-                                viewModel.switchToDevice(id: device.id)
-                                Haptic.success()
-                                dismiss()
-                            } label: {
-                                Label("Switch to", systemImage: "arrow.right.arrow.left")
-                            }
-                            .tint(theme.accent)
-                        }
-                    }
-                }
-                .onDelete { offsets in
-                    let devices = offsets.map { viewModel.pairedDevices[$0] }
-                    for device in devices {
-                        viewModel.unpairDevice(device)
-                    }
-                }
-            }
-
-            Button {
-                showPairingSheet = true
-            } label: {
-                Label("Pair New Desktop…", systemImage: "plus")
-            }
-        } header: {
-            Text("Paired Desktops")
-        } footer: {
-            Text("Tap a desktop to set a custom name and icon. Changes sync to all paired iPhones.")
-        }
-    }
-
-    private var appVersionString: String {
-        let info = Bundle.main.infoDictionary
-        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
-        let build = info?["CFBundleVersion"] as? String ?? "?"
-        let hash = info?["IonBuildHash"] as? String ?? "?"
-        return "v\(version) (\(build).\(hash))"
-    }
-
-    private var aboutSection: some View {
-        Section("About") {
-            HStack {
-                Spacer()
-                VStack(spacing: 8) {
-                    Image(systemName: "bolt.shield.fill")
-                        .font(.system(size: 40))
-                        .foregroundStyle(theme.accent)
-                    Text("Ion Remote")
-                        .font(.headline)
-                    Text(appVersionString)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-            }
-            .listRowBackground(Color.clear)
-
-            NavigationLink("Diagnostic Log") {
-                DiagnosticLogView()
-            }
-
-            Button(role: .destructive) {
-                dismiss()
-                viewModel.resetAll()
-            } label: {
-                HStack {
-                    Spacer()
-                    Text("Unpair All Devices")
-                        .font(.subheadline.weight(.medium))
-                    Spacer()
-                }
-            }
-            .buttonStyle(.bordered)
-            .tint(.red)
-            .listRowBackground(Color.clear)
         }
     }
 }

--- a/ios/IonRemote/Views/SettingsVoiceView.swift
+++ b/ios/IonRemote/Views/SettingsVoiceView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct SettingsVoiceView: View {
+    @Environment(SessionViewModel.self) private var viewModel
+    @Environment(\.appTheme) private var theme
+
+    @State private var elevenLabsKey: String = ""
+    @State private var keySaved = false
+    @State private var voiceTestInProgress = false
+    @State private var voiceTestResult: VoiceService.TestResult?
+    @State private var showVoiceTestAlert = false
+    @State private var voicePromptText: String = ""
+
+    var body: some View {
+        List {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { viewModel.voiceService.isEnabled },
+                    set: {
+                        viewModel.voiceService.isEnabled = $0
+                        viewModel.sendVoiceConfig()
+                    }
+                )) {
+                    Label("Voice Responses", systemImage: "waveform")
+                }
+                SecureField("ElevenLabs API Key", text: $elevenLabsKey)
+                    .textContentType(.password)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                Button {
+                    if elevenLabsKey.trimmingCharacters(in: .whitespaces).isEmpty {
+                        KeychainHelper.delete("com.ion.remote.elevenlabs")
+                    } else {
+                        KeychainHelper.set(elevenLabsKey, service: "com.ion.remote.elevenlabs")
+                    }
+                    withAnimation { keySaved = true }
+                    Haptic.success()
+                    Task {
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        withAnimation { keySaved = false }
+                    }
+                } label: {
+                    HStack {
+                        Text(keySaved ? "Key Saved ✓" : "Save Key")
+                        if keySaved {
+                            Spacer()
+                        }
+                    }
+                    .foregroundStyle(keySaved ? .green : theme.accent)
+                }
+                Button {
+                    voiceTestInProgress = true
+                    Task {
+                        let result = await viewModel.voiceService.testVoice()
+                        voiceTestInProgress = false
+                        voiceTestResult = result
+                        showVoiceTestAlert = true
+                        if result.isSuccess { Haptic.success() } else { Haptic.error() }
+                    }
+                } label: {
+                    HStack {
+                        Text("Test Voice")
+                        if voiceTestInProgress {
+                            Spacer()
+                            ProgressView()
+                        }
+                    }
+                }
+                .disabled(voiceTestInProgress)
+                Picker(selection: Binding(
+                    get: { viewModel.voiceService.voiceMode },
+                    set: {
+                        viewModel.voiceService.voiceMode = $0
+                        viewModel.sendVoiceConfig()
+                    }
+                )) {
+                    Text("Client-Only").tag(VoiceService.VoiceMode.clientOnly)
+                    Text("Desktop-Assisted").tag(VoiceService.VoiceMode.desktopAssisted)
+                } label: {
+                    Label("Processing", systemImage: "cpu")
+                }
+                if viewModel.voiceService.voiceMode == .desktopAssisted {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Voice System Prompt")
+                            .font(.subheadline.weight(.medium))
+                        TextEditor(text: $voicePromptText)
+                            .font(.caption)
+                            .frame(minHeight: 120, maxHeight: 200)
+                            .scrollContentBackground(.hidden)
+                            .background(Color(.systemGray6))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        HStack {
+                            Button("Save Prompt") {
+                                viewModel.voiceService.voiceSystemPrompt = voicePromptText
+                                viewModel.sendVoiceConfig()
+                                Haptic.success()
+                            }
+                            .font(.subheadline)
+                            Spacer()
+                            Button("Reset to Default") {
+                                voicePromptText = VoiceService.defaultVoicePrompt
+                                viewModel.voiceService.voiceSystemPrompt = voicePromptText
+                                viewModel.sendVoiceConfig()
+                            }
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                Text("Voice")
+            } footer: {
+                if !viewModel.voiceService.isEnabled {
+                    Text("Voice is off.")
+                } else if viewModel.voiceService.voiceMode == .desktopAssisted {
+                    Text("Desktop shapes LLM output for voice before iOS speaks it.")
+                } else {
+                    Text("iOS speaks assistant responses with client-side filtering.")
+                }
+            }
+            .onAppear {
+                elevenLabsKey = KeychainHelper.get("com.ion.remote.elevenlabs") ?? ""
+                voicePromptText = viewModel.voiceService.voiceSystemPrompt
+            }
+            .alert(
+                voiceTestResult?.isSuccess == true ? "Voice Test Passed" : "Voice Test Failed",
+                isPresented: $showVoiceTestAlert
+            ) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(voiceTestResult?.message ?? "")
+            }
+        }
+        .navigationTitle("Voice")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios/IonRemote/Views/SlashCommandMenu.swift
+++ b/ios/IonRemote/Views/SlashCommandMenu.swift
@@ -6,19 +6,29 @@ struct SlashCommandMenu: View {
     let commands: [DiscoveredSlashCommand]
     let onSelect: (DiscoveredSlashCommand) -> Void
 
+    private static let scopeOrder: [String: Int] = [
+        "builtin": 0, "project": 1, "extension": 2, "user": 3,
+    ]
+
+    private static let scopeLabels: [String: String] = [
+        "project": "Project", "extension": "Extension", "user": "User",
+    ]
+
     private var filteredCommands: [DiscoveredSlashCommand] {
-        let query = filter.lowercased()
-        let matches = commands.filter { cmd in
-            "/\(cmd.name)".lowercased().hasPrefix(query)
+        // Fuzzy-match and sort: score desc → scope order → alphabetical.
+        let results: [(cmd: DiscoveredSlashCommand, score: Int)] = commands.compactMap { cmd in
+            guard let score = FuzzyMatch.score(query: filter, candidate: "/\(cmd.name)") else {
+                return nil
+            }
+            return (cmd, score)
         }
-        // Sort: project commands first, then user, alphabetical within each group
-        return matches.sorted { a, b in
-            let scopeOrder = ["project": 0, "user": 1]
-            let aOrder = scopeOrder[a.scope] ?? 2
-            let bOrder = scopeOrder[b.scope] ?? 2
+        return results.sorted { a, b in
+            if a.score != b.score { return a.score > b.score }
+            let aOrder = Self.scopeOrder[a.cmd.scope] ?? 99
+            let bOrder = Self.scopeOrder[b.cmd.scope] ?? 99
             if aOrder != bOrder { return aOrder < bOrder }
-            return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
-        }
+            return a.cmd.name.localizedCaseInsensitiveCompare(b.cmd.name) == .orderedAscending
+        }.map(\.cmd)
     }
 
     var body: some View {
@@ -29,7 +39,8 @@ struct SlashCommandMenu: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(items.enumerated()), id: \.element.name) { index, cmd in
-                        let showHeader = index == 0 || items[index - 1].scope != cmd.scope
+                        let prevScope = index > 0 ? items[index - 1].scope : nil
+                        let showHeader = cmd.scope != "builtin" && cmd.scope != prevScope
 
                         if showHeader {
                             sectionHeader(cmd.scope)
@@ -50,7 +61,7 @@ struct SlashCommandMenu: View {
 
     @ViewBuilder
     private func sectionHeader(_ scope: String) -> some View {
-        Text(scope == "project" ? "Project" : "User")
+        Text(Self.scopeLabels[scope] ?? scope.capitalized)
             .font(.caption2)
             .fontWeight(.medium)
             .textCase(.uppercase)
@@ -65,7 +76,7 @@ struct SlashCommandMenu: View {
             onSelect(cmd)
         } label: {
             HStack(spacing: 8) {
-                Image(systemName: cmd.scope == "project" ? "folder.fill" : "person.fill")
+                Image(systemName: iconName(for: cmd.scope))
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                     .frame(width: 20, height: 20)
@@ -92,5 +103,15 @@ struct SlashCommandMenu: View {
         }
         .buttonStyle(.plain)
         .hoverEffect(.highlight)
+    }
+
+    private func iconName(for scope: String) -> String {
+        switch scope {
+        case "builtin": return "terminal.fill"
+        case "project": return "folder.fill"
+        case "extension": return "puzzlepiece.fill"
+        case "user": return "person.fill"
+        default: return "questionmark.circle"
+        }
     }
 }

--- a/ios/IonRemoteTests/ContractSyncTests.swift
+++ b/ios/IonRemoteTests/ContractSyncTests.swift
@@ -18,6 +18,16 @@ import XCTest
 ///     `types-engine.ts`. Drift attribution: if a future review flags
 ///     a missing iOS mirror of an EngineConfig field, the answer is
 ///     "by design"; flip back to this comment.
+///   - `LlmContentBlock` is intentionally not mirrored on iOS. The type
+///     is the wire shape carried inside `LlmMessage` payloads, which
+///     iOS never decodes (iOS consumes the higher-level normalized event
+///     stream — `engine_text_delta`, `engine_compacting`, etc.). The
+///     `compact_boundary` variant added in the gentle-knitting-cup plan
+///     surfaces on the wire through the existing `engine_compacting`
+///     event (which iOS already decodes); the typed boundary block is an
+///     engine-internal marker, not a renderer input. If a future iOS
+///     feature ever needs to walk `LlmMessage` blocks (e.g. a compaction
+///     transcript reader), add the Swift mirror at that point.
 final class ContractSyncTests: XCTestCase {
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()

--- a/ios/IonRemoteTests/MarkdownFormatterFixtures.swift
+++ b/ios/IonRemoteTests/MarkdownFormatterFixtures.swift
@@ -1,0 +1,212 @@
+// @file-size-exception: test fixture — a 194-line markdown corpus extracted
+// verbatim from conversation 1780405865550-54fac261fb2e entry f1c0d1b6.
+// Splitting would harm readability of the regression test that proves we
+// no longer drop content past the second fenced code block. Treat this as
+// an immutable data file: do not edit, comment-out, or reformat.
+
+import Foundation
+
+/// The exact text content of the last assistant message in conversation
+/// `1780405865550-54fac261fb2e` (entry `f1c0d1b6`). This corpus reproduces
+/// the iOS truncation defect: the Foundation `AttributedString(markdown:)`
+/// parser silently drops everything after the second fenced code block in
+/// Step 10. swift-markdown parses it in full. The regression test asserts
+/// that the closing `STOP — awaiting confirmation` line is reachable.
+enum MarkdownFormatterFixtures {
+    static let longMixedContent: String = #"""
+**File overlap confirmed.** Every engine fix touches files introduced or heavily modified by `f7e202f`:
+
+| Commit | Files | Overlap with f7e202f |
+|--------|-------|---------------------|
+| 268d708 | `providers/compact_boundary_test.go` (new), `conversation/compact_boundary_persistence_test.go` (new) | Tests for `providers/anthropic.go`, `providers/openai.go`, `conversation/compact_boundary.go` (all f7e202f) |
+| e96e93e | `backend/backend.go`, `runloop_compact_boundary_test.go`, `runloop_compaction.go`, `session/prompt_runconfig.go` | All four files modified in f7e202f |
+| f1f8293 | `runloop_compaction.go`, `compaction/compaction.go`, `compaction/compact_boundary_test.go` | All three modified in f7e202f |
+| a3518ec | `backend/runloop_compact_boundary_test.go` | Created in f7e202f |
+| b4109b7 | `extension/sdk_hooks_compact_summary_test.go` (new) | Tests `extension/sdk_hooks_session.go` and `sdk.go` (both f7e202f) |
+| 5f74d0d | `docs/hooks/reference.md`, `docs/extensions/sdk-*.md`, `engine/AGENTS.md` | Documents the hook added in f7e202f |
+
+**Temporal proximity:** Commits 1–4 are within ~2 hours on 2026-05-28. Commits 5–9 are within ~8 minutes on 2026-06-02. Two work sessions, both extending the same f7e202f foundation.
+
+**Greenfield signal:** f7e202f introduces `compact_boundary.go` (139 new lines), `compact_boundary_test.go`, the `LlmContentBlock` `compact_boundary` variant, the `OnRequestCompactSummary` hook, the `HookCompactSummaryRequest` SDK hook, `BuildCompactBoundaryMessage`, `MessagesAfterLastCompactBoundary`, `PostCompactReset`, `renderCompactSummary`, four-tier ladder. Every follower extends or pins this foundation. Strong greenfield signal despite the `fix(engine)` label.
+
+## Step 5: Trace Fix → Feature Relationships
+
+The chain root (`f7e202f`) is labeled `fix` but is actually greenfield. Per Step 4's chain rule, the chain root keeps its position. The chain type promotion goes `feat!` > `feat` > `fix` > `chore`. Since there are no `feat(engine)` commits in this chain, the synthesized type is `fix(engine)`.
+
+Let me trace each follower:
+
+- **268d708** (fix, engine): "pin compact_boundary wire and persistence contracts" — body literally says "gentle-knitting-cup follow-up audit" referring to f7e202f. **Chain follower.**
+- **e96e93e** (fix, engine): explicitly references "added as a 2-arg function ... in commit f7e202f" and threads through Strategy that f7e202f introduced. **Chain follower.**
+- **f1f8293** (chore, engine): "renderCompactSummary was added in commit f7e202f as the documented single rendering decision point ... The helper was dead code." Completes the extraction f7e202f started. **Chain follower (cleanup).**
+- **a3518ec** (fix, engine): "compactReactive had four structural assertion tests in runloop_compact_boundary_test.go [added by f7e202f], but compactIfNeeded had only the pre-existing tests." Adds proactive-path coverage. **Chain follower.**
+- **b4109b7** (fix, engine): covers `FireCompactSummaryRequest` (introduced by f7e202f) return shapes. **Chain follower.**
+- **5f74d0d** (docs, engine): documents the `compact_summary_request` hook added by f7e202f. **Chain follower (docs).**
+
+## Step 6: Repeated Fix Clusters
+
+No repeated fix clusters in the strict sense (no two commits attack the same problem with similar messages). Each follower targets a distinct gap: provider wire test, persistence test, strategy threading, helper extraction, proactive-path test, return-shape test, docs. These are sequential gap-closures on the same foundation, which is exactly what a chain looks like.
+
+## Step 7: Superseding Rewrites
+
+None. The chain only extends and refines f7e202f's foundation — it doesn't replace anything.
+
+## Cross-scope check: 7580242 and 0d1994a
+
+- **7580242** `feat(desktop)`: mirrors `LlmContentBlock` into `desktop/src/shared/types-engine.ts`. Same logical feature as f7e202f but different scope.
+- **0d1994a** `docs(ios)`: notes that iOS intentionally does not mirror `LlmContentBlock`. Same logical feature, different scope.
+
+Per Step 4d, **cross-scope pairs are NOT squashed**. These stay as separate commits. They are informationally related to the engine chain but live in different scopes per the repo's commit-scope rules in `CLAUDE.md`.
+
+Also, both `7580242` and `0d1994a` are independent of each other only in scope — they document the same engine change for two different clients. They each stand alone in their respective scopes.
+
+## Step 8: Classify Every Commit
+
+| # | Hash | Disposition | Rebase action |
+|---|------|-------------|---------------|
+| 1 | f7e202f | **Chain root** (engine compaction) | `pick` |
+| 2 | 7580242 | Standalone (cross-scope: desktop) | `pick` |
+| 3 | 0d1994a | Standalone (cross-scope: ios) | `pick` |
+| 4 | 268d708 | Chain follower (engine) | `fixup` after f7e202f |
+| 5 | e96e93e | Chain follower (engine) | `fixup` after f7e202f |
+| 6 | f1f8293 | Chain follower (engine, chore) | `fixup` after f7e202f |
+| 7 | a3518ec | Chain follower (engine) | `fixup` after f7e202f |
+| 8 | b4109b7 | Chain follower (engine) | `fixup` after f7e202f |
+| 9 | 5f74d0d | Chain follower (engine, docs) | `fixup` after f7e202f |
+
+## Conflict risk for moved followers
+
+Followers 4–9 must move past commits 2 (desktop) and 3 (ios) to land adjacent to f7e202f. Both intervening commits touch **only** `desktop/` and `ios/` files. All chain followers touch **only** `engine/` or `docs/` files. **Zero file overlap — zero conflict risk.**
+
+## Step 9: Synthesize Chain Commit Message
+
+The root's subject "structurally dedupe compaction summaries" undersells the actual scope (it introduces `compact_boundary`, a new SDK hook, and a four-tier rendering ladder). Followers broaden it meaningfully (strategy threading, contract pinning, hook docs). The synthesized subject should reflect the full theme.
+
+Proposed synthesized message:
+
+```
+fix(engine): introduce compact_boundary and dedupe summaries
+
+- structurally dedupe compaction summaries
+- pin compact_boundary wire and persistence contracts
+- thread compact strategy through OnRequestCompactSummary
+- route compact summary through one helper
+- add proactive-path compact_boundary injection test
+- cover FireCompactSummaryRequest fan-out return shapes
+- document compact_summary_request hook
+```
+
+Subject is 49 chars (≤ 50 ✓), lowercase, imperative, no period, `fix(engine):` scope matches the root and the highest-priority type in the chain (no `feat` in the chain). Body lists each absorbed commit's original description, oldest to newest.
+
+## Step 10: Rebase Plan
+
+```
+pick   f7e202f fix(engine): structurally dedupe compaction summaries          # CHAIN ROOT (will reword)
+fixup  268d708 fix(engine): pin compact_boundary wire and persistence contracts
+fixup  e96e93e fix(engine): thread compact strategy through OnRequestCompactSummary
+fixup  f1f8293 chore(engine): route compact summary through one helper
+fixup  a3518ec fix(engine): add proactive-path compact_boundary injection test
+fixup  b4109b7 fix(engine): cover FireCompactSummaryRequest fan-out return shapes
+fixup  5f74d0d docs(engine): document compact_summary_request hook
+pick   7580242 feat(desktop): mirror LlmContentBlock with compact_boundary fields
+pick   0d1994a docs(ios): note LlmContentBlock is intentionally not mirrored
+```
+
+Approach: I'll do this in two passes.
+1. First pass: non-interactive rebase with a scripted todo that moves all chain followers adjacent to the root and marks them `fixup`. Use `GIT_SEQUENCE_EDITOR` to write the todo deterministically.
+2. After fixup completes, amend the (now-combined) chain root commit with the synthesized message via `git commit --amend -F <file>`.
+
+This avoids running `git rebase -i` twice and removes the `reword` complication.
+
+## Step 11: Analysis Presentation
+
+### Backup status
+`backup--work` already existed at HEAD `5f74d0d`. ✓
+
+### Commit summary
+- Total unpushed: **9 commits**
+- By type: 5 `fix`, 1 `feat`, 1 `chore`, 2 `docs`
+- By scope: 7 `engine`, 1 `desktop`, 1 `ios`
+
+### Feature chains (the one chain found)
+
+**Chain: engine compaction / compact_boundary**
+
+| Role | Hash | Original subject |
+|------|------|------------------|
+| Root | f7e202f | fix(engine): structurally dedupe compaction summaries |
+| Follower | 268d708 | fix(engine): pin compact_boundary wire and persistence contracts |
+| Follower | e96e93e | fix(engine): thread compact strategy through OnRequestCompactSummary |
+| Follower | f1f8293 | chore(engine): route compact summary through one helper |
+| Follower | a3518ec | fix(engine): add proactive-path compact_boundary injection test |
+| Follower | b4109b7 | fix(engine): cover FireCompactSummaryRequest fan-out return shapes |
+| Follower | 5f74d0d | docs(engine): document compact_summary_request hook |
+
+**Rationale:**
+- **Subject overlap:** every follower references `compact_boundary`, `compact_summary`, `OnRequestCompactSummary`, or `FireCompactSummaryRequest` — all introduced by f7e202f.
+- **Explicit hash citations:** four followers (268d708, e96e93e, f1f8293, 5f74d0d) name f7e202f by hash in their bodies.
+- **File overlap:** every follower touches files created or modified by f7e202f (`runloop_compaction.go`, `runloop_compact_boundary_test.go`, `compaction.go`, `backend.go`, `prompt_runconfig.go`, `compact_boundary.go`, providers, SDK hooks).
+- **Temporal proximity:** two work sessions (2026-05-28 ~2h window, 2026-06-02 ~8min window) all on the same subsystem.
+- **Greenfield signal:** f7e202f introduces 1316 lines of new infrastructure (new files `compact_boundary.go`, new SDK hook, new content-block variant, new helpers). Followers test, refine, and document this foundation — they do not modify pre-existing behavior.
+
+**Proposed synthesized commit message:**
+
+```
+fix(engine): introduce compact_boundary and dedupe summaries
+
+- structurally dedupe compaction summaries
+- pin compact_boundary wire and persistence contracts
+- thread compact strategy through OnRequestCompactSummary
+- route compact summary through one helper
+- add proactive-path compact_boundary injection test
+- cover FireCompactSummaryRequest fan-out return shapes
+- document compact_summary_request hook
+```
+
+### Fix follow-ups (non-chain)
+None. All fixes belong to the chain.
+
+### Repeated fix clusters
+None. Each follower closes a distinct gap.
+
+### Superseding rewrites
+None.
+
+### Cross-scope pairs (informational only — NOT squashed)
+- **7580242** `feat(desktop)`: mirrors the engine's new `LlmContentBlock.compact_boundary` fields into TypeScript for contract sync.
+- **0d1994a** `docs(ios)`: documents that iOS intentionally does not mirror `LlmContentBlock`.
+
+Both relate to f7e202f's engine work but belong to other scopes per `.commit.json` rules. They stay as separate commits.
+
+### Standalone commits
+- **7580242** `feat(desktop)` — cross-scope, kept as-is.
+- **0d1994a** `docs(ios)` — cross-scope, kept as-is.
+
+### Before / after count
+**9 commits → 3 commits (6 squashed away)**
+
+### Full rebase plan (annotated)
+
+```
+# Group: engine compaction chain
+pick   f7e202f fix(engine): structurally dedupe compaction summaries          # ROOT (will be amended with synthesized message)
+fixup  268d708 fix(engine): pin compact_boundary wire and persistence contracts
+fixup  e96e93e fix(engine): thread compact strategy through OnRequestCompactSummary
+fixup  f1f8293 chore(engine): route compact summary through one helper
+fixup  a3518ec fix(engine): add proactive-path compact_boundary injection test
+fixup  b4109b7 fix(engine): cover FireCompactSummaryRequest fan-out return shapes
+fixup  5f74d0d docs(engine): document compact_summary_request hook
+
+# Group: cross-scope (kept separate)
+pick   7580242 feat(desktop): mirror LlmContentBlock with compact_boundary fields
+pick   0d1994a docs(ios): note LlmContentBlock is intentionally not mirrored
+```
+
+**Conflict risk:** Low/zero. The chain followers (engine + docs files) are being moved past the desktop and ios commits, but the file sets are disjoint. No textual conflicts expected.
+
+After the rebase, `git commit --amend -F -` is used on the combined chain root to apply the synthesized message.
+
+---
+
+⚠️ **STOP — awaiting confirmation.**
+"""#
+}

--- a/ios/IonRemoteTests/MarkdownFormatterTests.swift
+++ b/ios/IonRemoteTests/MarkdownFormatterTests.swift
@@ -1,0 +1,267 @@
+import XCTest
+@testable import IonRemote
+
+/// Tests for `MarkdownFormatter.parse(_:)`. The primary goal is to lock in
+/// the fix for the iOS truncation defect (conversation
+/// `1780405865550-54fac261fb2e`, entry `f1c0d1b6`) where Foundation's
+/// `AttributedString(markdown:)` silently dropped everything after the
+/// second fenced code block. Beyond that, we exercise the robustness
+/// contract: unclosed fences, malformed tables, mismatched delimiters,
+/// mixed line endings, pathological size, and empty input. Every test
+/// asserts `parse(...)` returns non-empty and does not throw.
+@MainActor
+final class MarkdownFormatterTests: XCTestCase {
+
+    // MARK: - Regression: the truncation bug
+
+    /// The original defect: the f1c0d1b6 corpus contains four fenced code
+    /// blocks, multiple tables, ~20 headings, and ~12 KB of mixed content.
+    /// Foundation returned the prefix through the second code block and
+    /// dropped the rest. swift-markdown returns the entire document.
+    func testLongMixedContentParsesInFull() {
+        let blocks = MarkdownFormatter.parse(MarkdownFormatterFixtures.longMixedContent)
+
+        // Lower bound: the real count is ~80. We assert ≥ 30 to catch any
+        // future regression where a parser change silently halves output
+        // without going all the way to zero.
+        XCTAssertGreaterThanOrEqual(
+            blocks.count, 30,
+            "expected ≥30 blocks for 12KB mixed-content corpus, got \(blocks.count)"
+        )
+
+        // The closing line. If this is missing, the parser dropped the tail.
+        let allText = plainText(of: blocks)
+        XCTAssertTrue(
+            allText.contains("STOP"),
+            "tail content missing: closing 'STOP — awaiting confirmation' not in output"
+        )
+        XCTAssertTrue(
+            allText.contains("awaiting confirmation"),
+            "tail content missing: 'awaiting confirmation' phrase not in output"
+        )
+
+        // At least 3 fenced code blocks should land as `.code(...)`. The
+        // corpus contains 4; ≥ 3 leaves headroom if a future parser change
+        // merges an adjacent fence into surrounding text.
+        let codeCount = blocks.filter {
+            if case .code = $0 { return true } else { return false }
+        }.count
+        XCTAssertGreaterThanOrEqual(
+            codeCount, 3,
+            "expected ≥3 code blocks, got \(codeCount)"
+        )
+    }
+
+    // MARK: - Robustness: malformed / partial markdown
+
+    /// LLM cut off mid-stream: opens a fenced code block with ``` and never
+    /// closes it. Per the CommonMark spec, the code block extends to EOF.
+    /// We assert the trailing content lands as a `.code(...)` block and no
+    /// content is lost.
+    func testUnclosedFenceFromCutOffStream() {
+        let input = """
+        Here is some prose before the cut-off.
+
+        ```swift
+        func foo() {
+            let x = 1
+        // (LLM cut off here, no closing fence)
+        """
+
+        let blocks = MarkdownFormatter.parse(input)
+
+        XCTAssertFalse(blocks.isEmpty, "must return ≥1 block for non-empty input")
+
+        // The fenced code block must be present (per CommonMark, EOF closes it).
+        let codeBlocks = blocks.compactMap { block -> String? in
+            if case .code(_, let code) = block { return code } else { return nil }
+        }
+        XCTAssertGreaterThanOrEqual(
+            codeBlocks.count, 1,
+            "unclosed fence should still produce a code block at EOF"
+        )
+
+        // The body text from the cut-off body should be present somewhere
+        // in the parse output (either inside the code block or as paragraph
+        // text, depending on how the parser ended the block).
+        let allText = plainText(of: blocks)
+        XCTAssertTrue(
+            allText.contains("func foo()"),
+            "cut-off code content was lost: 'func foo()' missing from parse"
+        )
+    }
+
+    /// A header-only "table" with no separator row. Per GFM, this is not a
+    /// table — it should fall through to paragraph text. The pipe-delimited
+    /// text must still appear in the output.
+    func testUnclosedTableDemotedToParagraph() {
+        let input = """
+        | a | b | c |
+        Some text after the fake header row.
+        """
+
+        let blocks = MarkdownFormatter.parse(input)
+
+        XCTAssertFalse(blocks.isEmpty)
+        // No table block should be present.
+        let tableCount = blocks.filter {
+            if case .table = $0 { return true } else { return false }
+        }.count
+        XCTAssertEqual(tableCount, 0, "malformed table must not produce a .table block")
+
+        // The pipe text and the trailing prose must both survive.
+        let allText = plainText(of: blocks)
+        XCTAssertTrue(allText.contains("a"))
+        XCTAssertTrue(allText.contains("Some text after"))
+    }
+
+    /// Open with ``` but "close" with ~~~. CommonMark requires the closer
+    /// match the opener exactly, so ~~~ is body text and the fence runs to
+    /// EOF. No throw, all content preserved.
+    func testMismatchedFenceDelimiters() {
+        let input = """
+        ```swift
+        let x = 1
+        ~~~
+        let y = 2
+        """
+
+        let blocks = MarkdownFormatter.parse(input)
+
+        XCTAssertFalse(blocks.isEmpty)
+        let allText = plainText(of: blocks)
+        XCTAssertTrue(allText.contains("let x = 1"))
+        XCTAssertTrue(allText.contains("let y = 2"))
+        XCTAssertTrue(allText.contains("~~~"),
+                     "mismatched closer should be body text, not a separator")
+    }
+
+    /// Feed progressive prefixes of a multi-block document, simulating
+    /// engine_text_delta arrival mid-stream. Every prefix must parse
+    /// without throwing and return ≥ 1 block.
+    func testPartialStreamingInput() {
+        let full = """
+        # Heading
+
+        Some prose.
+
+        ```swift
+        let x = 1
+        ```
+
+        - bullet one
+        - bullet two
+        """
+
+        // Sample at byte offsets 1, 4, 16, 64, 256, ..., and the full length.
+        var offsets: [Int] = []
+        var n = 1
+        while n < full.count {
+            offsets.append(n)
+            n *= 4
+        }
+        offsets.append(full.count)
+
+        for offset in offsets {
+            let prefix = String(full.prefix(offset))
+            let blocks = MarkdownFormatter.parse(prefix)
+            XCTAssertGreaterThanOrEqual(
+                blocks.count, 1,
+                "prefix len=\(offset) returned 0 blocks"
+            )
+        }
+    }
+
+    /// CRLF, LF, and CR variants of the same document must produce the same
+    /// block count. swift-markdown normalizes per CommonMark; we also
+    /// normalize on entry as belt-and-suspenders.
+    func testMixedLineEndings() {
+        let lf = "# Heading\n\nSome prose.\n\n- bullet\n"
+        let crlf = lf.replacingOccurrences(of: "\n", with: "\r\n")
+        let cr = lf.replacingOccurrences(of: "\n", with: "\r")
+
+        let lfBlocks = MarkdownFormatter.parse(lf)
+        let crlfBlocks = MarkdownFormatter.parse(crlf)
+        let crBlocks = MarkdownFormatter.parse(cr)
+
+        XCTAssertEqual(lfBlocks.count, crlfBlocks.count,
+                      "CRLF and LF should produce same block count")
+        XCTAssertEqual(lfBlocks.count, crBlocks.count,
+                      "CR and LF should produce same block count")
+    }
+
+    /// 5MB single paragraph: must parse in bounded time and produce a small
+    /// number of paragraph blocks (cmark-gfm is a streaming C parser).
+    func testPathologicalSize() {
+        // Single very long line (no newlines) → one paragraph.
+        let big = String(repeating: "a ", count: 2_500_000)
+        XCTAssertGreaterThan(big.count, 4_000_000)
+
+        let start = Date()
+        let blocks = MarkdownFormatter.parse(big)
+        let elapsed = Date().timeIntervalSince(start)
+
+        XCTAssertFalse(blocks.isEmpty)
+        // Generous bound — we just want to catch O(n²) regressions.
+        XCTAssertLessThan(elapsed, 10.0,
+                         "5MB parse took \(elapsed)s; expected < 10s")
+    }
+
+    /// "Table-like" prose with pipes but no separator: must demote to
+    /// paragraph(s), never crash, and preserve all pipe text.
+    func testAdversarialTableLikeProse() {
+        let input = """
+        Here is some text | with pipes | scattered around |
+        | More | pipes | in the next line |
+        Final line.
+        """
+
+        let blocks = MarkdownFormatter.parse(input)
+        XCTAssertFalse(blocks.isEmpty)
+        let tableCount = blocks.filter {
+            if case .table = $0 { return true } else { return false }
+        }.count
+        XCTAssertEqual(tableCount, 0)
+
+        let allText = plainText(of: blocks)
+        XCTAssertTrue(allText.contains("Final line"))
+    }
+
+    /// Empty string and whitespace-only input both produce a single empty
+    /// paragraph (the no-blocks-ever-returned invariant).
+    func testEmptyInput() {
+        let empty = MarkdownFormatter.parse("")
+        XCTAssertEqual(empty.count, 1, "empty input should return [.paragraph(empty)]")
+        if case .paragraph(let t) = empty[0] {
+            XCTAssertEqual(String(t.characters), "")
+        } else {
+            XCTFail("expected single .paragraph for empty input, got \(empty)")
+        }
+
+        let whitespace = MarkdownFormatter.parse("   \n\n  \t  \n")
+        XCTAssertEqual(whitespace.count, 1, "whitespace input should return one block")
+    }
+
+    // MARK: - Helpers
+
+    /// Plain-text concatenation of every block's text for substring assertions.
+    private func plainText(of blocks: [MarkdownBlock]) -> String {
+        var out = ""
+        for block in blocks {
+            switch block {
+            case .heading(_, let t):     out += String(t.characters) + "\n"
+            case .paragraph(let t):      out += String(t.characters) + "\n"
+            case .code(_, let text):     out += text + "\n"
+            case .blockQuote(let t):     out += String(t.characters) + "\n"
+            case .listItem(_, _, let t): out += String(t.characters) + "\n"
+            case .thematicBreak:         out += "---\n"
+            case .table(let headers, let rows, _):
+                out += headers.map { String($0.characters) }.joined(separator: " | ") + "\n"
+                for row in rows {
+                    out += row.map { String($0.characters) }.joined(separator: " | ") + "\n"
+                }
+            }
+        }
+        return out
+    }
+}

--- a/relay/go.mod
+++ b/relay/go.mod
@@ -2,7 +2,7 @@ module github.com/dsswift/ion/relay
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/coder/websocket v1.8.14


### PR DESCRIPTION
## Summary

Overhauls compaction to eliminate duplicate summaries via a new `compact_boundary` content block with structural dedup, adds the `compact_summary_request` SDK hook for harness-supplied summarisation, introduces fuzzy matching for slash commands on both desktop and iOS, and fixes silent message truncation on both platforms.

## Changes

- **engine:** structurally deduplicate compaction summaries with a new `compact_boundary` LlmContentBlock variant, `MessagesAfterLastCompactBoundary` duplication firewall, and per-section fact caps
- **engine:** add `compact_summary_request` SDK hook for harness-supplied LLM summarisation with hook→regex fallback
- **engine:** thread compact strategy (`"auto"` | `"reactive"`) through `OnRequestCompactSummary` so harness handlers can branch on trigger type
- **engine:** route all compact summary rendering through `renderCompactSummary` helper, removing dead code
- **engine:** pin compact_boundary wire and persistence contracts with provider serializer and round-trip tests
- **engine:** deduplicate tool names in dispatched agent sessions to fix `Tool names must be unique` errors after extension respawn (#171)
- **engine:** unwrap `_payload` wrapper in SDK runtime so string hook payloads reach handlers as typed strings (#170)
- **engine:** preserve corrected agent display names
- **engine:** add proactive-path compact_boundary injection test and FireCompactSummaryRequest fan-out return shape coverage
- **desktop:** remove silent 10 KB truncation of non-tool messages that cut off long assistant responses
- **desktop:** mirror `LlmContentBlock` with compact_boundary fields in contract-sync
- **desktop:** add fuzzy matching for slash commands
- **ios:** replace Foundation markdown parser with apple/swift-markdown to fix truncation of multi-code-block messages
- **ios:** add fuzzy matching for slash commands
- **ios:** split settings into separate view files
- **docs:** document `compact_summary_request` hook in reference, SDK guides, and engine AGENTS.md
- **docs:** note `LlmContentBlock` is intentionally not mirrored on iOS

Fixes #171
Fixes #170