### PR TITLE
Model fallback indicator + slash-command frontmatter + epistemic-hygiene rules

### DIFF
--- a/.ion/commands/create-issue.md
+++ b/.ion/commands/create-issue.md
@@ -1,6 +1,11 @@
 ---
 description: Open a GitHub issue on the Ion engine repo for a bug or feature request derived from the current conversation, with consumer project details scrubbed.
 allowed-tools: Bash(gh issue create:*), Bash(gh issue list:*), Bash(gh issue view:*), Bash(ls:*), Read, Edit
+allowed_bash_commands:
+  - gh issue create
+  - gh issue list
+  - gh issue view
+model: smart
 ---
 
 Open a GitHub issue on the `dsswift/ion` repository based on the current conversation. The issue must contain enough context for Ion engine developers to understand what to implement and how it should behave — without leaking any details about the consumer project that surfaced the need.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ Desktop and iOS are co-equal clients. When a desktop change touches a feature th
 | Thinking indicator / interrupt button | Activity indicator / interrupt button | Real-time events (`engineTextDelta`, `tabStatus`) |
 | Tab context menu (TabStripTabContextMenu) | Tab context menu (TabRowContextMenu) | Actions operate on `RemoteTabState` fields; session identity via `snapshot.ts` → `RemoteTabState.conversationId` (CLI) and `StatusFields.sessionId` (engine) |
 | Desktop Settings dialog (SettingsDialog categories) | Desktop Settings detail (DesktopSettingsView sections) | `projectable-settings.ts` allowlist → `desktop_settings_snapshot` event (settings + schema + groups) → `DesktopSettingsView` auto-renders sections. iOS group IDs **must** match the desktop's `CATEGORIES` array; renaming a desktop category requires updating `PROJECTABLE_GROUP_LABELS` and the test in `projectable-settings.test.ts`. Adding a new user-editable desktop preference requires a parallel entry in `PROJECTABLE_SETTINGS_DATA` unless the setting is local-machine-only (font, path, secret). |
+| Model fallback indicator (EngineStatusBar per-instance ⚠) | Model fallback indicator (EngineInstanceBar per-instance ⚠) | `snapshot.ts` → `RemoteTabState.engineInstances[i].modelFallback`. Desktop populates `engineModelFallbacks` from the `engine_model_fallback` event; the snapshot poller projects each entry onto the corresponding `engineInstances[i]` and iOS reads it from the snapshot. Cleared on the next idle transition (per-instance). |
 
 ### When to skip iOS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,14 @@ Before flagging an engine change as a contract violation, ask: *would this break
 
 Use the external-consumer simulation, not the in-repo caller search, to decide.
 
+### The typed-event corollary
+
+When the engine has signal to communicate, it emits a typed `NormalizedEvent` variant. That emission is the engine's *complete* fulfillment of its signaling obligation for that signal. The engine does not also owe a parallel surface in stream content (no appending to `TaskCompleteEvent.Result`, no mutating `TextChunkEvent`, no synthetic system messages, no log-line-as-source-of-truth). Doing any of that would force every consumer through one specific UI-shaped interpretation and would corrupt headless pipelines that parse stream content as the LLM's verbatim output.
+
+Consequence: when a reviewer asks *"but a headless user who isn't subscribed to event X wouldn't notice Y"* — that is the engine working as designed. The headless user receives the JSON event stream; the typed event is in it. Their orchestration may abort, retry, notify, ignore, or do anything else. The engine has no opinion. Reference implementations in this repo (desktop, iOS) choose their own opinionated rendering; that is **one consumer's policy**, not the engine's recommendation.
+
+This applies equally to warnings (model fallback, deprecation notices), advisories (rate limits, retries, context compaction), and state transitions (agent lifecycle, plan-mode changes). Pick the right event shape, emit it once, and stop. Do not double-surface.
+
 ### Consequences (the operational rules that flow from the framing above)
 
 - **Do not require an in-repo consumer before adding engine API surface.** If a hook, protocol field, or SDK method is useful to external consumers, it belongs in the engine — even if desktop and iOS don't use it yet. The absence of desktop/iOS usage is not evidence of premature code; it is evidence that the reference implementations haven't caught up.
@@ -294,6 +302,63 @@ Specifically forbidden as plan resolutions for *any* finding you can fix in the 
 A valid plan resolution is one of: change code, change a contract, delete code, add a test that pins behavior, or explicitly decide to do nothing with a stated rationale. "Document the problem" is not a resolution.
 
 The `ion--review-changes.md` and `ion--align.md` commands enforce this rule at plan-generation time. Reviewers should reject any plan that violates it.
+
+## Operator premises — verify before acting
+
+Operator requests routinely contain **factual premises about the codebase** — "we only support X", "the only place that happens is Y", "this field is unused", "feature Z doesn't exist yet". These premises are frequently wrong. The author of this repository is wrong about them sometimes; new contributors are wrong about them more often. **Treat every premise as a claim to be verified, not as ground truth.**
+
+The failure mode this rule prevents: the operator states a premise, the agent silently accepts it, and the agent then refactors, deletes, restricts, or "fixes" code based on a misunderstanding the operator would have corrected if asked. By the time the operator sees the change, the wrong work is done.
+
+### When this rule fires
+
+Any operator request that asserts a concrete fact about the codebase. Common signals:
+
+- "we only support …" / "the only … is …" / "X is the only place that …"
+- "we don't have …" / "there's no …" / "X doesn't exist yet"
+- "X always does Y" / "X never does Y"
+- "the file picker only accepts …" / "the engine only emits …" / "the SDK only exposes …"
+- Any naming, shape, count, or scope claim about events, fields, hooks, tools, file types, config keys, protocol messages, or supported inputs.
+
+The trigger is **the presence of a factual claim**, not the operator's tone or confidence. A confidently stated wrong premise is the most dangerous kind.
+
+### What verification looks like
+
+Before designing or implementing anything that depends on the premise:
+
+1. **Locate the ground-truth source.** Find the code, contract, or doc that proves or disproves the claim — the actual file filter, the actual event variant list, the actual SDK surface, the actual permission list.
+2. **Compare the premise to ground truth.** Be specific: "the operator said *only* `index.ts` and `extension.ts`; the manifest loader at `engine/internal/extension/manifest.go` accepts `<actual list>`."
+3. **Decide based on the comparison, not the premise.**
+
+This step is not "extra rigor." It is the first step of the work. Skipping it is a defect.
+
+### What to do when the premise is wrong
+
+**Stop and surface the discrepancy to the operator before doing any of the requested work.** Do not:
+
+- Silently implement what was asked, hoping the operator was right.
+- Silently implement the "corrected" version you think they meant.
+- Refactor, narrow, delete, or restrict existing functionality to match the (wrong) premise.
+
+Instead, respond with a short message that contains:
+
+1. **The premise as stated.** ("You said we only support `index.ts` and `extension.ts`.")
+2. **The ground truth.** ("The engine actually accepts `<list>`, loaded via `<path>`.")
+3. **A direct question.** ("Do you still want the picker restricted to the two filenames, or should it match the engine's full set?")
+
+Only proceed once the operator confirms which version of reality the change should target.
+
+### What this rule is not
+
+- It is **not** an excuse to pepper the operator with questions about every adjective in their request. The trigger is a verifiable factual claim about the codebase, not stylistic ambiguity ("make it pretty") or judgment calls ("pick a good default").
+- It is **not** a license to refuse work. The expected outcome is *clarification in seconds*, then the right work — not an extended debate.
+- It is **not** limited to the author. New contributors and external developers will hit this more often than the author does. The rule exists because *any* operator can be wrong about *any* codebase fact, and the agent is the last line of defense against acting on the wrong fact.
+
+### Anti-patterns
+
+- "The operator said X, so I'll implement X." — Without verifying X against the code, this is the exact failure mode the rule exists to prevent.
+- "I noticed the premise is wrong, but I implemented what they asked anyway and noted it in the response." — Too late. The wrong work is done. Surface the discrepancy *before* writing code, not after.
+- "I noticed the premise is wrong, so I implemented what I thought they really meant." — Also wrong. Confirm with the operator which version is correct; do not silently substitute your interpretation.
+- "The premise is *probably* right, I'll skip verification." — The premises that look most obviously right are the ones where verification is cheapest and the cost of being wrong is highest. Verify anyway.
 
 ## Solution quality — no cheap substitutes
 

--- a/desktop/src/main/__tests__/discover-commands-ipc.test.ts
+++ b/desktop/src/main/__tests__/discover-commands-ipc.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression test for the IPC.DISCOVER_COMMANDS handler in
+ * `ipc/sessions-list.ts`.
+ *
+ * Bug: when `enableClaudeCompat` was disabled in desktop settings, the
+ * handler short-circuited to `[]` for the entire result set, hiding
+ * `~/.ion/commands/` and `{project}/.ion/commands/` entries. Only the
+ * renderer's built-in `/clear` remained in the autocomplete list.
+ *
+ * Fix: always call `discoverCommands`, then filter out
+ * `origin === 'claude'` entries when the setting is off. Ion-native
+ * commands are always available; only `.claude/*` paths are gated by
+ * the setting (matching the expansion-time gate in
+ * `slash-classify.ts`).
+ *
+ * Sibling regression: the iOS `discover_commands` remote handler in
+ * `remote/handlers/tabs.ts` had no gate at all, so iOS would show
+ * `.claude/*` entries even when the desktop setting was off. The same
+ * filter is applied there for desktop↔iOS parity.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const handlers = new Map<string, (...args: any[]) => any>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: any[]) => any) => {
+      handlers.set(channel, handler)
+    },
+    on: (channel: string, handler: (...args: any[]) => any) => {
+      handlers.set(channel, handler)
+    },
+  },
+}))
+
+// Mutable settings shim so each test can flip enableClaudeCompat.
+const settingsMock = vi.hoisted(() => ({ enableClaudeCompat: true as boolean }))
+
+vi.mock('../settings-store', () => ({
+  readSettings: () => ({ enableClaudeCompat: settingsMock.enableClaudeCompat }),
+  SETTINGS_DEFAULTS: { enableClaudeCompat: true },
+  currentBackend: 'cli',
+  loadSessionLabels: () => ({}),
+}))
+
+vi.mock('../logger', () => ({
+  log: vi.fn(),
+}))
+
+// Mock os.homedir so the discovery function reads from our temp dir
+// instead of the real user home. command-discovery.ts imports `homedir`
+// from 'os' at module scope, so this mock has to be installed before
+// the registerSessionsListIpc import lower in the file.
+const homeMock = vi.hoisted(() => ({ home: '' }))
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os')
+  return {
+    ...actual,
+    homedir: () => homeMock.home,
+  }
+})
+
+// state / session-meta dependencies are not exercised by DISCOVER_COMMANDS
+// but must mock cleanly so registerSessionsListIpc imports without error.
+vi.mock('../state', () => ({
+  sessionPlane: {
+    loadSessionHistory: vi.fn(),
+    getConversation: vi.fn(),
+  },
+}))
+vi.mock('../session-meta', () => ({
+  cleanCliTags: (s: string) => s,
+  collapseSessionChains: (s: any) => s,
+  decodeProjectPath: () => null,
+  extractBashEntries: () => ({ bashEntries: [] }),
+  extractTag: () => null,
+  loadClaudeSessionMessages: () => [],
+  loadEngineConversationMessages: () => [],
+  parseSessionMeta: () => null,
+}))
+
+import { registerSessionsListIpc } from '../ipc/sessions-list'
+
+let tempRoot: string
+let projectPath: string
+
+beforeEach(() => {
+  handlers.clear()
+  settingsMock.enableClaudeCompat = true
+
+  // Build a fake home + project on disk.
+  tempRoot = mkdtempSync(join(tmpdir(), 'ion-discover-test-'))
+  const fakeHome = join(tempRoot, 'home')
+  projectPath = join(tempRoot, 'project')
+
+  // ~/.ion/commands/foo.md   (ion user)
+  mkdirSync(join(fakeHome, '.ion', 'commands'), { recursive: true })
+  writeFileSync(join(fakeHome, '.ion', 'commands', 'foo.md'), 'foo: ion-user command\n')
+
+  // ~/.claude/commands/bar.md   (claude user)
+  mkdirSync(join(fakeHome, '.claude', 'commands'), { recursive: true })
+  writeFileSync(join(fakeHome, '.claude', 'commands', 'bar.md'), 'bar: claude-user command\n')
+
+  // {project}/.ion/commands/baz.md   (ion project)
+  mkdirSync(join(projectPath, '.ion', 'commands'), { recursive: true })
+  writeFileSync(join(projectPath, '.ion', 'commands', 'baz.md'), 'baz: ion-project command\n')
+
+  // {project}/.claude/commands/qux.md   (claude project)
+  mkdirSync(join(projectPath, '.claude', 'commands'), { recursive: true })
+  writeFileSync(join(projectPath, '.claude', 'commands', 'qux.md'), 'qux: claude-project command\n')
+
+  // ~/.claude/skills/myskill/SKILL.md   (claude user skill)
+  mkdirSync(join(fakeHome, '.claude', 'skills', 'myskill'), { recursive: true })
+  writeFileSync(
+    join(fakeHome, '.claude', 'skills', 'myskill', 'SKILL.md'),
+    '---\ndescription: A test skill\n---\nbody\n',
+  )
+
+  homeMock.home = fakeHome
+  registerSessionsListIpc()
+})
+
+afterEach(() => {
+  rmSync(tempRoot, { recursive: true, force: true })
+})
+
+describe('IPC.DISCOVER_COMMANDS handler', () => {
+  it('returns the full ion + claude union when enableClaudeCompat is true', async () => {
+    settingsMock.enableClaudeCompat = true
+    const handler = handlers.get('ion:discover-commands')
+    expect(handler).toBeDefined()
+
+    const result: Array<{ name: string; origin: string }> = await handler!(null, projectPath)
+    const names = result.map((c) => c.name).sort()
+
+    expect(names).toEqual(['bar', 'baz', 'foo', 'myskill', 'qux'])
+  })
+
+  it('returns only ion-native entries when enableClaudeCompat is false (regression: ion-native commands must not disappear from the autocomplete list)', async () => {
+    settingsMock.enableClaudeCompat = false
+    const handler = handlers.get('ion:discover-commands')
+    expect(handler).toBeDefined()
+
+    const result: Array<{ name: string; origin: string }> = await handler!(null, projectPath)
+    const names = result.map((c) => c.name).sort()
+
+    // foo (~/.ion/commands) and baz ({project}/.ion/commands) are ion-native
+    // and must always survive. bar (~/.claude/commands),
+    // qux ({project}/.claude/commands), and myskill (~/.claude/skills) are
+    // all gated by the setting.
+    expect(names).toEqual(['baz', 'foo'])
+
+    // Every surviving entry must carry origin='ion' so future filters can
+    // re-derive the directory family without re-scanning paths.
+    expect(result.every((c) => c.origin === 'ion')).toBe(true)
+  })
+
+  it('stamps every returned entry with an origin field (contract: DiscoveredCommand.origin is required)', async () => {
+    settingsMock.enableClaudeCompat = true
+    const handler = handlers.get('ion:discover-commands')
+    const result: Array<{ name: string; origin: string }> = await handler!(null, projectPath)
+
+    for (const c of result) {
+      expect(c.origin).toMatch(/^(ion|claude)$/)
+    }
+
+    const byName = new Map(result.map((c) => [c.name, c.origin]))
+    expect(byName.get('foo')).toBe('ion')          // ~/.ion/commands
+    expect(byName.get('baz')).toBe('ion')          // {project}/.ion/commands
+    expect(byName.get('bar')).toBe('claude')       // ~/.claude/commands
+    expect(byName.get('qux')).toBe('claude')       // {project}/.claude/commands
+    expect(byName.get('myskill')).toBe('claude')   // ~/.claude/skills
+  })
+
+  it('rejects invalid project paths without scanning the filesystem', async () => {
+    settingsMock.enableClaudeCompat = true
+    const handler = handlers.get('ion:discover-commands')
+    // Validator requires absolute paths; a relative path should bounce.
+    const result = await handler!(null, 'relative/path')
+    expect(result).toEqual([])
+  })
+})

--- a/desktop/src/main/__tests__/prompt-pipeline-model-frontmatter.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-model-frontmatter.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Tests for the slash-frontmatter → `RunOptions.Model` (and engine-tab
+ * `p.model`) wiring shipped by the `model:` frontmatter feature.
+ *
+ * Contract pinned: when a slash command's YAML frontmatter declares a
+ * `model:` key, the prompt pipeline must forward the value verbatim
+ * onto the per-prompt `model` field — onto `p.runOptions.model` for
+ * the CLI path and onto `p.model` for the engine-tab path — UNLESS
+ * the caller has already supplied an explicit per-prompt override,
+ * in which case the explicit value is preserved (no-stomp policy).
+ *
+ * The desktop deliberately does NOT resolve the value: the engine
+ * walks tier → literal → `defaultModel` via
+ * `modelconfig.ResolveTierChain` (`engine/internal/session/prompt_options.go`)
+ * and `runloop.go`'s unknown-model fallback. The tests below pin only
+ * the desktop's plumbing contribution.
+ *
+ * Sibling to `prompt-pipeline-bash-additions.test.ts`. The mock
+ * posture is intentionally identical so the two files can be diffed
+ * side-by-side and only the frontmatter-key / expected-call-arg
+ * fields differ.
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const bridgeListeners = new Map<string, Array<(key: string, event: any) => void>>()
+  const sendCommandMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const sendPromptMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.({ ok: true }) ?? function () { return Promise.resolve({ ok: true }) }
+  const sendSetPlanModeMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const submitPromptMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.(undefined) ?? function () { return Promise.resolve() }
+  const setPermissionModeMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const remoteSendMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const executeJsMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.(null) ?? function () { return Promise.resolve(null) }
+  const broadcastMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const expandSlashMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const clearConversationFileMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.(undefined) ?? function () { return Promise.resolve() }
+  const getTabStatusMock = (globalThis as any).vi?.fn?.()?.mockReturnValue?.({ conversationId: null }) ?? function () { return { conversationId: null } }
+  return {
+    bridgeListeners,
+    sendCommandMock,
+    sendPromptMock,
+    sendSetPlanModeMock,
+    submitPromptMock,
+    setPermissionModeMock,
+    remoteSendMock,
+    executeJsMock,
+    broadcastMock,
+    expandSlashMock,
+    clearConversationFileMock,
+    getTabStatusMock,
+  }
+})
+
+mocks.sendCommandMock = vi.fn()
+mocks.sendPromptMock = vi.fn().mockResolvedValue({ ok: true })
+mocks.sendSetPlanModeMock = vi.fn()
+mocks.submitPromptMock = vi.fn().mockResolvedValue(undefined)
+mocks.setPermissionModeMock = vi.fn()
+mocks.remoteSendMock = vi.fn()
+mocks.executeJsMock = vi.fn().mockResolvedValue(null)
+mocks.broadcastMock = vi.fn()
+mocks.expandSlashMock = vi.fn().mockResolvedValue({ expanded: false })
+mocks.clearConversationFileMock = vi.fn().mockResolvedValue(undefined)
+mocks.getTabStatusMock = vi.fn().mockReturnValue({ conversationId: null })
+
+vi.mock('electron', () => ({
+  app: { get isPackaged() { return false } },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: (s: string) => Buffer.from(s),
+    decryptString: (b: Buffer) => b.toString(),
+  },
+}))
+
+vi.mock('../state', () => {
+  const mockEngineBridge = {
+    sendCommand: (...args: any[]) => mocks.sendCommandMock(...args),
+    sendPrompt: (...args: any[]) => mocks.sendPromptMock(...args),
+    sendSetPlanMode: (...args: any[]) => mocks.sendSetPlanModeMock(...args),
+    clearConversationFile: (...args: any[]) => mocks.clearConversationFileMock(...args),
+    on: (name: string, fn: (key: string, event: any) => void) => {
+      const arr = mocks.bridgeListeners.get(name) ?? []
+      arr.push(fn)
+      mocks.bridgeListeners.set(name, arr)
+    },
+  }
+  return {
+    state: {
+      mainWindow: { webContents: { executeJavaScript: (...args: any[]) => mocks.executeJsMock(...args) } },
+      remoteTransport: { send: (...args: any[]) => mocks.remoteSendMock(...args) },
+    },
+    sessionPlane: {
+      submitPrompt: (...args: any[]) => mocks.submitPromptMock(...args),
+      setPermissionMode: (...args: any[]) => mocks.setPermissionModeMock(...args),
+      getTabStatus: (...args: any[]) => mocks.getTabStatusMock(...args),
+      notifyConversationCleared: vi.fn(),
+    },
+    engineBridge: mockEngineBridge,
+    extensionCommandRegistry: new Map(),
+  }
+})
+
+vi.mock('../broadcast', () => ({
+  broadcast: (...args: any[]) => mocks.broadcastMock(...args),
+}))
+
+vi.mock('../logger', () => ({
+  log: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
+vi.mock('../cli-compat/slash-expand', () => ({
+  expandSlashCommand: (...args: any[]) => mocks.expandSlashMock(...args),
+}))
+
+vi.mock('../settings-store', () => ({
+  readSettings: () => ({ enableClaudeCompat: true }),
+  SETTINGS_DEFAULTS: { enableClaudeCompat: true },
+}))
+
+vi.mock('../remote/attachment-encoder', () => ({
+  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+}))
+
+import { processIncomingPrompt } from '../prompt-pipeline'
+import { _resetAwaitersForTests } from '../command-await'
+
+function emitBridgeEvent(key: string, event: any): void {
+  const arr = mocks.bridgeListeners.get('event') ?? []
+  for (const fn of arr) fn(key, event)
+}
+
+beforeEach(() => {
+  mocks.sendCommandMock.mockReset()
+  mocks.sendPromptMock.mockReset().mockResolvedValue({ ok: true })
+  mocks.sendSetPlanModeMock.mockReset()
+  mocks.submitPromptMock.mockReset().mockResolvedValue(undefined)
+  mocks.setPermissionModeMock.mockReset()
+  mocks.remoteSendMock.mockReset()
+  mocks.executeJsMock.mockReset().mockResolvedValue(null)
+  mocks.broadcastMock.mockReset()
+  mocks.expandSlashMock.mockReset().mockResolvedValue({ expanded: false })
+  mocks.clearConversationFileMock.mockReset().mockResolvedValue(undefined)
+  mocks.getTabStatusMock.mockReset().mockReturnValue({ conversationId: null })
+  mocks.bridgeListeners.clear()
+  _resetAwaitersForTests()
+
+  // The pipeline dispatches the slash to the engine first; the engine
+  // replies unknown_command, and the pipeline then falls through to
+  // the .md template path. We emit the result asynchronously from
+  // sendCommand so the await in command-await unblocks and the
+  // expansion branch runs.
+  mocks.sendCommandMock.mockImplementation((key: string, command: string) => {
+    setTimeout(() => emitBridgeEvent(key, {
+      type: 'engine_command_result',
+      command,
+      commandError: 'unknown_command',
+      message: `unknown command: ${command}`,
+    }), 0)
+  })
+})
+
+describe('processIncomingPrompt — slash-frontmatter model hint (engine-tab path)', () => {
+  it('applies frontmatter model onto p.model when no explicit override is supplied', async () => {
+    // Frontmatter `model: smart` reaches the engine as RunOptions.Model
+    // (3rd positional arg to sendPrompt, index 2). The engine then walks
+    // tier → literal → defaultModel; the desktop's job ends at "forward
+    // the value verbatim". The pipeline must NOT pre-resolve the tier
+    // alias — that's deliberately left to the engine so a single
+    // ~/.ion/models.json change applies uniformly to every consumer.
+    mocks.expandSlashMock.mockResolvedValue({
+      expanded: true,
+      systemPrompt: 'sys',
+      userPrompt: 'body',
+      frontmatter: {
+        description: 'Open an issue',
+        model: 'smart',
+      },
+    })
+
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: '/create-issue feature foo',
+      reqId: 'req-1',
+      source: 'desktop',
+      isEngineTab: true,
+      instanceId: 'inst-A',
+      projectPath: '/proj',
+    } as any)
+
+    expect(mocks.sendPromptMock).toHaveBeenCalledTimes(1)
+    const call = mocks.sendPromptMock.mock.calls[0]
+    // sendPrompt(key, text, model, ...) — index 2 carries RunOptions.Model.
+    expect(call[2]).toBe('smart')
+  })
+
+  it('preserves an explicit p.model override (no-stomp policy)', async () => {
+    // The renderer or harness can set an explicit model for one prompt
+    // (e.g. a "use opus for this specific request" affordance). That
+    // value must win over the slash-command's frontmatter hint — the
+    // hint is a default, not a directive.
+    mocks.expandSlashMock.mockResolvedValue({
+      expanded: true,
+      systemPrompt: 'sys',
+      userPrompt: 'body',
+      frontmatter: {
+        model: 'smart', // frontmatter says smart
+      },
+    })
+
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: '/create-issue',
+      reqId: 'req-1',
+      source: 'desktop',
+      isEngineTab: true,
+      instanceId: 'inst-A',
+      projectPath: '/proj',
+      model: 'claude-opus-4-7', // explicit override wins
+    } as any)
+
+    expect(mocks.sendPromptMock).toHaveBeenCalledTimes(1)
+    const call = mocks.sendPromptMock.mock.calls[0]
+    expect(call[2]).toBe('claude-opus-4-7')
+  })
+
+  it('leaves model undefined when frontmatter has no model key', async () => {
+    // Most commands won't declare a model hint. The pipeline must
+    // pass through whatever the caller supplied (undefined here) so
+    // the engine resolves via the session default. This pins the
+    // "absence is meaningful" semantic — we never inject a default
+    // value on the desktop side.
+    mocks.expandSlashMock.mockResolvedValue({
+      expanded: true,
+      systemPrompt: 'sys',
+      userPrompt: 'body',
+      frontmatter: {
+        description: 'No model hint',
+      },
+    })
+
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: '/plain',
+      reqId: 'req-1',
+      source: 'desktop',
+      isEngineTab: true,
+      instanceId: 'inst-A',
+      projectPath: '/proj',
+    } as any)
+
+    expect(mocks.sendPromptMock).toHaveBeenCalledTimes(1)
+    const call = mocks.sendPromptMock.mock.calls[0]
+    expect(call[2]).toBeUndefined()
+  })
+})
+
+describe('processIncomingPrompt — slash-frontmatter model hint (CLI path)', () => {
+  // The CLI path goes through sessionPlane.submitPrompt rather than
+  // engineBridge.sendPrompt. The slash-expansion mutates
+  // p.runOptions.prompt in place, and the model hint must land on
+  // p.runOptions.model so EngineControlPlane.submitPrompt picks it up.
+
+  function makeRunOptions(overrides: Record<string, unknown> = {}): any {
+    return {
+      prompt: '',
+      projectPath: '/proj',
+      // realistic placeholders for the fields the pipeline doesn't read
+      maxTokens: 0,
+      ...overrides,
+    }
+  }
+
+  it('applies frontmatter model onto p.runOptions.model when no explicit override is supplied', async () => {
+    mocks.expandSlashMock.mockResolvedValue({
+      expanded: true,
+      systemPrompt: 'sys',
+      userPrompt: 'body',
+      frontmatter: {
+        model: 'smart',
+      },
+    })
+
+    const runOptions = makeRunOptions()
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: '/create-issue',
+      reqId: 'req-1',
+      source: 'desktop',
+      isEngineTab: false, // CLI path
+      projectPath: '/proj',
+      runOptions,
+    } as any)
+
+    expect(mocks.submitPromptMock).toHaveBeenCalledTimes(1)
+    // sessionPlane.submitPrompt(tabId, requestId, runOptions); index 2
+    // is the RunOptions object. We assert against that object directly
+    // because the pipeline mutates it in place during expansion.
+    const submitCall = mocks.submitPromptMock.mock.calls[0]
+    expect(submitCall[2]).toBe(runOptions)
+    expect(runOptions.model).toBe('smart')
+  })
+
+  it('preserves an explicit runOptions.model override (no-stomp policy)', async () => {
+    mocks.expandSlashMock.mockResolvedValue({
+      expanded: true,
+      systemPrompt: 'sys',
+      userPrompt: 'body',
+      frontmatter: {
+        model: 'smart',
+      },
+    })
+
+    const runOptions = makeRunOptions({ model: 'claude-opus-4-7' })
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: '/create-issue',
+      reqId: 'req-1',
+      source: 'desktop',
+      isEngineTab: false,
+      projectPath: '/proj',
+      runOptions,
+    } as any)
+
+    expect(runOptions.model).toBe('claude-opus-4-7')
+  })
+
+  it('leaves runOptions.model untouched when frontmatter has no model key', async () => {
+    mocks.expandSlashMock.mockResolvedValue({
+      expanded: true,
+      systemPrompt: 'sys',
+      userPrompt: 'body',
+      frontmatter: {
+        description: 'No model hint',
+      },
+    })
+
+    const runOptions = makeRunOptions()
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: '/plain',
+      reqId: 'req-1',
+      source: 'desktop',
+      isEngineTab: false,
+      projectPath: '/proj',
+      runOptions,
+    } as any)
+
+    expect(runOptions.model).toBeUndefined()
+  })
+})

--- a/desktop/src/main/__tests__/slash-expand-frontmatter.test.ts
+++ b/desktop/src/main/__tests__/slash-expand-frontmatter.test.ts
@@ -146,4 +146,71 @@ describe('parseFrontmatter', () => {
     const { meta } = parseFrontmatter(content)
     expect(meta.description).toBe('with anchor')
   })
+
+  // ── model frontmatter field ───────────────────────────────────────
+  // The `model:` key is forwarded verbatim onto `RunOptions.Model`
+  // and the engine resolves it through tier → literal → defaultModel.
+  // parseFrontmatter's job is only to extract a non-empty trimmed
+  // string; non-string values are rejected to keep the contract
+  // ("a tier alias or a model id") clean.
+
+  it('parses model field as a string', () => {
+    const content = '---\nmodel: smart\n---\nbody'
+    const { body, meta } = parseFrontmatter(content)
+    expect(body).toBe('body')
+    expect(meta.model).toBe('smart')
+  })
+
+  it('leaves meta.model undefined when frontmatter has no model key', () => {
+    const content = '---\ndescription: hi\n---\nbody'
+    const { meta } = parseFrontmatter(content)
+    expect(meta.model).toBeUndefined()
+  })
+
+  it('ignores non-string model values', () => {
+    // YAML `model: 123` decodes to a number, not a string. The type
+    // guard in parseFrontmatter rejects it so meta.model stays
+    // undefined. This pins the guard against future refactors that
+    // might forget the `typeof === 'string'` check.
+    const content = '---\nmodel: 123\n---\nbody'
+    const { meta } = parseFrontmatter(content)
+    expect(meta.model).toBeUndefined()
+  })
+
+  it('trims whitespace from model value', () => {
+    // Quoted scalar preserves the leading/trailing spaces; the parser
+    // must trim them so downstream code never sees a padded value.
+    const content = '---\nmodel: "  smart  "\n---\nbody'
+    const { meta } = parseFrontmatter(content)
+    expect(meta.model).toBe('smart')
+  })
+
+  it('treats whitespace-only model value as absent', () => {
+    // After trim, an empty string is meaningless as a model hint;
+    // collapsing it to undefined keeps the field semantics binary
+    // (present-and-useful, or absent) so downstream pipeline logs
+    // don't show spurious-looking blank hints.
+    const content = '---\nmodel: "   "\n---\nbody'
+    const { meta } = parseFrontmatter(content)
+    expect(meta.model).toBeUndefined()
+  })
+
+  it('parses model alongside description and allowed_bash_commands', () => {
+    // Integration case: a real-world frontmatter block carrying all
+    // three currently-parsed keys. Confirms parseFrontmatter doesn't
+    // drop the model field when the surrounding fields are present.
+    const content = [
+      '---',
+      'description: Open a GitHub issue',
+      'allowed_bash_commands:',
+      '  - gh issue create',
+      'model: smart',
+      '---',
+      'body',
+    ].join('\n')
+    const { meta } = parseFrontmatter(content)
+    expect(meta.description).toBe('Open a GitHub issue')
+    expect(meta.allowedBashCommands).toEqual(['gh issue create'])
+    expect(meta.model).toBe('smart')
+  })
 })

--- a/desktop/src/main/cli-compat/command-discovery.ts
+++ b/desktop/src/main/cli-compat/command-discovery.ts
@@ -14,6 +14,11 @@ export type { DiscoveredCommand }
  * compat gate lives at expansion time in slash-classify.ts, not at
  * discovery time. This keeps the autocomplete list complete regardless
  * of the gate setting.
+ *
+ * Each returned `DiscoveredCommand` carries an `origin` field
+ * (`'ion' | 'claude'`) so the autocomplete IPC handler can filter out
+ * Claude-compat entries when `enableClaudeCompat` is disabled without
+ * having to re-derive the directory family from the command name.
  */
 export async function discoverCommands(projectPath: string): Promise<DiscoveredCommand[]> {
   const home = homedir()
@@ -25,11 +30,11 @@ export async function discoverCommands(projectPath: string): Promise<DiscoveredC
     userSkills,
     projectCommands,
   ] = await Promise.all([
-    scanCommandDir(join(home, '.ion', 'commands'), 'user'),
-    scanCommandDir(join(projectPath, '.ion', 'commands'), 'project'),
-    scanCommandDir(join(home, '.claude', 'commands'), 'user'),
+    scanCommandDir(join(home, '.ion', 'commands'), 'user', 'ion'),
+    scanCommandDir(join(projectPath, '.ion', 'commands'), 'project', 'ion'),
+    scanCommandDir(join(home, '.claude', 'commands'), 'user', 'claude'),
     scanSkillsDir(join(home, '.claude', 'skills')),
-    scanCommandDir(join(projectPath, '.claude', 'commands'), 'project'),
+    scanCommandDir(join(projectPath, '.claude', 'commands'), 'project', 'claude'),
   ])
 
   return [
@@ -97,11 +102,12 @@ function parseFrontmatterDescription(content: string): string {
 async function scanCommandDir(
   dirPath: string,
   scope: 'user' | 'project',
+  origin: 'ion' | 'claude',
 ): Promise<DiscoveredCommand[]> {
   if (!(await dirExists(dirPath))) return []
 
   const commands: DiscoveredCommand[] = []
-  await walkCommandDir(dirPath, dirPath, scope, commands)
+  await walkCommandDir(dirPath, dirPath, scope, origin, commands)
   return commands
 }
 
@@ -109,6 +115,7 @@ async function walkCommandDir(
   baseDir: string,
   currentDir: string,
   scope: 'user' | 'project',
+  origin: 'ion' | 'claude',
   results: DiscoveredCommand[],
 ): Promise<void> {
   let entries
@@ -126,7 +133,7 @@ async function walkCommandDir(
     const fullPath = join(currentDir, entry.name)
 
     if (entry.isDirectory()) {
-      tasks.push(walkCommandDir(baseDir, fullPath, scope, results))
+      tasks.push(walkCommandDir(baseDir, fullPath, scope, origin, results))
     } else if (entry.isFile() && extname(entry.name) === '.md') {
       tasks.push(
         readFile(fullPath, 'utf-8').then((content) => {
@@ -138,6 +145,7 @@ async function walkCommandDir(
             description: extractCommandDescription(content),
             scope,
             source: 'command',
+            origin,
           })
         }).catch(() => {
           // Skip files that can't be read
@@ -151,6 +159,11 @@ async function walkCommandDir(
 
 /**
  * Scan ~/.claude/skills/ for directories containing SKILL.md.
+ *
+ * Skills are inherently a Claude-compat artifact (Ion does not have a
+ * `~/.ion/skills/` directory) so every result is tagged
+ * `origin: 'claude'`. The IPC handler filters these out when
+ * `enableClaudeCompat` is disabled.
  */
 async function scanSkillsDir(skillsDir: string): Promise<DiscoveredCommand[]> {
   if (!(await dirExists(skillsDir))) return []
@@ -173,6 +186,7 @@ async function scanSkillsDir(skillsDir: string): Promise<DiscoveredCommand[]> {
           description: parseFrontmatterDescription(content),
           scope: 'user',
           source: 'skill',
+          origin: 'claude',
         }
       } catch {
         return null

--- a/desktop/src/main/cli-compat/slash-expand.ts
+++ b/desktop/src/main/cli-compat/slash-expand.ts
@@ -8,6 +8,18 @@ import { log as _log } from '../logger'
 export interface FrontmatterMeta {
   description?: string
   allowedBashCommands?: string[]
+  /**
+   * Model identifier hint from the slash-command frontmatter. May be a
+   * tier alias (resolved via `~/.ion/models.json` `tiers` section by
+   * the engine's `modelconfig.ResolveTierChain`), a literal model name,
+   * or anything in between. The desktop does NOT attempt resolution
+   * itself — the field is forwarded onto `RunOptions.Model` and the
+   * engine walks the chain (tier → literal → `defaultModel` from
+   * `engine.json`). An explicit per-prompt override on the desktop
+   * side takes precedence over this hint; see `prompt-pipeline.ts`
+   * for the no-stomp policy.
+   */
+  model?: string
 }
 
 /** Result of slash command expansion. */
@@ -203,6 +215,18 @@ export function parseFrontmatter(content: string): { body: string; meta: Frontma
       .filter((v): v is string => typeof v === 'string')
       .map((s) => s.trim())
       .filter(Boolean)
+  }
+  // Optional `model` hint. Accepted only as a string; anything else
+  // (number, array, object, null) is ignored — the field's contract
+  // is "a tier alias or model id", neither of which is meaningful as
+  // a non-string. Whitespace is trimmed so `model: '  smart  '` →
+  // `'smart'`; an empty/whitespace-only value collapses to undefined
+  // so it doesn't appear in logs as a spurious-looking blank hint.
+  if (typeof obj.model === 'string') {
+    const trimmed = obj.model.trim()
+    if (trimmed.length > 0) {
+      meta.model = trimmed
+    }
   }
 
   return { body, meta }

--- a/desktop/src/main/ipc/sessions-list.ts
+++ b/desktop/src/main/ipc/sessions-list.ts
@@ -43,9 +43,26 @@ export function registerSessionsListIpc(): void {
       try {
         const s = readSettings()
         claudeCompat = s.enableClaudeCompat ?? claudeCompat
-      } catch {}
-      if (!claudeCompat) return []
-      return await discoverCommands(projectPath)
+      } catch (err) {
+        // Per desktop/AGENTS.md "no silent catch": surface the fallback so
+        // a settings-read failure doesn't silently change the autocomplete
+        // composition. The default flips claude-compat ON, so this matters.
+        log(`DISCOVER_COMMANDS: readSettings failed reading enableClaudeCompat; defaulting to ${claudeCompat}: ${err}`)
+      }
+      const all = await discoverCommands(projectPath)
+      if (claudeCompat) {
+        log(`DISCOVER_COMMANDS: claudeCompat=true, returning ${all.length} entries (ion + claude)`)
+        return all
+      }
+      // Claude Code Compatibility off: return only ion-native entries.
+      // Ion-native commands (~/.ion/commands, {project}/.ion/commands) are
+      // never gated by this setting — only .claude/commands and
+      // .claude/skills are. See `slash-classify.ts` for the matching
+      // expansion-time gate.
+      const ionOnly = all.filter((c) => c.origin === 'ion')
+      const claudeFiltered = all.length - ionOnly.length
+      log(`DISCOVER_COMMANDS: claudeCompat=false, returning ${ionOnly.length} ion entries, filtered ${claudeFiltered} claude entries`)
+      return ionOnly
     } catch (err) {
       log(`DISCOVER_COMMANDS error: ${err}`)
       return []

--- a/desktop/src/main/prompt-pipeline.ts
+++ b/desktop/src/main/prompt-pipeline.ts
@@ -474,6 +474,39 @@ async function handleSlash(p: IncomingPrompt, slash: ParsedSlash): Promise<void>
         log(`pipeline: frontmatter bash allowlist additions=${expansion.allowedBashCommands.length} key=${key} (per-prompt, no session mutation)`)
         p.bashAllowlistAdditionsForThisPrompt = expansion.allowedBashCommands
       }
+      // If the expansion specifies a model hint (frontmatter `model:`),
+      // apply it onto the appropriate model field. The engine resolves
+      // the value through tier → literal → `defaultModel` (see
+      // `engine/internal/session/prompt_options.go:resolveModelTier`
+      // and `engine/internal/backend/runloop.go:56-65`); the desktop
+      // does not pre-resolve it.
+      //
+      // No-stomp policy: an explicit per-prompt model override (set by
+      // the renderer via `runOptions.model`, or by an engine-tab caller
+      // via `p.model`) takes precedence over the frontmatter hint.
+      // Matches the precedent set by `enterPlanModeDescription` /
+      // `planModeSparseReminder` in `submitAsPrompt`.
+      //
+      // Both branches log (apply + skip-because-already-set) per
+      // `desktop/AGENTS.md` § Logging — operators investigating "why
+      // did the wrong model run?" can replay the decision from
+      // `~/.ion/desktop.log` without attaching a debugger.
+      if (expansion.model) {
+        if (p.runOptions) {
+          if (!p.runOptions.model) {
+            log(`pipeline: frontmatter model applied target=runOptions value=${expansion.model} key=${engineKey(p)}`)
+            p.runOptions.model = expansion.model
+          } else {
+            log(`pipeline: frontmatter model skipped target=runOptions reason=explicit-override existing=${p.runOptions.model} frontmatter=${expansion.model} key=${engineKey(p)}`)
+          }
+        }
+        if (!p.model) {
+          log(`pipeline: frontmatter model applied target=p value=${expansion.model} key=${engineKey(p)}`)
+          p.model = expansion.model
+        } else {
+          log(`pipeline: frontmatter model skipped target=p reason=explicit-override existing=${p.model} frontmatter=${expansion.model} key=${engineKey(p)}`)
+        }
+      }
       await submitAsPrompt(p)
       return
     }

--- a/desktop/src/main/remote/handlers/tabs.ts
+++ b/desktop/src/main/remote/handlers/tabs.ts
@@ -5,7 +5,7 @@ import { log as _log } from '../../logger'
 import { state, sessionPlane, engineBridge } from '../../state'
 import { broadcast } from '../../broadcast'
 import { terminalManager } from '../../terminal-manager-instance'
-import { readSettings } from '../../settings-store'
+import { readSettings, SETTINGS_DEFAULTS } from '../../settings-store'
 import { getRemoteTabStates } from '../snapshot'
 import { discoverCommands } from '../../cli-compat/command-discovery'
 import { autoPullDiagnosticLogs } from './diagnostics'
@@ -410,7 +410,26 @@ export async function handleLoadConversation(cmd: Extract<RemoteCommand, { type:
 export async function handleDiscoverCommands(cmd: Extract<RemoteCommand, { type: 'discover_commands' }>, deviceId: string): Promise<void> {
   const { directory } = cmd
   try {
-    const commands = await discoverCommands(directory)
+    const all = await discoverCommands(directory)
+    // Mirror the desktop IPC handler's enableClaudeCompat filter so the iOS
+    // autocomplete shows the same list the desktop does. Ion-native
+    // commands are always returned; .claude/* entries are gated by the
+    // user's Claude Code Compatibility setting. See
+    // `desktop/src/main/ipc/sessions-list.ts` for the matching filter and
+    // `desktop/src/main/slash-classify.ts` for the expansion-time gate.
+    let claudeCompat = SETTINGS_DEFAULTS.enableClaudeCompat
+    try {
+      const s = readSettings()
+      claudeCompat = s.enableClaudeCompat ?? claudeCompat
+    } catch (err) {
+      log(`discover_commands: readSettings failed reading enableClaudeCompat; defaulting to ${claudeCompat}: ${err}`)
+    }
+    const commands = claudeCompat ? all : all.filter((c) => c.origin === 'ion')
+    if (!claudeCompat) {
+      log(`discover_commands: claudeCompat=false, returning ${commands.length} ion entries, filtered ${all.length - commands.length} claude entries (device=${deviceId})`)
+    } else {
+      log(`discover_commands: claudeCompat=true, returning ${commands.length} entries (device=${deviceId})`)
+    }
     state.remoteTransport?.sendToDevice(deviceId, { type: 'discover_commands_response', directory, commands })
   } catch (err) {
     log(`discover_commands error: ${(err as Error).message}`)

--- a/desktop/src/main/remote/protocol.ts
+++ b/desktop/src/main/remote/protocol.ts
@@ -53,7 +53,7 @@ export interface RemoteTabState {
   isTerminalOnly?: boolean
   isEngine?: boolean
   engineProfileId?: string | null
-  engineInstances?: Array<{ id: string; label: string; waitingState?: 'plan-ready' | 'question' | null; isRunning?: boolean }>
+  engineInstances?: Array<{ id: string; label: string; waitingState?: 'plan-ready' | 'question' | null; isRunning?: boolean; modelFallback?: { requestedModel: string; fallbackModel: string } }>
   activeEngineInstanceId?: string | null
   terminalInstances?: TerminalInstanceInfo[]
   activeTerminalInstanceId?: string | null

--- a/desktop/src/main/remote/snapshot.ts
+++ b/desktop/src/main/remote/snapshot.ts
@@ -139,7 +139,26 @@ export async function getRemoteTabStates(): Promise<RemoteTabState[]> {
                     instRunning = st === 'running' || st === 'connecting' || st === 'starting';
                   }
                 }
-                return { id: inst.id, label: inst.label, waitingState: ws, isRunning: instRunning || undefined };
+                // Per-instance model-fallback indicator. Projects the
+                // renderer's engineModelFallbacks map onto each instance
+                // so iOS can render a matching ⚠ glyph on its
+                // EngineInstanceBar. The desktop populates the source
+                // map from engine_model_fallback events; we forward only
+                // the requested + fallback model strings (no timestamp,
+                // no reason — iOS doesn't need them to render the
+                // indicator). When iOS's snapshot pull arrives with the
+                // field omitted, the iOS indicator clears — matching the
+                // desktop's clear-on-idle behaviour via the snapshot tick.
+                // See CLAUDE.md § "Common parity surfaces" row for model
+                // fallback indicator.
+                var mfOut = undefined;
+                if (s.engineModelFallbacks && s.engineModelFallbacks.get) {
+                  var mf = s.engineModelFallbacks.get(t.id + ':' + inst.id);
+                  if (mf) {
+                    mfOut = { requestedModel: mf.requestedModel, fallbackModel: mf.fallbackModel };
+                  }
+                }
+                return { id: inst.id, label: inst.label, waitingState: ws, isRunning: instRunning || undefined, modelFallback: mfOut };
               });
               activeEngineInstanceId = ePaneForList.activeInstanceId || ePaneForList.instances[0].id;
             }

--- a/desktop/src/main/slash-classify.ts
+++ b/desktop/src/main/slash-classify.ts
@@ -132,6 +132,16 @@ export interface ExpansionResult {
   systemPrompt: string
   /** Allowed Bash command prefixes from the template's frontmatter. */
   allowedBashCommands?: string[]
+  /**
+   * Optional model hint from the template's frontmatter `model:` key.
+   * Forwarded as-is to the engine; the engine walks
+   * tier → literal → `defaultModel` (see `modelconfig.ResolveTierChain`
+   * and `runloop.go`'s unknown-model fallback). The desktop does not
+   * resolve this value; it only chooses whether to apply it to
+   * `RunOptions.Model` (no-stomp policy — explicit per-prompt
+   * overrides take precedence). See `prompt-pipeline.ts:handleSlash`.
+   */
+  model?: string
 }
 
 /**
@@ -216,6 +226,7 @@ export async function tryExpandMarkdownSlash(
       userPrompt: ionExpansion.userPrompt,
       systemPrompt: ionExpansion.systemPrompt,
       allowedBashCommands: ionExpansion.frontmatter.allowedBashCommands,
+      model: ionExpansion.frontmatter.model,
     }
   }
 
@@ -267,5 +278,6 @@ export async function tryExpandMarkdownSlash(
     userPrompt: claudeExpansion.userPrompt,
     systemPrompt: claudeExpansion.systemPrompt,
     allowedBashCommands: claudeExpansion.frontmatter.allowedBashCommands,
+    model: claudeExpansion.frontmatter.model,
   }
 }

--- a/desktop/src/renderer/components/EngineStatusBar.tsx
+++ b/desktop/src/renderer/components/EngineStatusBar.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react'
-import { Plus, X } from '@phosphor-icons/react'
+import { Plus, X, Warning } from '@phosphor-icons/react'
 import { Reorder } from 'framer-motion'
 import { useShallow } from 'zustand/shallow'
 import { useColors } from '../theme'
 import { useSessionStore } from '../stores/sessionStore'
 import type { EngineInstance } from '../../shared/types'
 import { getEngineInstanceWaitingState } from './TabStripShared'
+import { Tooltip } from './git/Tooltip'
 
 interface Props {
   tabId: string
@@ -35,6 +36,23 @@ export function EngineStatusBar({ tabId }: Props) {
       for (const inst of pane?.instances || []) {
         const state = s.engineStatusFields.get(`${tabId}:${inst.id}`)?.state
         if (state) out.set(inst.id, state)
+      }
+      return out
+    }),
+  )
+  // Subscribe to engineModelFallbacks scoped to this tab's instances.
+  // The slice writes per `${tabId}:${instanceId}` so we project by
+  // instance id, mirroring the engineStateByInstance pattern above.
+  // useShallow keeps render cost low — we only re-render when the
+  // {id, info} pairs actually change, not on unrelated session-store
+  // writes. See engine-event-slice.ts case 'engine_model_fallback' for
+  // the writer and engine-event-status.ts (idle branch) for the clear.
+  const modelFallbackByInstance = useSessionStore(
+    useShallow((s) => {
+      const out = new Map<string, { requestedModel: string; fallbackModel: string }>()
+      for (const inst of pane?.instances || []) {
+        const fb = s.engineModelFallbacks.get(`${tabId}:${inst.id}`)
+        if (fb) out.set(inst.id, { requestedModel: fb.requestedModel, fallbackModel: fb.fallbackModel })
       }
       return out
     }),
@@ -181,6 +199,34 @@ export function EngineStatusBar({ tabId }: Props) {
         ) : (
           <span>{inst.label}</span>
         )}
+        {/* Model-fallback indicator. The engine emits engine_model_fallback
+            when a dispatched run's requested model didn't resolve to a
+            provider and the runloop fell back to the engine's configured
+            defaultModel. This client's policy is to display a small ⚠
+            glyph on the affected instance pill until the next idle
+            transition. Per CLAUDE.md § "The typed-event corollary", that
+            policy is one consumer's choice — headless harnesses are
+            free to react differently or ignore the event. */}
+        {(() => {
+          const fb = modelFallbackByInstance.get(inst.id)
+          if (!fb) return null
+          return (
+            <Tooltip text={`Requested model "${fb.requestedModel}" not configured; running with default "${fb.fallbackModel}"`}>
+              <span
+                data-ion-ui
+                data-testid={`model-fallback-warning-${inst.id}`}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  color: colors.infoText,
+                  flexShrink: 0,
+                }}
+              >
+                <Warning size={11} weight="fill" />
+              </span>
+            </Tooltip>
+          )
+        })()}
         {/* Close button */}
         <button
           data-ion-ui

--- a/desktop/src/renderer/components/FileEditorPreview.tsx
+++ b/desktop/src/renderer/components/FileEditorPreview.tsx
@@ -25,6 +25,42 @@ function resolveRelativePath(baseDir: string, href: string): string {
 }
 
 /**
+ * Split a markdown document into YAML frontmatter (raw, unparsed) and body.
+ *
+ * Mirrors `stripFrontmatter` semantics from
+ * `desktop/src/main/cli-compat/slash-expand.ts:147` (first line must be
+ * exactly `---`, scan downward for the next standalone `---` line; if no
+ * closing fence is found, treat the file as having no frontmatter rather
+ * than swallowing the entire document).
+ *
+ * Reimplemented inline rather than imported because the main and renderer
+ * processes are separate bundles and the logic is small enough that
+ * duplication is cheaper than restructuring the module graph. The
+ * behavior is pinned to the existing helper's contract.
+ *
+ * Returns the *raw* frontmatter block (without the fence lines) so the
+ * preview can render it verbatim — we deliberately do not parse the YAML
+ * here because the goal is to show the user exactly what is in the file,
+ * not a re-serialized projection of it.
+ */
+function splitFrontmatter(content: string): { frontmatterRaw: string | null; body: string } {
+  const lines = content.split('\n')
+  if (lines[0]?.trim() !== '---') return { frontmatterRaw: null, body: content }
+
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      const frontmatterRaw = lines.slice(1, i).join('\n')
+      const body = lines.slice(i + 1).join('\n').trimStart()
+      return { frontmatterRaw, body }
+    }
+  }
+
+  // Unclosed fence — treat as no frontmatter so we don't accidentally
+  // hide the whole document behind a collapsible section.
+  return { frontmatterRaw: null, body: content }
+}
+
+/**
  * Markdown preview pane. Resolves relative links against the active file's
  * directory and routes editable files back into the editor; everything else
  * opens in the OS default handler.
@@ -37,6 +73,19 @@ export function FileEditorPreview({ dir, tabId, activeFile }: FileEditorPreviewP
       ? activeFile.filePath.replace(/\/[^/]+$/, '')
       : dir
   }, [activeFile?.filePath, dir])
+
+  // Split frontmatter off the body before handing the content to
+  // react-markdown. Without this, `remark-gfm` sees the closing `---`
+  // fence as a setext H2 underline, which (a) renders the first
+  // frontmatter line as a giant heading, (b) consumes the fence as an
+  // <hr>, and (c) corrupts parser state so the first real heading below
+  // the frontmatter renders as body text. Splitting here keeps the
+  // metadata visible (in its own collapsible section above the preview)
+  // while letting the markdown parser see a clean document.
+  const { frontmatterRaw, body } = useMemo(
+    () => splitFrontmatter(activeFile.content),
+    [activeFile.content],
+  )
 
   const markdownComponents = useMemo(() => ({
     a: ({ href, children }: any) => (
@@ -111,9 +160,49 @@ export function FileEditorPreview({ dir, tabId, activeFile }: FileEditorPreviewP
         padding: '12px 16px',
       }}
     >
+      {frontmatterRaw !== null && (
+        <details
+          style={{
+            marginBottom: 12,
+            border: `1px solid ${colors.containerBorder}`,
+            borderRadius: 8,
+            background: 'transparent',
+          }}
+        >
+          <summary
+            style={{
+              cursor: 'pointer',
+              padding: '6px 10px',
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+              color: colors.textSecondary,
+              userSelect: 'none',
+            }}
+          >
+            Frontmatter
+          </summary>
+          <pre
+            style={{
+              margin: 0,
+              padding: '8px 12px',
+              borderTop: `1px solid ${colors.containerBorder}`,
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: colors.textSecondary,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-word',
+            }}
+          >
+            {frontmatterRaw}
+          </pre>
+        </details>
+      )}
       <div className="text-[13px] leading-[1.6] prose-cloud" style={{ color: colors.textSecondary }}>
         <Markdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
-          {activeFile.content}
+          {body}
         </Markdown>
       </div>
     </div>

--- a/desktop/src/renderer/stores/__tests__/engine-event-slice-model-fallback.test.ts
+++ b/desktop/src/renderer/stores/__tests__/engine-event-slice-model-fallback.test.ts
@@ -1,0 +1,173 @@
+/**
+ * engine-event-slice — engine_model_fallback handling.
+ *
+ * The engine emits `engine_model_fallback` once per run when the
+ * requested model couldn't be resolved to a provider and the runloop
+ * fell back to the configured `defaultModel`. The desktop renderer's
+ * policy (one possible consumer choice — see CLAUDE.md § "The
+ * typed-event corollary") is to display a ⚠ glyph on the affected
+ * EngineStatusBar instance pill until the next idle transition.
+ *
+ * This test pins:
+ *
+ *   1. `engine_model_fallback` writes a per-instance entry into the
+ *      `engineModelFallbacks` map keyed by `${tabId}:${instanceId}`.
+ *   2. The subsequent `engine_status { state: "idle" }` for the same
+ *      instance clears the entry.
+ *   3. Other instances are unaffected (write and clear are per-key).
+ *
+ * Auto-clear semantics: no wall-clock timer. The indicator stays
+ * sticky until the run actually completes — if the run never goes
+ * idle, the indicator persists, which is the correct UX because the
+ * underlying configuration mistake (missing tiers.standard) is still
+ * latent.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../session-store-helpers', () => ({
+  makeLocalTab: vi.fn(),
+  nextMsgId: vi.fn(() => 'mock-msg-id'),
+  playNotificationIfHidden: vi.fn(async () => {}),
+  totalInputTokens: vi.fn(() => 0),
+  scheduleDoneGroupMove: vi.fn(),
+}))
+
+import { createEngineEventSlice } from '../slices/engine-event-slice'
+import { handleEngineStatusEvent } from '../slices/engine-event-status'
+import type { State } from '../session-store-types'
+
+function buildHarness() {
+  const state: any = {
+    tabs: [{
+      id: 'tab1',
+      isEngine: true,
+      status: 'running',
+      lastEventAt: 0,
+      permissionDenied: null,
+      contextTokens: 0,
+      contextPercent: 0,
+      historicalSessionIds: [],
+    }],
+    activeTabId: 'tab1',
+    engineAgentStates: new Map(),
+    engineStatusFields: new Map(),
+    engineWorkingMessages: new Map(),
+    engineNotifications: new Map(),
+    engineDialogs: new Map(),
+    enginePinnedPrompt: new Map(),
+    engineUsage: new Map(),
+    engineMessages: new Map(),
+    engineDraftInputs: new Map(),
+    engineModelOverrides: new Map(),
+    engineConversationIds: new Map(),
+    enginePanes: new Map(),
+    enginePermissionDenied: new Map(),
+    engineModelFallbacks: new Map(),
+  }
+  const set = (partial: any) => {
+    const patch = typeof partial === 'function' ? partial(state) : partial
+    Object.assign(state, patch)
+  }
+  const get = () => state as State
+  const slice = createEngineEventSlice(set, get) as State
+  return { state, slice, set }
+}
+
+describe('engine_model_fallback slice handling', () => {
+  it('writes engineModelFallbacks entry keyed by tabId:instanceId', () => {
+    const { state, slice } = buildHarness()
+    const key = 'tab1:inst1'
+
+    slice.handleEngineEvent(key, {
+      type: 'engine_model_fallback',
+      fallbackRequestedModel: 'standard',
+      fallbackModel: 'claude-sonnet-4-6',
+      fallbackReason: 'no_provider_found',
+    } as any)
+
+    const entry = state.engineModelFallbacks.get(key)
+    expect(entry).toBeDefined()
+    expect(entry?.requestedModel).toBe('standard')
+    expect(entry?.fallbackModel).toBe('claude-sonnet-4-6')
+    expect(entry?.reason).toBe('no_provider_found')
+    expect(typeof entry?.at).toBe('number')
+  })
+
+  it('clears the entry on engine_status state=idle for the same instance', () => {
+    const { state, slice, set } = buildHarness()
+    const key = 'tab1:inst1'
+
+    slice.handleEngineEvent(key, {
+      type: 'engine_model_fallback',
+      fallbackRequestedModel: 'standard',
+      fallbackModel: 'claude-sonnet-4-6',
+      fallbackReason: 'no_provider_found',
+    } as any)
+    expect(state.engineModelFallbacks.has(key)).toBe(true)
+
+    // Drive the idle transition through the status handler directly —
+    // the slice's case 'engine_status' delegates to handleEngineStatusEvent.
+    handleEngineStatusEvent(set, key, 'tab1', {
+      type: 'engine_status',
+      fields: { state: 'idle' },
+    } as any)
+
+    expect(state.engineModelFallbacks.has(key)).toBe(false)
+  })
+
+  it('leaves other instances untouched on write and clear', () => {
+    const { state, slice, set } = buildHarness()
+    const a = 'tab1:inst-a'
+    const b = 'tab1:inst-b'
+
+    slice.handleEngineEvent(a, {
+      type: 'engine_model_fallback',
+      fallbackRequestedModel: 'standard',
+      fallbackModel: 'claude-sonnet-4-6',
+      fallbackReason: 'no_provider_found',
+    } as any)
+    slice.handleEngineEvent(b, {
+      type: 'engine_model_fallback',
+      fallbackRequestedModel: 'fast',
+      fallbackModel: 'claude-haiku-4-5',
+      fallbackReason: 'no_provider_found',
+    } as any)
+
+    expect(state.engineModelFallbacks.size).toBe(2)
+
+    // Idle only instance A — B's indicator must stay.
+    handleEngineStatusEvent(set, a, 'tab1', {
+      type: 'engine_status',
+      fields: { state: 'idle' },
+    } as any)
+
+    expect(state.engineModelFallbacks.has(a)).toBe(false)
+    expect(state.engineModelFallbacks.has(b)).toBe(true)
+    expect(state.engineModelFallbacks.get(b)?.fallbackModel).toBe('claude-haiku-4-5')
+  })
+
+  it('does not perturb the entry on a running-state engine_status tick', () => {
+    const { state, slice, set } = buildHarness()
+    const key = 'tab1:inst1'
+
+    slice.handleEngineEvent(key, {
+      type: 'engine_model_fallback',
+      fallbackRequestedModel: 'standard',
+      fallbackModel: 'claude-sonnet-4-6',
+      fallbackReason: 'no_provider_found',
+    } as any)
+    expect(state.engineModelFallbacks.has(key)).toBe(true)
+
+    // A status tick that is NOT idle (cost-only update, running, etc.)
+    // must not clear the indicator. The renderer's auto-clear rule is
+    // tied to the idle transition specifically.
+    handleEngineStatusEvent(set, key, 'tab1', {
+      type: 'engine_status',
+      fields: { state: 'running', totalCostUsd: 0.001 },
+    } as any)
+
+    expect(state.engineModelFallbacks.has(key)).toBe(true)
+    expect(state.engineModelFallbacks.get(key)?.fallbackModel).toBe('claude-sonnet-4-6')
+  })
+})

--- a/desktop/src/renderer/stores/session-store-types.ts
+++ b/desktop/src/renderer/stores/session-store-types.ts
@@ -61,6 +61,25 @@ export interface State {
   engineModelOverrides: Map<string, string>
   engineDraftInputs: Map<string, string>
   /**
+   * Pending model-fallback notice per engine instance, keyed by the
+   * compound `${tabId}:${instanceId}` key. Populated when the engine
+   * emits a `model_fallback` NormalizedEvent — typically because a
+   * dispatched agent requested an unconfigured tier alias and the
+   * runloop swapped to the engine's configured `defaultModel`.
+   *
+   * This client's policy: display a small ⚠ glyph on the affected
+   * EngineStatusBar pill with a tooltip naming the requested and
+   * fallback models. Clear on the next `task_complete` for that
+   * instance (no wall-clock timer — clients don't invent retention
+   * rules per `docs/architecture/agent-state.md`).
+   *
+   * The engine event is workflow, not state — it fires once at the
+   * swap site and is not retained in any snapshot. Persisting the
+   * fact in renderer state turns it into a sticky-until-cleared UI
+   * indicator. See CLAUDE.md § "The typed-event corollary".
+   */
+  engineModelFallbacks: Map<string, { requestedModel: string; fallbackModel: string; reason: string; at: number }>
+  /**
    * Pending AskUserQuestion / ExitPlanMode denials per engine instance,
    * keyed by the compound `${tabId}:${instanceId}` key. A `null` slot is
    * the explicit "no pending denial" marker for an instance (preserved

--- a/desktop/src/renderer/stores/sessionStore.ts
+++ b/desktop/src/renderer/stores/sessionStore.ts
@@ -61,6 +61,7 @@ const initialState = {
   engineMessages: new Map<string, Message[]>(),
   engineModelOverrides: new Map<string, string>(),
   engineDraftInputs: new Map<string, string>(),
+  engineModelFallbacks: new Map<string, { requestedModel: string; fallbackModel: string; reason: string; at: number }>(),
   // Per-engine-instance AskUserQuestion / ExitPlanMode denials. Keyed by
   // `${tabId}:${instanceId}`. See `enginePermissionDenied` JSDoc on
   // `State` (session-store-types.ts) for the full rationale. Mirrors the

--- a/desktop/src/renderer/stores/slices/engine-event-slice.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-slice.ts
@@ -522,6 +522,33 @@ export function createEngineEventSlice(set: StoreSet, _get: StoreGet): Partial<S
           })
           break
         }
+        case 'engine_model_fallback': {
+          // The engine fell back to its configured defaultModel because
+          // the requested model didn't resolve to a provider. This
+          // client's policy: show a small ⚠ glyph on the affected
+          // engine instance pill via the EngineStatusBar. The fact is
+          // stored per-instance (compound key) and cleared on the next
+          // engine_status state=idle for that same instance (see the
+          // `state === 'idle'` branch in engine-event-status.ts).
+          //
+          // Engine event semantics: ModelFallbackEvent is a workflow
+          // signal, not a state snapshot — it fires once at the swap
+          // site. Persisting it in renderer state is renderer policy,
+          // not engine policy; another consumer (headless harness,
+          // future CLI client) is free to ignore the event entirely.
+          // See CLAUDE.md § "The typed-event corollary".
+          set((state) => {
+            const fallbacks = new Map(state.engineModelFallbacks)
+            fallbacks.set(key, {
+              requestedModel: event.fallbackRequestedModel,
+              fallbackModel: event.fallbackModel,
+              reason: event.fallbackReason,
+              at: Date.now(),
+            })
+            return { engineModelFallbacks: fallbacks }
+          })
+          break
+        }
       }
     },
   }

--- a/desktop/src/renderer/stores/slices/engine-event-status.ts
+++ b/desktop/src/renderer/stores/slices/engine-event-status.ts
@@ -181,6 +181,23 @@ export function handleEngineStatusEvent(
     if (enginePermissionDeniedUpdate) {
       returnPatch.enginePermissionDenied = enginePermissionDeniedUpdate
     }
+
+    // Auto-clear the model-fallback indicator on the idle transition.
+    // The fallback indicator is a workflow signal — once the affected
+    // run completes (state=idle), the user has seen the ⚠ glyph and
+    // the next dispatch starts fresh. No wall-clock timer: per
+    // docs/architecture/agent-state.md, clients do not invent retention
+    // rules. If the run never completes, the indicator stays sticky.
+    //
+    // Defensive: pre-existing test harnesses don't always initialize
+    // engineModelFallbacks on their mock state object. Production
+    // initializes it in sessionStore.ts, but the guard keeps this
+    // helper compatible with leaner test scaffolding.
+    if (isIdle && state.engineModelFallbacks?.has(key)) {
+      const fallbacks = new Map(state.engineModelFallbacks)
+      fallbacks.delete(key)
+      returnPatch.engineModelFallbacks = fallbacks
+    }
     if (needsTabUpdate) {
       const tabs = state.tabs.map((t) => {
         if (t.id !== tabId) return t

--- a/desktop/src/shared/__tests__/contract-sync.test.ts
+++ b/desktop/src/shared/__tests__/contract-sync.test.ts
@@ -86,6 +86,7 @@ const TS_NORMALIZED_EVENTS: Record<string, string[]> = {
   compacting: ['active', 'clearedBlocks', 'messagesAfter', 'messagesBefore', 'strategy', 'summary'],
   tool_stalled: ['elapsed', 'toolId', 'toolName'],
   steer_injected: ['messageLength'],
+  model_fallback: ['fallbackModel', 'reason', 'requestedModel'],
 }
 
 // ─── TS SharedTypes field map ───

--- a/desktop/src/shared/types-engine.ts
+++ b/desktop/src/shared/types-engine.ts
@@ -184,6 +184,16 @@ export type EngineEvent =
   // already part of the conversation. See
   // engine/internal/types/normalized_event.go (SteerInjectedEvent).
   | { type: 'engine_steer_injected'; steerMessageLength: number }
+  // engine_model_fallback — workflow signal emitted by the engine when
+  // it fell back to its configured defaultModel because the requested
+  // model didn't resolve to a provider. Mirrors the underlying
+  // ModelFallbackEvent NormalizedEvent variant. The desktop renders a
+  // small ⚠ glyph on the affected engine instance pill via the
+  // engineModelFallbacks store map; iOS receives the fact through the
+  // snapshot path (RemoteTabState.engineInstances[i].modelFallback)
+  // rather than as a live RemoteEvent. See CLAUDE.md §
+  // "The typed-event corollary" for the broader rule.
+  | { type: 'engine_model_fallback'; fallbackRequestedModel: string; fallbackModel: string; fallbackReason: string }
   | { type: 'engine_extension_died'; extensionName: string; exitCode: number | null; signal: string | null }
   | { type: 'engine_extension_respawned'; extensionName: string; attemptNumber: number }
   | { type: 'engine_events_dropped'; count: number }

--- a/desktop/src/shared/types-events.ts
+++ b/desktop/src/shared/types-events.ts
@@ -5,6 +5,19 @@ export interface DiscoveredCommand {
   description: string
   scope: 'user' | 'project'
   source: 'command' | 'skill'
+  /**
+   * Which directory family this command was discovered from:
+   *   - `'ion'`    → `~/.ion/commands/` or `{project}/.ion/commands/`
+   *   - `'claude'` → `~/.claude/commands/`, `{project}/.claude/commands/`,
+   *                  or `~/.claude/skills/`
+   *
+   * Consumers use this to filter out `'claude'` entries when the
+   * `enableClaudeCompat` setting is disabled. Ion-native commands are
+   * always available; only Claude-compat entries are gated by the
+   * setting. See `desktop/src/main/ipc/sessions-list.ts` and
+   * `desktop/src/main/remote/handlers/tabs.ts` for the filter logic.
+   */
+  origin: 'ion' | 'claude'
 }
 
 // ─── CLI Backend Stream Event Types ───

--- a/desktop/src/shared/types-events.ts
+++ b/desktop/src/shared/types-events.ts
@@ -147,3 +147,4 @@ export type NormalizedEvent =
   | { type: 'compacting'; active: boolean; summary?: string; messagesBefore?: number; messagesAfter?: number; clearedBlocks?: number; strategy?: string }
   | { type: 'tool_stalled'; toolId: string; toolName: string; elapsed: number }
   | { type: 'steer_injected'; messageLength: number }
+  | { type: 'model_fallback'; requestedModel: string; fallbackModel: string; reason: string }

--- a/docs/engine-grounding.md
+++ b/docs/engine-grounding.md
@@ -68,6 +68,10 @@ Every consumer depends on published contracts. **Never ship a breaking change to
 - Change the **semantics** of an existing event (e.g. turning a snapshot into an incremental update, or vice versa) — even if the wire shape is unchanged.
 - Stop emitting an existing event on one of its established triggers, even when the wire shape is unchanged. Consumers depend on *when* events fire, not just on their schema. Exceptions require an ADR documenting the semantic rationale and the migration impact; the ADR is the single source of truth for what changed and why (e.g. [ADR-003](architecture/adr/003-state-events-vs-workflow-events.md) for the `engine_plan_mode_changed` / `ExitPlanMode` trigger removal).
 
+### Typed events are the complete signaling surface
+
+Typed events fulfill the engine's signaling obligation in full. Do not double-surface signal in stream content, log lines, or system messages. See root [`CLAUDE.md`](../CLAUDE.md) § "The typed-event corollary" for the full rule. Short version: when the engine needs to communicate something to consumers, it emits a typed `NormalizedEvent` variant — and nothing else. Mutating `TaskCompleteEvent.Result`, `TextChunkEvent`, or injecting synthetic system messages to make the same information visible "by another path" is forbidden because it forces every consumer through one UI-shaped interpretation and corrupts headless pipelines that parse stream content as the LLM's verbatim output.
+
 ### Cross-language sync (mandatory when shared types change)
 
 Go is the source of truth. `engine/internal/types/contract_test.go` extracts JSON field names into `engine/internal/types/testdata/contracts.json`. TS and Swift validate against it.
@@ -147,6 +151,7 @@ Logging is first-class. Every operation must be reconstructible from logs alone,
 - Engine executes; harness decides; clients render.
 - Contracts are additive only. Semantics count.
 - Snapshots replace; incrementals merge. Pick one and document it.
+- Typed events are the complete signaling surface. Never double-surface in stream content.
 - Engine changes are dangerous. Default to "no."
 - Settings belong to the consumer that owns them.
 - Log everything; success and failure; with context.

--- a/docs/protocol/normalized-events.md
+++ b/docs/protocol/normalized-events.md
@@ -271,6 +271,40 @@ No additional fields.
 
 ---
 
+### model_fallback
+
+Workflow event emitted once per run when the requested model could not be
+resolved to a provider and the engine fell back to its configured
+`defaultModel`. Informational only — the run continues normally on the
+fallback model. The event is the engine's complete signaling surface for
+this condition; the engine never mutates stream content
+(`TaskCompleteEvent.Result`, `TextChunkEvent`) to communicate the
+fallback. Consumers may surface this however they wish — render a UI
+warning, abort a downstream orchestration, log a metric, or ignore the
+event entirely. See [CLAUDE.md § "The typed-event corollary"](https://github.com/dsswift/ion/blob/main/CLAUDE.md).
+
+Snapshot semantics: workflow signal, not state. The event fires once at
+the swap site and is not retained or replayed on reconnect. Consumers
+that need sticky UI must project the fact into their own snapshot state.
+
+When the engine has no `defaultModel` configured and the requested model
+is unresolvable, **no** `model_fallback` event is emitted — the engine
+falls through to the existing `error` event with `errorCode: "invalid_model"`,
+which already carries the actionable hard-fail message.
+
+| Field            | Type              | Description |
+|------------------|-------------------|-------------|
+| `type`           | `"model_fallback"` | Event type |
+| `requestedModel` | string            | The model string the run was started with (e.g. an unconfigured tier alias like `"standard"`). |
+| `fallbackModel`  | string            | The engine's configured `defaultModel` that the run will actually use. Never empty when this event is emitted. |
+| `reason`         | string            | Short machine-readable code. Currently always `"no_provider_found"`; reserved for future fallback triggers. |
+
+**Produced from:** `ModelFallbackEvent` in
+[`engine/internal/types/normalized_event.go`](https://github.com/dsswift/ion/blob/main/engine/internal/types/normalized_event.go),
+emitted at the model-fallback swap site in `runloop.go`.
+
+---
+
 ## Normalization Pipeline
 
 The normalizer processes raw events by inspecting the top-level `type` field:

--- a/engine/internal/backend/runloop.go
+++ b/engine/internal/backend/runloop.go
@@ -39,38 +39,14 @@ func (b *ApiBackend) runLoop(ctx context.Context, run *activeRun, opts types.Run
 		earlyStop.maxContinuations, earlyStop.diminishingDelta, earlyStop.source, opts.IsSubagent,
 	))
 
-	// Resolve provider
-	model := opts.Model
-	if model == "" {
-		msg := "no model configured: set defaultModel in ~/.ion/engine.json or pass --model. See docs/configuration/engine-json.md."
-		utils.Error("ApiBackend", msg)
-		b.emit(run, types.NormalizedEvent{Data: &types.ErrorEvent{
-			ErrorMessage: msg,
-			ErrorCode:    "no_model_configured",
-		}})
-		b.emitError(run, fmt.Errorf("%s", msg))
-		b.emitExit(run.requestID, intPtr(1), nil, opts.SessionID)
-		return
-	}
-
-	provider := b.resolveProvider(model)
-	if provider == nil && run.cfg != nil && run.cfg.DefaultModel != "" && run.cfg.DefaultModel != model {
-		// Graceful degradation: the requested model (e.g. an unrecognized
-		// tier alias like "standard") didn't resolve. Fall back to the
-		// engine's default model instead of hard-failing.
-		utils.Warn("ApiBackend", fmt.Sprintf("model %q not found, falling back to default %q", model, run.cfg.DefaultModel))
-		model = run.cfg.DefaultModel
-		opts.Model = model
-		provider = b.resolveProvider(model)
-	}
+	// Resolve provider — applies the engine's graceful-degradation
+	// policy (fall back to DefaultModel when the requested model is
+	// unknown) and emits ModelFallbackEvent on the swap path. See
+	// runloop_provider_resolve.go for the full contract; on any
+	// non-recoverable failure the helper has already emitted the
+	// appropriate ErrorEvent + exit and we just return.
+	provider, model := b.resolveProviderForRun(run, &opts)
 	if provider == nil {
-		utils.Error("ApiBackend", fmt.Sprintf("no provider for model %q", model))
-		b.emit(run, types.NormalizedEvent{Data: &types.ErrorEvent{
-			ErrorMessage: fmt.Sprintf("no provider found for model %q", model),
-			ErrorCode:    "invalid_model",
-		}})
-		b.emitError(run, fmt.Errorf("no provider found for model %q", model))
-		b.emitExit(run.requestID, intPtr(1), nil, opts.SessionID)
 		return
 	}
 

--- a/engine/internal/backend/runloop_model_fallback_test.go
+++ b/engine/internal/backend/runloop_model_fallback_test.go
@@ -1,0 +1,174 @@
+package backend
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// TestModelFallback_SwapsToDefaultAndEmitsEvent locks in the fix for the
+// "child agent dispatched with unresolved tier alias" bug. When a child run
+// starts with a model string that doesn't resolve to a registered provider
+// (the canonical case: ion-meta specialists declaring `model: standard`
+// when the user has no `tiers.standard` configured), the engine must:
+//
+//  1. Fall back to RunConfig.DefaultModel (already wired pre-fix).
+//  2. Emit exactly one ModelFallbackEvent so consumers can react (NEW).
+//  3. Leave the LLM's text output byte-identical (NEW — pins the
+//     "engine never mutates stream content" invariant against any future
+//     change that tries to "helpfully" append a fallback note to
+//     TaskCompleteEvent.Result).
+//
+// Without (2) and (3), the engine either failed silently (no signal to
+// consumers that the model wasn't what they asked for) or risked
+// poisoning downstream parsers by mutating stream content. See the
+// grand-surfing-moth plan and CLAUDE.md § "The typed-event corollary".
+func TestModelFallback_SwapsToDefaultAndEmitsEvent(t *testing.T) {
+	const llmOutput = "this is the exact verbatim LLM output, do not touch"
+
+	// Register a provider only for testModel — the "real" model. The run
+	// will be started with "standard" (unregistered) and must fall back.
+	setupTestProvider([][]types.LlmStreamEvent{
+		textResponse(llmOutput, 10, 5),
+	})
+
+	b := NewApiBackend()
+
+	cfg := &RunConfig{
+		DefaultModel: testModel,
+	}
+
+	c := collectEvents(b, "req-fallback-1")
+	b.StartRunWithConfig("req-fallback-1", types.RunOptions{
+		Prompt:           "hello",
+		ProjectPath:      "/tmp",
+		Model:            "standard", // unresolvable; must fall back
+		EarlyStopEnabled: testEarlyStopDisabled(),
+	}, cfg)
+
+	if !waitForExit(c, 5*time.Second) {
+		t.Fatal("timed out waiting for run to exit")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Guarantee 1: no invalid_model error — the fallback actually fired.
+	for _, ev := range c.normalized {
+		if errEv, ok := ev.Data.(*types.ErrorEvent); ok && errEv.ErrorCode == "invalid_model" {
+			t.Fatalf("unexpected invalid_model ErrorEvent — fallback didn't fire: %s", errEv.ErrorMessage)
+		}
+	}
+
+	// Guarantee 2: exactly one ModelFallbackEvent with the right fields.
+	var fallbacks []*types.ModelFallbackEvent
+	for _, ev := range c.normalized {
+		if mf, ok := ev.Data.(*types.ModelFallbackEvent); ok {
+			fallbacks = append(fallbacks, mf)
+		}
+	}
+	if len(fallbacks) != 1 {
+		t.Fatalf("expected exactly 1 ModelFallbackEvent, got %d", len(fallbacks))
+	}
+	mf := fallbacks[0]
+	if mf.RequestedModel != "standard" {
+		t.Errorf("RequestedModel: got %q want %q", mf.RequestedModel, "standard")
+	}
+	if mf.FallbackModel != testModel {
+		t.Errorf("FallbackModel: got %q want %q", mf.FallbackModel, testModel)
+	}
+	if mf.Reason != "no_provider_found" {
+		t.Errorf("Reason: got %q want %q", mf.Reason, "no_provider_found")
+	}
+
+	// Guarantee 3: the LLM's output is byte-identical in TaskCompleteEvent.
+	// Exact string equality — no substring match — pins the rule that the
+	// engine never mutates stream content to communicate the fallback.
+	// If a future change adds a notice to Result, this test fails loudly.
+	var tcResult string
+	var tcSeen bool
+	for _, ev := range c.normalized {
+		if tc, ok := ev.Data.(*types.TaskCompleteEvent); ok {
+			tcResult = tc.Result
+			tcSeen = true
+		}
+	}
+	if !tcSeen {
+		t.Fatal("no TaskCompleteEvent emitted")
+	}
+	if tcResult != llmOutput {
+		t.Errorf("TaskCompleteEvent.Result was mutated by the engine.\n  got:  %q\n  want: %q (verbatim LLM output)", tcResult, llmOutput)
+	}
+}
+
+// TestModelFallback_SkippedWhenNoDefaultConfigured locks in the chosen
+// behaviour for the "no fallback available" case: when the run's RunConfig
+// has DefaultModel == "" (or the run has no RunConfig at all), the
+// existing no_provider_found / invalid_model hard fail still wins and NO
+// ModelFallbackEvent is emitted. Emitting an event with empty FallbackModel
+// would mislead clients about which model is running.
+//
+// This pins the "short-circuit, no fake event" decision documented in the
+// grand-surfing-moth plan §2 "Default-also-missing case".
+func TestModelFallback_SkippedWhenNoDefaultConfigured(t *testing.T) {
+	// Register a provider so the runtime is wired, but the test run uses
+	// an unrelated model. With DefaultModel == "" the fallback guard
+	// short-circuits.
+	setupTestProvider([][]types.LlmStreamEvent{
+		textResponse("unused", 10, 5),
+	})
+
+	b := NewApiBackend()
+
+	cfg := &RunConfig{
+		DefaultModel: "", // No default — fallback must not fire.
+	}
+
+	c := collectEvents(b, "req-fallback-skipped-1")
+	b.StartRunWithConfig("req-fallback-skipped-1", types.RunOptions{
+		Prompt:           "hello",
+		ProjectPath:      "/tmp",
+		Model:            "standard",
+		EarlyStopEnabled: testEarlyStopDisabled(),
+	}, cfg)
+
+	if !waitForExit(c, 5*time.Second) {
+		t.Fatal("timed out waiting for run to exit")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Guarantee 1: no ModelFallbackEvent was emitted.
+	for _, ev := range c.normalized {
+		if _, ok := ev.Data.(*types.ModelFallbackEvent); ok {
+			t.Fatal("ModelFallbackEvent emitted with no DefaultModel — must not fire when no fallback is available")
+		}
+	}
+
+	// Guarantee 2: the existing invalid_model error still fires with its
+	// actionable message text.
+	var invalidModel *types.ErrorEvent
+	for _, ev := range c.normalized {
+		if errEv, ok := ev.Data.(*types.ErrorEvent); ok && errEv.ErrorCode == "invalid_model" {
+			invalidModel = errEv
+			break
+		}
+	}
+	if invalidModel == nil {
+		t.Fatal("expected ErrorEvent{ErrorCode: invalid_model} when fallback is unavailable")
+	}
+	if !strings.Contains(invalidModel.ErrorMessage, "standard") {
+		t.Errorf("invalid_model message should name the requested model, got: %q", invalidModel.ErrorMessage)
+	}
+
+	// Guarantee 3: the run exited with a non-zero code (hard fail).
+	if c.exitCode == nil {
+		t.Fatal("expected non-nil exit code")
+	}
+	if *c.exitCode == 0 {
+		t.Errorf("expected non-zero exit code on hard-fail path, got 0")
+	}
+}

--- a/engine/internal/backend/runloop_provider_resolve.go
+++ b/engine/internal/backend/runloop_provider_resolve.go
@@ -1,0 +1,98 @@
+package backend
+
+import (
+	"fmt"
+
+	"github.com/dsswift/ion/engine/internal/providers"
+	"github.com/dsswift/ion/engine/internal/types"
+	"github.com/dsswift/ion/engine/internal/utils"
+)
+
+// resolveProviderForRun resolves the LLM provider for a run, applying the
+// engine's "fall back to DefaultModel when the requested model is
+// unknown" graceful-degradation policy. Returns the resolved provider
+// and the (possibly swapped) model id, or nil if the run cannot proceed.
+//
+// When the provider cannot be resolved AND no fallback is available
+// (either because run.cfg is nil or run.cfg.DefaultModel is empty), the
+// function emits the existing ErrorEvent{ErrorCode: "invalid_model"} +
+// emitError + emitExit and returns nil — telling the caller to abort
+// the run. When the empty-model precondition fails (model == ""), it
+// emits a distinct ErrorEvent{ErrorCode: "no_model_configured"} with
+// actionable text. Both paths log to ~/.ion/engine.log so the decision
+// is reconstructible.
+//
+// When the fallback fires, the function:
+//
+//  1. Logs the swap at WARN level (existing behaviour, preserved).
+//  2. Emits a typed ModelFallbackEvent on the run's normalized stream
+//     so consumers can react. The event is a workflow signal — fired
+//     once at the swap site, not retained in any snapshot, never
+//     duplicated to stream content (TaskCompleteEvent.Result,
+//     TextChunkEvent). See CLAUDE.md § "The typed-event corollary"
+//     for the rule that prohibits double-surfacing.
+//  3. Logs the emission at INFO with the session id so it's grep-able.
+//
+// Mutates opts.Model in place when the swap happens; that's deliberate —
+// the rest of runLoop reads opts.Model for telemetry, hooks, and
+// conversation persistence and must see the actual model that ran.
+func (b *ApiBackend) resolveProviderForRun(run *activeRun, opts *types.RunOptions) (providers.LlmProvider, string) {
+	model := opts.Model
+	if model == "" {
+		msg := "no model configured: set defaultModel in ~/.ion/engine.json or pass --model. See docs/configuration/engine-json.md."
+		utils.Error("ApiBackend", msg)
+		b.emit(run, types.NormalizedEvent{Data: &types.ErrorEvent{
+			ErrorMessage: msg,
+			ErrorCode:    "no_model_configured",
+		}})
+		b.emitError(run, fmt.Errorf("%s", msg))
+		b.emitExit(run.requestID, intPtr(1), nil, opts.SessionID)
+		return nil, ""
+	}
+
+	provider := b.resolveProvider(model)
+	if provider == nil && run.cfg != nil && run.cfg.DefaultModel != "" && run.cfg.DefaultModel != model {
+		// Graceful degradation: the requested model (e.g. an unrecognized
+		// tier alias like "standard") didn't resolve. Fall back to the
+		// engine's default model instead of hard-failing.
+		//
+		// Emit a typed ModelFallbackEvent so consumers (clients, harness
+		// extensions) can react. The event is a workflow signal — fired
+		// once at the swap site, not retained in any snapshot. Consumers
+		// that need sticky UI must project the fact into their own state.
+		// We never mutate stream content (TaskCompleteEvent.Result,
+		// TextChunkEvent) to communicate this — typed event is the entire
+		// signaling surface. See CLAUDE.md § "The typed-event corollary".
+		original := model
+		utils.Warn("ApiBackend", fmt.Sprintf("model %q not found, falling back to default %q", model, run.cfg.DefaultModel))
+		model = run.cfg.DefaultModel
+		opts.Model = model
+		provider = b.resolveProvider(model)
+		b.emit(run, types.NormalizedEvent{Data: &types.ModelFallbackEvent{
+			RequestedModel: original,
+			FallbackModel:  run.cfg.DefaultModel,
+			Reason:         "no_provider_found",
+		}})
+		utils.Log("ApiBackend", fmt.Sprintf("model_fallback_emitted: requested=%q fallback=%q reason=%s sessionID=%s", original, run.cfg.DefaultModel, "no_provider_found", opts.SessionID))
+	}
+	if provider == nil {
+		// No fallback was attempted (or attempted but the default model
+		// itself didn't resolve, which is a configuration error). Log
+		// whether the fallback was even available so the "no default
+		// configured" branch is distinguishable in engine.log from the
+		// "default model is unknown" branch.
+		if run.cfg == nil || run.cfg.DefaultModel == "" {
+			utils.Log("ApiBackend", fmt.Sprintf("model_fallback_skipped: requested=%q reason=no_default_configured runCfgNil=%v sessionID=%s", model, run.cfg == nil, opts.SessionID))
+		}
+		utils.Error("ApiBackend", fmt.Sprintf("no provider for model %q", model))
+		b.emit(run, types.NormalizedEvent{Data: &types.ErrorEvent{
+			ErrorMessage: fmt.Sprintf("no provider found for model %q", model),
+			ErrorCode:    "invalid_model",
+		}})
+		b.emitError(run, fmt.Errorf("no provider found for model %q", model))
+		b.emitExit(run.requestID, intPtr(1), nil, opts.SessionID)
+		return nil, ""
+	}
+
+	return provider, model
+}

--- a/engine/internal/session/backend_helpers.go
+++ b/engine/internal/session/backend_helpers.go
@@ -3,6 +3,7 @@ package session
 import (
 	"github.com/dsswift/ion/engine/internal/backend"
 	"github.com/dsswift/ion/engine/internal/providers"
+	"github.com/dsswift/ion/engine/internal/types"
 	"github.com/dsswift/ion/engine/internal/utils"
 )
 
@@ -59,4 +60,35 @@ func (m *Manager) newChildBackend() backend.RunBackend {
 	default:
 		return backend.NewApiBackend()
 	}
+}
+
+// startChildRun dispatches a child run with an optional RunConfig, choosing
+// StartRunWithConfig when the concrete backend type supports it. This is
+// the parallel of extcontext.startChild for callers inside the session
+// package (currently prompt_agent_spawner.go) that need to thread per-run
+// config — most importantly DefaultModel — into the child run so the
+// runloop's existing fallback at runloop.go:57 can fire when the child's
+// requested model doesn't resolve to a provider.
+//
+// When cfg is nil the function degrades to plain StartRun, preserving the
+// pre-existing behaviour for callers that don't need per-run config.
+//
+// Detection is by interface assertion (configurableBackend) rather than
+// concrete type switch so that test stubs can opt in by implementing
+// StartRunWithConfig — the production *ApiBackend and *HybridBackend both
+// satisfy the interface.
+type configurableBackend interface {
+	StartRunWithConfig(requestID string, options types.RunOptions, cfg *backend.RunConfig)
+}
+
+func startChildRun(child backend.RunBackend, reqID string, runOpts types.RunOptions, cfg *backend.RunConfig) {
+	if cfg != nil {
+		if cb, ok := child.(configurableBackend); ok {
+			cb.StartRunWithConfig(reqID, runOpts, cfg)
+			return
+		}
+	}
+	// CliBackend, generic test stubs, or any backend that doesn't carry
+	// RunConfig fall through to the plain interface method.
+	child.StartRun(reqID, runOpts)
 }

--- a/engine/internal/session/event_translation.go
+++ b/engine/internal/session/event_translation.go
@@ -571,6 +571,22 @@ func translateToEngineEvent(event types.NormalizedEvent, contextWindow int) type
 		// to be echoed back over the wire.
 		return types.EngineEvent{Type: "engine_steer_injected", SteerMessageLength: e.MessageLength}
 
+	case *types.ModelFallbackEvent:
+		// Surface the model-fallback workflow signal as a typed engine
+		// event so clients can render an indicator. The desktop and iOS
+		// renderers display a small ⚠ glyph on the affected engine
+		// instance pill; headless harnesses may abort, retry, or route
+		// elsewhere. The engine has no opinion — see CLAUDE.md §
+		// "The typed-event corollary" for the rule that the typed event
+		// is the engine's *complete* signaling surface (no parallel
+		// stream-content mutation).
+		return types.EngineEvent{
+			Type:                   "engine_model_fallback",
+			FallbackRequestedModel: e.RequestedModel,
+			FallbackModel:          e.FallbackModel,
+			FallbackReason:         e.Reason,
+		}
+
 	default:
 		return types.EngineEvent{}
 	}

--- a/engine/internal/session/extcontext/dispatch_agent.go
+++ b/engine/internal/session/extcontext/dispatch_agent.go
@@ -155,6 +155,23 @@ func BuildDispatchAgentFunc(sa SessionAccessor, registry *DispatchRegistry) func
 			}
 		}
 
+		// Thread the engine's DefaultModel into the child run config so the
+		// runloop fallback (runloop.go:57) fires when the child's model
+		// doesn't resolve to a provider. Without this, dispatched children
+		// hard-fail with "no provider found" when the requested model is
+		// an unconfigured tier alias. Mirrors the spawner-side fix in
+		// prompt_agent_spawner.go. See plan §1 "Secondary path note".
+		var dispatchDefaultModel string
+		if engCfg := sa.EngineConfig(); engCfg != nil {
+			dispatchDefaultModel = engCfg.DefaultModel
+		}
+		if childCfg == nil {
+			childCfg = &backend.RunConfig{DefaultModel: dispatchDefaultModel}
+		} else if childCfg.DefaultModel == "" {
+			childCfg.DefaultModel = dispatchDefaultModel
+		}
+		utils.Log("Session", fmt.Sprintf("child run config: defaultModelThreaded=%q source=dispatch sessionKey=%s requestedModel=%q", dispatchDefaultModel, sa.SessionKey(), model))
+
 		// Shared mutable state for the event handler closure.
 		var totalCost float64
 		var totalInputTokens, totalOutputTokens int

--- a/engine/internal/session/manager_agent_lifecycle_test.go
+++ b/engine/internal/session/manager_agent_lifecycle_test.go
@@ -1,8 +1,11 @@
 package session
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/dsswift/ion/engine/internal/backend"
 	"github.com/dsswift/ion/engine/internal/types"
 )
 
@@ -191,5 +194,112 @@ func TestReconcileState_UnknownSessionNoEmit(t *testing.T) {
 
 	if emitted {
 		t.Fatal("expected no events for unknown session reconcile")
+	}
+}
+
+// TestAgentLifecycle_ModelFallbackDoesNotPerturbSnapshots locks in the
+// snapshot contract across the new ModelFallbackEvent termination path:
+// when a dispatched specialist receives a ModelFallbackEvent from the
+// child backend before completing, the parent's engine_agent_state
+// snapshot sequence must still be exactly the canonical two emissions
+// (running at start, done at completion). The fallback event is a
+// workflow signal — it must not trigger an extra agent_state snapshot
+// nor leave the agent in "running" status after termination.
+//
+// This pins docs/architecture/agent-state.md against the new termination
+// path introduced by the grand-surfing-moth plan.
+func TestAgentLifecycle_ModelFallbackDoesNotPerturbSnapshots(t *testing.T) {
+	// Stub child emits a ModelFallbackEvent followed by TaskCompleteEvent.
+	// The spawner's OnNormalized handler must ignore the fallback event
+	// for agent_state purposes and emit exactly two snapshots: running
+	// at start, done at completion.
+	stub := &childStubBackend{
+		resultText:        "specialist done",
+		emitModelFallback: true,
+	}
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	mgr.childBackendOverride = func() backend.RunBackend { return stub }
+
+	if _, err := mgr.StartSession("lifecycle-fallback", defaultConfig()); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	captured := captureAgentStateEvents(mgr)
+
+	mgr.mu.Lock()
+	s := mgr.sessions["lifecycle-fallback"]
+	mgr.mu.Unlock()
+
+	// Hook-capturing group lets the spawner fire agent_start / agent_end
+	// without panicking; the test doesn't assert on hook ordering, only
+	// on snapshot emissions.
+	group, _ := installHookCapturingGroup(t)
+	mgr.mu.Lock()
+	s.extGroup = group
+	mgr.mu.Unlock()
+
+	runCfg := &backend.RunConfig{}
+	mgr.wireAgentSpawner(s, "lifecycle-fallback", "claude-opus-4-7", group, runCfg)
+	if runCfg.AgentSpawner == nil {
+		t.Fatal("AgentSpawner not installed")
+	}
+
+	_, spawnErr := runCfg.AgentSpawner(
+		context.Background(),
+		"specialist",
+		"task",
+		"",
+		"/tmp",
+		"claude-sonnet-4-6",
+	)
+	if spawnErr != nil {
+		t.Fatalf("spawner returned error: %v", spawnErr)
+	}
+
+	// Give the goroutine a brief moment to flush the final snapshot —
+	// the spawner emits agent_state after onExit on its own goroutine,
+	// not synchronously with the spawner closure return.
+	time.Sleep(50 * time.Millisecond)
+
+	// Snapshot count: the spawner emits one running snapshot at start
+	// (reason=agent_start) and one terminal snapshot at end
+	// (reason=agent_end). The intervening ModelFallbackEvent must not
+	// trigger an additional emission.
+	snapshots := *captured
+	if len(snapshots) != 2 {
+		var summary []string
+		for _, snap := range snapshots {
+			row := ""
+			for _, a := range snap.Agents {
+				row += a.Name + "=" + a.Status + " "
+			}
+			summary = append(summary, "["+row+"]")
+		}
+		t.Fatalf("expected exactly 2 agent_state snapshots (running → done) across the fallback path, got %d: %v", len(snapshots), summary)
+	}
+
+	// The spawner generates the agent name from the unique dispatch ID
+	// (e.g. "agent-1") because the test registered no spec named
+	// "specialist". Locate by single-entry-snapshot rather than by name.
+	if len(snapshots[0].Agents) != 1 {
+		t.Fatalf("first snapshot should contain exactly 1 agent, got %d: %+v", len(snapshots[0].Agents), snapshots[0].Agents)
+	}
+	if len(snapshots[1].Agents) != 1 {
+		t.Fatalf("final snapshot should contain exactly 1 agent, got %d: %+v", len(snapshots[1].Agents), snapshots[1].Agents)
+	}
+
+	// First snapshot: agent is running.
+	if got := snapshots[0].Agents[0].Status; got != "running" {
+		t.Errorf("first snapshot status = %q, want %q", got, "running")
+	}
+
+	// Final snapshot: agent is done, never orphaned in running.
+	finalStatus := snapshots[1].Agents[0].Status
+	if finalStatus == "running" {
+		t.Errorf("agent still running in final snapshot (snapshot contract violated): %+v", snapshots[1].Agents[0])
+	}
+	if finalStatus != "done" {
+		t.Errorf("final snapshot status = %q, want %q", finalStatus, "done")
 	}
 }

--- a/engine/internal/session/prompt_agent_spawner.go
+++ b/engine/internal/session/prompt_agent_spawner.go
@@ -284,7 +284,24 @@ func (m *Manager) wireAgentSpawner(s *engineSession, key string, parentModel str
 				runOpts.AllowedTools = spec.Tools
 			}
 		}
-		child.StartRun(childRequestID, runOpts)
+
+		// Thread the engine's DefaultModel into the child run so the
+		// existing fallback at runloop.go fires when the child's model
+		// (e.g. a tier alias like "standard" that wasn't configured in
+		// models.json) doesn't resolve to a provider. Without this,
+		// children start with cfg=nil and the runloop's fallback guard
+		// short-circuits — the child hard-fails with "no provider found".
+		// Always pass a child RunConfig, even when DefaultModel is empty;
+		// the runloop guard at line 57 still short-circuits in that case
+		// and the existing no_provider_found error wins. This is the
+		// chosen behaviour — see plan §2 "Default-also-missing case".
+		var childDefaultModel string
+		if m.config != nil {
+			childDefaultModel = m.config.DefaultModel
+		}
+		utils.Log("Session", fmt.Sprintf("child run config: defaultModelThreaded=%q source=spawner sessionKey=%s requestedModel=%q", childDefaultModel, capturedKey, childModel))
+		childRunCfg := &backend.RunConfig{DefaultModel: childDefaultModel}
+		startChildRun(child, childRequestID, runOpts, childRunCfg)
 
 		// Wait for child to finish OR parent context to cancel.
 		doneCh := make(chan struct{})

--- a/engine/internal/session/prompt_agent_spawner_test.go
+++ b/engine/internal/session/prompt_agent_spawner_test.go
@@ -41,6 +41,11 @@ type childStubBackend struct {
 	// resultText is emitted as TaskCompleteEvent.Result before exit
 	// (when releaseGate is nil, i.e. immediate completion).
 	resultText string
+	// emitModelFallback, when true, causes the stub to emit a synthetic
+	// ModelFallbackEvent before the TaskCompleteEvent. Used by lifecycle
+	// tests to verify the parent's agent_state snapshot sequence isn't
+	// perturbed by intermediate workflow events from the child run.
+	emitModelFallback bool
 	// childErr, when non-nil, is delivered via onError after StartRun
 	// returns control.
 	childErr error
@@ -52,7 +57,12 @@ type childStubBackend struct {
 
 	startedRequestID string
 	startedOpts      types.RunOptions
-	cancelCalled     bool
+	// startedCfg captures the RunConfig passed to StartRunWithConfig.
+	// nil when the caller used plain StartRun (the pre-fix path) — that
+	// distinction matters for tests that verify DefaultModel was actually
+	// threaded into the child run.
+	startedCfg   *backend.RunConfig
+	cancelCalled bool
 }
 
 func (c *childStubBackend) StartRun(requestID string, opts types.RunOptions) {
@@ -63,6 +73,7 @@ func (c *childStubBackend) StartRun(requestID string, opts types.RunOptions) {
 	onExit := c.onExit
 	gate := c.releaseGate
 	result := c.resultText
+	emitFallback := c.emitModelFallback
 	errToEmit := c.childErr
 	c.mu.Unlock()
 
@@ -72,6 +83,18 @@ func (c *childStubBackend) StartRun(requestID string, opts types.RunOptions) {
 		// and child-error path).
 		if gate != nil {
 			<-gate
+		}
+		// Emit a synthetic ModelFallbackEvent before the task-complete so
+		// lifecycle tests can verify it doesn't perturb the parent's
+		// engine_agent_state snapshot sequence.
+		if emitFallback && onNorm != nil {
+			onNorm(requestID, types.NormalizedEvent{
+				Data: &types.ModelFallbackEvent{
+					RequestedModel: "standard",
+					FallbackModel:  "claude-sonnet-4-6",
+					Reason:         "no_provider_found",
+				},
+			})
 		}
 		if onNorm != nil && result != "" {
 			onNorm(requestID, types.NormalizedEvent{
@@ -94,6 +117,17 @@ func (c *childStubBackend) StartRun(requestID string, opts types.RunOptions) {
 			onExit(requestID, &zero, nil, "child-conv-id")
 		}
 	}()
+}
+
+// StartRunWithConfig implements the configurableBackend interface so the
+// session-package startChildRun helper routes through this method when the
+// spawner passes a non-nil RunConfig (the post-fix path). Captures cfg
+// alongside opts so tests can assert DefaultModel was threaded through.
+func (c *childStubBackend) StartRunWithConfig(requestID string, opts types.RunOptions, cfg *backend.RunConfig) {
+	c.mu.Lock()
+	c.startedCfg = cfg
+	c.mu.Unlock()
+	c.StartRun(requestID, opts)
 }
 
 func (c *childStubBackend) Cancel(_ string) bool {
@@ -454,5 +488,90 @@ func TestWireAgentSpawner_ConcreteModelPassesThrough(t *testing.T) {
 	}
 	if len(gotFallbacks) != 0 {
 		t.Errorf("child fallbacks = %v, want empty (no tier config)", gotFallbacks)
+	}
+}
+
+// TestWireAgentSpawner_ThreadsDefaultModelToChild locks in the fix for the
+// "child agent dispatched with unresolved tier alias" bug. When the agent
+// spec declares `model: standard` but the user has no models.json (so
+// ResolveTierChain returns "standard" verbatim), the spawner must still
+// pass the engine's DefaultModel into the child's RunConfig so that the
+// runloop fallback at runloop.go:57 can fire when the child's "standard"
+// model doesn't resolve to a provider.
+//
+// Without this fix, the spawner called child.StartRun (no RunConfig), the
+// runloop guard short-circuited (run.cfg == nil), and the child hard-failed
+// with "no provider found for model standard". See the grand-surfing-moth
+// plan §1.
+func TestWireAgentSpawner_ThreadsDefaultModelToChild(t *testing.T) {
+	// No ~/.ion/models.json — ResolveTierChain passes "standard" through
+	// unchanged. This is the exact production case the bug surfaces in.
+	t.Setenv("HOME", t.TempDir())
+
+	stub := &childStubBackend{resultText: "ok"}
+	mb := newMockBackend()
+	mgr := NewManager(mb)
+	mgr.childBackendOverride = func() backend.RunBackend { return stub }
+
+	// Configure the engine with a DefaultModel — this is what should
+	// propagate into the child's RunConfig so the runloop fallback can
+	// fire. The fallback itself is exercised in
+	// runloop_model_fallback_test.go; here we only assert the thread-through.
+	mgr.SetConfig(&types.EngineRuntimeConfig{
+		DefaultModel: "claude-sonnet-4-6",
+	})
+
+	if _, err := mgr.StartSession("threadthrough-test", defaultConfig()); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	mgr.mu.Lock()
+	s := mgr.sessions["threadthrough-test"]
+	mgr.mu.Unlock()
+
+	// Register an agent spec with a tier alias as its model. Without a
+	// models.json mapping for "standard", ResolveTierChain returns the
+	// input verbatim and the literal string "standard" reaches the
+	// child run as the requested Model.
+	s.agents.RegisterSpec(types.AgentSpec{
+		Name:  "test-specialist",
+		Model: "standard",
+	})
+
+	runCfg := &backend.RunConfig{}
+	mgr.wireAgentSpawner(s, "threadthrough-test", "claude-opus-4-7", nil, runCfg)
+	if runCfg.AgentSpawner == nil {
+		t.Fatal("AgentSpawner not installed")
+	}
+
+	_, spawnErr := runCfg.AgentSpawner(
+		context.Background(),
+		"test-specialist",
+		"audit the extension",
+		"",    // description
+		"/tmp",
+		"",    // model (empty — falls back to spec → "standard")
+	)
+	if spawnErr != nil {
+		t.Fatalf("spawner returned error: %v", spawnErr)
+	}
+
+	// Guarantee: the child received a RunConfig via StartRunWithConfig
+	// (not the bare StartRun path that loses RunConfig).
+	stub.mu.Lock()
+	gotCfg := stub.startedCfg
+	gotModel := stub.startedOpts.Model
+	stub.mu.Unlock()
+
+	if gotCfg == nil {
+		t.Fatal("child started with no RunConfig — startChildRun must dispatch to StartRunWithConfig so DefaultModel reaches the runloop fallback")
+	}
+	if gotCfg.DefaultModel != "claude-sonnet-4-6" {
+		t.Errorf("child RunConfig.DefaultModel = %q, want %q (engine default must be threaded through)", gotCfg.DefaultModel, "claude-sonnet-4-6")
+	}
+	// The child still received the unresolved tier alias as its Model —
+	// that's deliberate. The runloop is the layer that performs the swap
+	// (see runloop_model_fallback_test.go).
+	if gotModel != "standard" {
+		t.Errorf("child opts.Model = %q, want %q (tier passthrough — runloop performs the swap)", gotModel, "standard")
 	}
 }

--- a/engine/internal/types/contract_test.go
+++ b/engine/internal/types/contract_test.go
@@ -66,6 +66,7 @@ func normalizedEventVariants() map[string]NormalizedEventData {
 		EventCompacting:        &CompactingEvent{},
 		EventToolStalled:       &ToolStalledEvent{},
 		EventSteerInjected:     &SteerInjectedEvent{},
+		EventModelFallback:     &ModelFallbackEvent{},
 	}
 }
 

--- a/engine/internal/types/engine_event.go
+++ b/engine/internal/types/engine_event.go
@@ -82,6 +82,19 @@ type EngineEvent struct {
 	// SteerInjectedEvent for the underlying normalized variant.
 	SteerMessageLength int `json:"steerMessageLength,omitempty"`
 
+	// engine_model_fallback — workflow signal emitted when the engine
+	// fell back to its configured defaultModel because the requested
+	// model didn't resolve to a provider. Mirrors the underlying
+	// ModelFallbackEvent NormalizedEvent variant. Fields are surfaced
+	// distinctly (not packed into Metadata) so a typed client like the
+	// desktop or iOS doesn't have to parse an opaque map to learn the
+	// fallback decision. Consumers may surface a status indicator,
+	// abort orchestration, log a metric, or ignore the event — see
+	// CLAUDE.md § "The typed-event corollary".
+	FallbackRequestedModel string `json:"fallbackRequestedModel,omitempty"`
+	FallbackModel          string `json:"fallbackModel,omitempty"`
+	FallbackReason         string `json:"fallbackReason,omitempty"`
+
 	// engine_dead
 	ExitCode   *int     `json:"exitCode,omitempty"`
 	Signal     *string  `json:"signal,omitempty"`

--- a/engine/internal/types/normalized_event.go
+++ b/engine/internal/types/normalized_event.go
@@ -26,6 +26,7 @@ const (
 	EventCompacting        = "compacting"
 	EventToolStalled       = "tool_stalled"
 	EventSteerInjected     = "steer_injected"
+	EventModelFallback     = "model_fallback"
 )
 
 // NormalizedEventData is the interface satisfied by all canonical event variants.
@@ -108,6 +109,8 @@ func (e *NormalizedEvent) UnmarshalJSON(data []byte) error {
 		target = &ToolStalledEvent{}
 	case EventSteerInjected:
 		target = &SteerInjectedEvent{}
+	case EventModelFallback:
+		target = &ModelFallbackEvent{}
 	default:
 		return fmt.Errorf("unknown normalized event type: %q", peek.Type)
 	}
@@ -405,3 +408,30 @@ type SteerInjectedEvent struct {
 }
 
 func (SteerInjectedEvent) eventType() string { return EventSteerInjected }
+
+// ModelFallbackEvent is emitted once per run when the requested model
+// could not be resolved to a provider and the engine fell back to the
+// configured DefaultModel. Informational only — the run continues
+// normally on the fallback model. Consumers (clients, parent extensions)
+// may surface this however they wish; the engine never mutates stream
+// content to communicate it.
+//
+// Workflow signal, not a state snapshot. It fires once at the swap site
+// and is not replayed on reconnect; the engine does not retain it in any
+// snapshot. Consumers that need sticky UI must project the fact into
+// snapshot state at their own layer.
+type ModelFallbackEvent struct {
+	// RequestedModel is the model string the run was started with (e.g.
+	// a tier alias like "standard" that didn't resolve to a configured tier).
+	RequestedModel string `json:"requestedModel"`
+	// FallbackModel is the engine's configured DefaultModel that the run
+	// will actually use instead. Never empty when this event is emitted —
+	// if there is no default to fall back to, the event is not emitted
+	// and the engine returns the existing no_provider_found error.
+	FallbackModel string `json:"fallbackModel"`
+	// Reason is a short machine-readable code. Currently always
+	// "no_provider_found"; reserved for future fallback triggers.
+	Reason string `json:"reason"`
+}
+
+func (ModelFallbackEvent) eventType() string { return EventModelFallback }

--- a/engine/internal/types/testdata/contracts.json
+++ b/engine/internal/types/testdata/contracts.json
@@ -17,6 +17,11 @@
       "retryable",
       "sessionId"
     ],
+    "model_fallback": [
+      "fallbackModel",
+      "reason",
+      "requestedModel"
+    ],
     "permission_request": [
       "options",
       "questionId",
@@ -147,6 +152,9 @@
     "errorCode",
     "exitCode",
     "extensionName",
+    "fallbackModel",
+    "fallbackReason",
+    "fallbackRequestedModel",
     "fields",
     "httpStatus",
     "index",

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		A1B2C3D4E5F60001000240AA /* NormalizedEventStreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000241AA /* NormalizedEventStreamTests.swift */; };
 		A1B2C3D4E5F60001000242AA /* NormalizedEventPermissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000243AA /* NormalizedEventPermissionTests.swift */; };
 		A1B2C3D4E5F60001000244AA /* NormalizedEventLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000245AA /* NormalizedEventLifecycleTests.swift */; };
+		A1B2C3D4E5F60003000201AA /* ModelFallbackSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60003000202AA /* ModelFallbackSnapshotTests.swift */; };
 		A1B2C3D4E5F60001000246AA /* NormalizedEventTerminalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000247AA /* NormalizedEventTerminalTests.swift */; };
 		A1B2C3D4E5F60001000248AA /* ContractSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001000249AA /* ContractSyncTests.swift */; };
 		A1B2C3D4E5F60001E80006AA /* DesktopSettingsContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001E80007AA /* DesktopSettingsContractTests.swift */; };
@@ -294,6 +295,7 @@
 		A1B2C3D4E5F60001000241AA /* NormalizedEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventStreamTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000243AA /* NormalizedEventPermissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventPermissionTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000245AA /* NormalizedEventLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventLifecycleTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60003000202AA /* ModelFallbackSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFallbackSnapshotTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000247AA /* NormalizedEventTerminalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventTerminalTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001000249AA /* ContractSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractSyncTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001E80007AA /* DesktopSettingsContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesktopSettingsContractTests.swift; sourceTree = "<group>"; };
@@ -564,6 +566,7 @@
 				A1B2C3D4E5F60001000245AA /* NormalizedEventLifecycleTests.swift */,
 				A1B2C3D4E5F60001000247AA /* NormalizedEventTerminalTests.swift */,
 				A1B2C3D4E5F60001000249AA /* ContractSyncTests.swift */,
+				A1B2C3D4E5F60003000202AA /* ModelFallbackSnapshotTests.swift */,
 				A1B2C3D4E5F60001E80007AA /* DesktopSettingsContractTests.swift */,
 				A1B2C3D4E5F60001F00007AA /* ContractSyncEngineEventsTests.swift */,
 				A1B2C3D4E5F60001F00013AA /* RemoteCommandPillTests.swift */,
@@ -908,6 +911,7 @@
 				A1B2C3D4E5F60001000242AA /* NormalizedEventPermissionTests.swift in Sources */,
 				A1B2C3D4E5F60001000244AA /* NormalizedEventLifecycleTests.swift in Sources */,
 				A1B2C3D4E5F60001000246AA /* NormalizedEventTerminalTests.swift in Sources */,
+				A1B2C3D4E5F60003000201AA /* ModelFallbackSnapshotTests.swift in Sources */,
 				A1B2C3D4E5F60001000248AA /* ContractSyncTests.swift in Sources */,
 				A1B2C3D4E5F60001E80006AA /* DesktopSettingsContractTests.swift in Sources */,
 				A1B2C3D4E5F60001F00006AA /* ContractSyncEngineEventsTests.swift in Sources */,

--- a/ios/IonRemote.xcodeproj/project.pbxproj
+++ b/ios/IonRemote.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		A1B2C3D4E5F60001FF0003AA /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = A1B2C3D4E5F60001FF0001AA /* Markdown */; };
 		A1B2C3D4E5F60001FF0005AA /* MarkdownFormatterFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001FF0004AA /* MarkdownFormatterFixtures.swift */; };
 		A1B2C3D4E5F60001FF0007AA /* MarkdownFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001FF0006AA /* MarkdownFormatterTests.swift */; };
+		A1B2C3D4E5F60001FF0011AA /* FrontmatterSplitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001FF0010AA /* FrontmatterSplitter.swift */; };
+		A1B2C3D4E5F60001FF0013AA /* FrontmatterSplitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001FF0012AA /* FrontmatterSplitterTests.swift */; };
 		A1B2C3D4E5F600010000C0AA /* JetBrainsMonoNLNerdFontMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000C1AA /* JetBrainsMonoNLNerdFontMono-Regular.ttf */; };
 		A1B2C3D4E5F600010000C2AA /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000C3AA /* OFL.txt */; };
 		A1B2C3D4E5F600010000D0AA /* EngineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600010000D1AA /* EngineView.swift */; };
@@ -216,6 +218,8 @@
 		A1B2C3D4E5F60001000028AA /* E2ECryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2ECryptoTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001FF0004AA /* MarkdownFormatterFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatterFixtures.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60001FF0006AA /* MarkdownFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownFormatterTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001FF0010AA /* FrontmatterSplitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterSplitter.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60001FF0012AA /* FrontmatterSplitterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterSplitterTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100002AAA /* TransportManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportManagerTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100002CAA /* RelayClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayClientTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6000100002EAA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -573,6 +577,7 @@
 				A1B2C3D4E5F60001000028AA /* E2ECryptoTests.swift */,
 				A1B2C3D4E5F60001FF0004AA /* MarkdownFormatterFixtures.swift */,
 				A1B2C3D4E5F60001FF0006AA /* MarkdownFormatterTests.swift */,
+				A1B2C3D4E5F60001FF0012AA /* FrontmatterSplitterTests.swift */,
 				A1B2C3D4E5F6000100002AAA /* TransportManagerTests.swift */,
 				A1B2C3D4E5F6000100002CAA /* RelayClientTests.swift */,
 			);
@@ -617,6 +622,7 @@
 				A1B2C3D4E5F60001009001AA /* TabSearchHelper.swift */,
 				A1B2C3D4E5F60001009D00AA /* SafeDecodable.swift */,
 				A1B2C3D4E5F60001F1000CAA /* FuzzyMatch.swift */,
+				A1B2C3D4E5F60001FF0010AA /* FrontmatterSplitter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -850,6 +856,7 @@
 				A1B2C3D4E5F600010000F0AA /* EngineProfile.swift in Sources */,
 				A1B2C3D4E5F600010000F2AA /* KeyboardUtilityBar.swift in Sources */,
 				A1B2C3D4E5F600010000F6AA /* MarkdownFormatter.swift in Sources */,
+				A1B2C3D4E5F60001FF0011AA /* FrontmatterSplitter.swift in Sources */,
 				A1B2C3D4E5F600010000F8AA /* PlanFullScreenView.swift in Sources */,
 				A1B2C3D4E5F600010000FAAA /* MarkdownContentView.swift in Sources */,
 				A1B2C3D4E5F60001000501AA /* ConnectionQuality.swift in Sources */,
@@ -919,6 +926,7 @@
 				A1B2C3D4E5F60001000027AA /* E2ECryptoTests.swift in Sources */,
 				A1B2C3D4E5F60001FF0005AA /* MarkdownFormatterFixtures.swift in Sources */,
 				A1B2C3D4E5F60001FF0007AA /* MarkdownFormatterTests.swift in Sources */,
+				A1B2C3D4E5F60001FF0013AA /* FrontmatterSplitterTests.swift in Sources */,
 				A1B2C3D4E5F60001000029AA /* TransportManagerTests.swift in Sources */,
 				A1B2C3D4E5F6000100002BAA /* RelayClientTests.swift in Sources */,
 			);

--- a/ios/IonRemote/Models/DiscoveredSlashCommand.swift
+++ b/ios/IonRemote/Models/DiscoveredSlashCommand.swift
@@ -8,4 +8,16 @@ struct DiscoveredSlashCommand: Codable, Sendable, Identifiable {
     let description: String
     let scope: String       // "user" | "project"
     let source: String      // "command" | "skill"
+    /// Which directory family this command was discovered from.
+    /// `"ion"` for ~/.ion/commands and {project}/.ion/commands.
+    /// `"claude"` for ~/.claude/commands, {project}/.claude/commands,
+    /// and ~/.claude/skills.
+    ///
+    /// The desktop server filters out `"claude"` entries before sending
+    /// when the user has Claude Code Compatibility disabled, so iOS does
+    /// not have to act on this field — it just decodes it. Marked
+    /// optional to keep decoding resilient against older desktop builds
+    /// that pre-date the field (the field was added alongside the
+    /// claude-compat filter fix).
+    let origin: String?     // "ion" | "claude"
 }

--- a/ios/IonRemote/Models/RemoteTabState.swift
+++ b/ios/IonRemote/Models/RemoteTabState.swift
@@ -50,6 +50,30 @@ struct TerminalInstanceInfo: Codable, Identifiable, Sendable {
     var cwd: String
 }
 
+// MARK: - EngineInstanceModelFallback
+
+/// Per-engine-instance model-fallback indicator carried on
+/// EngineInstanceInfo. Populated by the desktop snapshot when the engine
+/// emitted a ModelFallbackEvent for the corresponding run — i.e. the
+/// requested model didn't resolve to a provider and the engine fell
+/// back to its configured `defaultModel`.
+///
+/// iOS receives this via the snapshot path, not via a live RemoteEvent,
+/// because the engine's ModelFallbackEvent is a workflow signal (fires
+/// once at the swap site) — to give iOS a sticky-across-reconnect
+/// indicator without a new RemoteEvent variant, the desktop projects
+/// the fact onto the snapshot. See CLAUDE.md § "Common parity surfaces"
+/// row for model fallback indicator and § "The typed-event corollary"
+/// for the broader rule that the engine's typed event is the complete
+/// signaling surface.
+struct EngineInstanceModelFallback: Codable, Sendable, Equatable {
+    /// The model string the run was started with (e.g. an unconfigured
+    /// tier alias like "standard").
+    let requestedModel: String
+    /// The engine's configured `defaultModel` that the run actually used.
+    let fallbackModel: String
+}
+
 // MARK: - EngineInstanceInfo
 
 struct EngineInstanceInfo: Codable, Identifiable, Sendable {
@@ -71,6 +95,13 @@ struct EngineInstanceInfo: Codable, Identifiable, Sendable {
     /// status is aggregated by the snapshot — if any instance is running,
     /// `RemoteTabState.status` is promoted to `.running`.
     var isRunning: Bool? = nil
+    /// Per-engine-instance model-fallback indicator. Non-nil when the
+    /// desktop's engineModelFallbacks map holds an entry for this
+    /// `tabId:instanceId` — i.e. the engine emitted ModelFallbackEvent
+    /// for the current/most recent run and the run hasn't yet gone
+    /// idle. `EngineInstanceBar` renders a ⚠ glyph when non-nil; tap
+    /// to reveal the requested + fallback model names.
+    var modelFallback: EngineInstanceModelFallback? = nil
 }
 
 // MARK: - PermissionMode

--- a/ios/IonRemote/Utilities/FrontmatterSplitter.swift
+++ b/ios/IonRemote/Utilities/FrontmatterSplitter.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Splits a markdown document into its YAML frontmatter block and body.
+///
+/// Mirrors the desktop renderer's `splitFrontmatter` helper in
+/// `desktop/src/renderer/components/FileEditorPreview.tsx` so the two
+/// reference clients render frontmatter-bearing markdown identically. The
+/// motivation is the same on both platforms:
+///
+/// - CommonMark (and its GFM extension) does not understand YAML
+///   frontmatter. The opening `---` is treated as plain text; the *closing*
+///   `---`, sitting on its own line directly under a non-blank line, is
+///   then matched as a **setext H2 underline**. The result is that the
+///   first frontmatter key renders as a giant heading, the closing fence
+///   is consumed as an `<hr>`, and parser state is corrupted enough that
+///   the first real heading below the frontmatter renders as body text.
+///   Splitting the frontmatter off before parsing avoids the misparse.
+///
+/// - The frontmatter is intentionally authored metadata (model hints,
+///   descriptions, allowed bash lists for slash commands, etc.) and the
+///   user should still be able to see it. The preview surfaces it in a
+///   dedicated collapsible section above the markdown body rather than
+///   discarding it.
+///
+/// Contract (pinned by `FrontmatterSplitterTests`):
+///
+/// - The first line of the input must be exactly `---` (trimmed) for any
+///   frontmatter to be recognized. Anything else ⇒ no frontmatter, body
+///   is the original content unchanged.
+/// - Scanning starts from line 2 and looks for the next line that, when
+///   trimmed, equals `---`. That line is the closing fence.
+/// - If no closing fence is found, the helper degrades to "no frontmatter"
+///   rather than swallowing the entire document. This avoids the
+///   surprising failure mode where a user typed a single `---` somewhere
+///   near the top of the file and the rest of the document vanishes
+///   behind a collapsible section.
+/// - The returned `frontmatterRaw` excludes the fence lines themselves so
+///   the UI can show the YAML body verbatim (no double-`---` decoration).
+/// - The returned `body` has leading whitespace/newlines trimmed so the
+///   parsed markdown does not start with a phantom blank line.
+///
+/// We intentionally do *not* parse the YAML here. The goal is to show the
+/// user exactly what is in the file, not a re-serialized projection of
+/// it, and parsing would require a YAML dependency on iOS that is not
+/// otherwise present in this client.
+enum FrontmatterSplitter {
+
+    /// Result of splitting a markdown document.
+    struct Split {
+        /// Raw frontmatter text (without the `---` fence lines). `nil`
+        /// when the input has no recognized frontmatter block.
+        let frontmatterRaw: String?
+
+        /// Markdown body. When `frontmatterRaw` is `nil` this is the
+        /// original input unchanged; otherwise it is the content below
+        /// the closing fence with leading whitespace trimmed.
+        let body: String
+    }
+
+    /// Split `content` into frontmatter and body. See the type-level doc
+    /// for the contract.
+    static func split(_ content: String) -> Split {
+        // Split on `\n`. We do not pre-normalize CRLF here because the
+        // markdown parser (swift-markdown) handles line-ending variants
+        // itself; the only thing the splitter cares about is whether the
+        // first line and some later line, after trimming, equal `---`.
+        // Trimming with `.whitespacesAndNewlines` absorbs a stray `\r`
+        // on Windows-style line endings.
+        let lines = content.components(separatedBy: "\n")
+        guard let first = lines.first,
+              first.trimmingCharacters(in: .whitespacesAndNewlines) == "---"
+        else {
+            return Split(frontmatterRaw: nil, body: content)
+        }
+
+        // Scan for the closing fence starting at line 2 (index 1). The
+        // first line is the opening fence; anything we slice as the
+        // frontmatter block lives strictly between the two fence lines.
+        for i in 1..<lines.count {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "---" {
+                let frontmatterLines = lines[1..<i]
+                let bodyLines = lines[(i + 1)...]
+                let frontmatterRaw = frontmatterLines.joined(separator: "\n")
+                let body = trimLeadingWhitespaceAndNewlines(
+                    bodyLines.joined(separator: "\n")
+                )
+                return Split(frontmatterRaw: frontmatterRaw, body: body)
+            }
+        }
+
+        // Unclosed fence — treat as no frontmatter. This matches the
+        // desktop renderer's behavior and protects users from
+        // accidentally hiding their entire document behind a
+        // collapsible section by typing a stray `---` at the top.
+        return Split(frontmatterRaw: nil, body: content)
+    }
+
+    // MARK: - Helpers
+
+    /// Drop any leading whitespace or newline characters from `s`. This
+    /// mirrors JavaScript's `String.prototype.trimStart` used by the
+    /// desktop renderer, so the two clients return body strings that
+    /// begin at the same character.
+    private static func trimLeadingWhitespaceAndNewlines(_ s: String) -> String {
+        var idx = s.startIndex
+        while idx < s.endIndex,
+              s[idx].isWhitespace || s[idx].isNewline
+        {
+            idx = s.index(after: idx)
+        }
+        return String(s[idx...])
+    }
+}

--- a/ios/IonRemote/Views/EngineInstanceBar.swift
+++ b/ios/IonRemote/Views/EngineInstanceBar.swift
@@ -9,6 +9,12 @@ struct EngineInstanceBar: View {
     @Environment(SessionViewModel.self) private var viewModel
     @State private var renamingInstance: EngineInstanceInfo? = nil
     @State private var renameText: String = ""
+    /// When non-nil, surfaces a small alert describing the model-fallback
+    /// for the corresponding instance — tapped by the user on the ⚠
+    /// glyph rendered in `instanceButton`. iOS has no tooltip primitive
+    /// equivalent to the desktop's Tooltip component, so an alert is the
+    /// idiomatic disclosure surface for this kind of one-shot detail.
+    @State private var fallbackDetail: (instanceLabel: String, info: EngineInstanceModelFallback)? = nil
 
     /// Other engine tabs the active instance can be moved to.
     private var moveTargets: [RemoteTabState] {
@@ -41,6 +47,22 @@ struct EngineInstanceBar: View {
         } message: {
             Text("Enter a new name for this instance")
         }
+        // Model-fallback disclosure alert. Triggered when the user taps
+        // the ⚠ glyph rendered next to an instance label in
+        // `instanceButton`. Shows the requested vs. fallback model
+        // names so the user understands which model is actually running.
+        // The indicator clears on its own when the run completes (idle
+        // transition propagates through the next snapshot tick).
+        .alert("Model fallback", isPresented: Binding(
+            get: { fallbackDetail != nil },
+            set: { if !$0 { fallbackDetail = nil } }
+        )) {
+            Button("OK", role: .cancel) { fallbackDetail = nil }
+        } message: {
+            if let detail = fallbackDetail {
+                Text("Instance \"\(detail.instanceLabel)\" requested model \"\(detail.info.requestedModel)\" which isn't configured; running with default \"\(detail.info.fallbackModel)\" instead.")
+            }
+        }
     }
 
     @ViewBuilder
@@ -68,6 +90,29 @@ struct EngineInstanceBar: View {
                 Text(instance.label)
                     .font(.caption)
                     .lineLimit(1)
+
+                // Model-fallback indicator. The desktop populates
+                // `EngineInstanceInfo.modelFallback` via the snapshot
+                // projection (see snapshot.ts) when the engine emitted
+                // a ModelFallbackEvent for this instance's most recent
+                // run. Rendered as a small ⚠ glyph in the same pill;
+                // tapping opens an alert with the requested + fallback
+                // model names. The indicator clears on its own when the
+                // run goes idle (the desktop's clear-on-idle propagates
+                // through the next snapshot tick). Per CLAUDE.md §
+                // "Common parity surfaces", iOS shows the same signal
+                // as desktop EngineStatusBar.
+                if let fb = instance.modelFallback {
+                    Button {
+                        fallbackDetail = (instanceLabel: instance.label, info: fb)
+                    } label: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(Color(hex: 0x4A9EF5))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Model fallback active for \(instance.label)")
+                }
 
                 if instances.count > 1 {
                     Button {

--- a/ios/IonRemote/Views/FileEditorView.swift
+++ b/ios/IonRemote/Views/FileEditorView.swift
@@ -129,11 +129,7 @@ struct FileEditorView: View {
     private var previewView: some View {
         ScrollView {
             if isMarkdown {
-                MarkdownContentView(blocks: MarkdownFormatter.parse(editedContent))
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                markdownPreview
             } else {
                 HStack(alignment: .top, spacing: 0) {
                     // Line number gutter
@@ -159,6 +155,67 @@ struct FileEditorView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Markdown Preview (with frontmatter handling)
+
+    /// Markdown preview body. Splits any YAML frontmatter off the top of
+    /// the document before handing the content to `MarkdownFormatter`,
+    /// then renders the frontmatter (if present) in a dedicated collapsible
+    /// section above the parsed markdown body.
+    ///
+    /// Why split: swift-markdown (CommonMark + GFM) does not recognize
+    /// YAML frontmatter and parses the closing `---` fence as a setext
+    /// H2 underline, which mangles the first frontmatter key into a giant
+    /// heading and corrupts parser state so the first real heading below
+    /// is rendered as body text. See `FrontmatterSplitter` for the full
+    /// rationale; this mirrors the desktop renderer's behavior so the two
+    /// reference clients render frontmatter-bearing markdown identically.
+    private var markdownPreview: some View {
+        let split = FrontmatterSplitter.split(editedContent)
+        return VStack(alignment: .leading, spacing: 12) {
+            if let frontmatter = split.frontmatterRaw {
+                frontmatterSection(frontmatter)
+            }
+            MarkdownContentView(blocks: MarkdownFormatter.parse(split.body))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Collapsible section that shows the raw frontmatter YAML verbatim.
+    /// Default state: collapsed, so the preview reads cleanly. iOS's
+    /// `DisclosureGroup` is the native equivalent of the desktop
+    /// `<details>` element used in `FileEditorPreview.tsx`.
+    private func frontmatterSection(_ raw: String) -> some View {
+        DisclosureGroup {
+            ScrollView(.horizontal, showsIndicators: false) {
+                Text(raw)
+                    .font(.system(.footnote, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(Color(.secondarySystemFill).opacity(0.4))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+        } label: {
+            Text("Frontmatter")
+                .font(.caption.weight(.semibold))
+                .textCase(.uppercase)
+                .foregroundStyle(.secondary)
+                .kerning(0.4)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.separator), lineWidth: 0.5)
+        )
     }
 
     // MARK: - Editor View

--- a/ios/IonRemote/Views/InputBar.swift
+++ b/ios/IonRemote/Views/InputBar.swift
@@ -62,9 +62,11 @@ struct InputBar: View {
         var cmds = viewModel.discoveredCommands[workingDirectory] ?? []
 
         // Inject the /clear builtin (matches desktop's SLASH_COMMANDS constant).
+        // `origin` is nil for synthetic local entries — the filter only applies
+        // to disk-discovered commands the desktop server sent us.
         let clearCmd = DiscoveredSlashCommand(
             name: "clear", description: "Clear conversation history",
-            scope: "builtin", source: "builtin"
+            scope: "builtin", source: "builtin", origin: nil
         )
         if !cmds.contains(where: { $0.name == "clear" }) {
             cmds.insert(clearCmd, at: 0)
@@ -82,7 +84,8 @@ struct InputBar: View {
                     name: ec.name,
                     description: ec.description ?? ec.name,
                     scope: "extension",
-                    source: "extension"
+                    source: "extension",
+                    origin: nil
                 ))
             }
         }

--- a/ios/IonRemoteTests/ContractSyncTests.swift
+++ b/ios/IonRemoteTests/ContractSyncTests.swift
@@ -28,6 +28,15 @@ import XCTest
 ///     engine-internal marker, not a renderer input. If a future iOS
 ///     feature ever needs to walk `LlmMessage` blocks (e.g. a compaction
 ///     transcript reader), add the Swift mirror at that point.
+///   - `ModelFallbackEvent` is intentionally not decoded as a live
+///     RemoteEvent on iOS. The engine emits `model_fallback` as a
+///     workflow signal at the swap site; the desktop projects it onto
+///     its session store and forwards the *fact* to iOS via the
+///     snapshot path (RemoteTabState.engineInstances[i].modelFallback).
+///     iOS reads from the snapshot only — there is no live RemoteEvent
+///     variant for this signal. If a future iOS feature needs the live
+///     event (e.g. per-instance toast notifications), add the Swift
+///     case at that point. See the grand-surfing-moth plan, §4.
 final class ContractSyncTests: XCTestCase {
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()

--- a/ios/IonRemoteTests/FrontmatterSplitterTests.swift
+++ b/ios/IonRemoteTests/FrontmatterSplitterTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import IonRemote
+
+/// Tests for `FrontmatterSplitter.split(_:)`. Pins the contract documented
+/// on the type so future refactors cannot silently regress the parity
+/// behavior shared with the desktop renderer's `splitFrontmatter` helper.
+///
+/// The behavioral baseline is the same shape as the desktop tests
+/// implicitly cover via the `FileEditorPreview` snapshot: first-line `---`
+/// gate, closing-fence scan, unclosed-fence ⇒ no frontmatter, and
+/// leading-whitespace trim on the returned body.
+final class FrontmatterSplitterTests: XCTestCase {
+
+    // MARK: - No frontmatter
+
+    func testNoFrontmatterWhenFirstLineIsNotFence() {
+        let input = "# Heading\n\nBody text"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertNil(result.frontmatterRaw)
+        XCTAssertEqual(result.body, input)
+    }
+
+    func testNoFrontmatterOnEmptyInput() {
+        let result = FrontmatterSplitter.split("")
+        XCTAssertNil(result.frontmatterRaw)
+        XCTAssertEqual(result.body, "")
+    }
+
+    func testNoFrontmatterWhenFirstLineHasContentAfterFence() {
+        // A line like `---note` is not a fence; it must trim to exactly `---`.
+        let input = "---note\nkey: value\n---\nbody"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertNil(result.frontmatterRaw)
+        XCTAssertEqual(result.body, input)
+    }
+
+    // MARK: - Frontmatter happy path
+
+    func testSplitsFrontmatterFromBody() {
+        let input = """
+        ---
+        description: hello
+        model: smart
+        ---
+        # Real Heading
+
+        Body paragraph.
+        """
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertEqual(result.frontmatterRaw, "description: hello\nmodel: smart")
+        XCTAssertEqual(result.body, "# Real Heading\n\nBody paragraph.")
+    }
+
+    func testFrontmatterWithEmptyBlockIsRecognized() {
+        let input = "---\n---\n# Heading"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertEqual(result.frontmatterRaw, "")
+        XCTAssertEqual(result.body, "# Heading")
+    }
+
+    func testFrontmatterWithEmptyBody() {
+        let input = "---\nkey: value\n---\n"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertEqual(result.frontmatterRaw, "key: value")
+        XCTAssertEqual(result.body, "")
+    }
+
+    func testFenceWithTrailingWhitespaceIsRecognized() {
+        // The fence lines must be exactly `---` after trimming
+        // `.whitespacesAndNewlines`. Stray spaces/tabs/CR are absorbed.
+        let input = "---   \nkey: value\n---\t\nbody"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertEqual(result.frontmatterRaw, "key: value")
+        XCTAssertEqual(result.body, "body")
+    }
+
+    func testCRLFLineEndingsHandled() {
+        // CRLF input: the splitter should still recognize the fences
+        // because the trailing `\r` lands inside the
+        // `.whitespacesAndNewlines` trim set.
+        let input = "---\r\nkey: value\r\n---\r\n# Heading"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertEqual(result.frontmatterRaw, "key: value\r")
+        // The `\r` survives because we only split on `\n` and don't
+        // pre-normalize. The downstream markdown parser normalizes line
+        // endings itself; this test pins the raw splitter behavior.
+        XCTAssertEqual(result.body, "# Heading")
+    }
+
+    // MARK: - Unclosed fence degrades safely
+
+    func testUnclosedFenceDegradesToNoFrontmatter() {
+        // The user typed `---` somewhere near the top but never closed
+        // it. We must not swallow the entire document — that would be a
+        // surprising failure mode where the markdown preview vanishes.
+        let input = "---\nkey: value\nbut no closing fence\n# Heading\nBody"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertNil(result.frontmatterRaw)
+        XCTAssertEqual(result.body, input)
+    }
+
+    // MARK: - Body trim
+
+    func testBodyHasLeadingWhitespaceTrimmed() {
+        // The desktop renderer uses `String.prototype.trimStart` on the
+        // body so the markdown parser doesn't start with a phantom
+        // blank line that would push the first heading down. The Swift
+        // splitter must match.
+        let input = "---\nkey: value\n---\n\n\n   # Heading"
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertEqual(result.frontmatterRaw, "key: value")
+        XCTAssertEqual(result.body, "# Heading")
+    }
+
+    // MARK: - Regression: the underlying bug
+
+    /// Pinning the actual user-visible bug. Without splitting, swift-markdown
+    /// sees `description: hello\n---` as a setext H2 ("description: hello"
+    /// underlined by `---`), and the real `# Frontmatter Test` heading is
+    /// degraded. After splitting, the body the parser sees starts with the
+    /// real H1 heading, so the regression cannot recur.
+    func testRegressionFirstHeadingPreservedBelowFrontmatter() {
+        let input = """
+        ---
+        description: hello
+        ---
+        # Frontmatter Test
+
+        Some body.
+        """
+        let result = FrontmatterSplitter.split(input)
+        XCTAssertNotNil(result.frontmatterRaw)
+        XCTAssertTrue(
+            result.body.hasPrefix("# Frontmatter Test"),
+            "body must start with the real H1 heading; got: \(result.body.prefix(40))"
+        )
+    }
+}

--- a/ios/IonRemoteTests/ModelFallbackSnapshotTests.swift
+++ b/ios/IonRemoteTests/ModelFallbackSnapshotTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import IonRemote
+
+/// Pins the wire shape and decode behaviour for the per-engine-instance
+/// model-fallback indicator.
+///
+/// The engine emits ModelFallbackEvent when a child run's requested model
+/// doesn't resolve to a provider. The desktop projects that fact onto
+/// `RemoteTabState.engineInstances[i].modelFallback` via the snapshot,
+/// rather than as a live RemoteEvent variant — the engine's event is a
+/// workflow signal, and projecting through the snapshot gives iOS a
+/// sticky-across-reconnect indicator without a new wire variant. See
+/// CLAUDE.md § "Common parity surfaces" row for model fallback indicator
+/// and § "The typed-event corollary" for the broader rule that the
+/// engine's typed event is the complete signaling surface; how each
+/// consumer renders it is the consumer's policy, not engine policy.
+///
+/// This test pins:
+///   1. Decoding a snapshot with `modelFallback` populates the
+///      `EngineInstanceInfo.modelFallback` Swift field.
+///   2. Decoding a snapshot without `modelFallback` leaves the field nil
+///      — so when the desktop omits it on a subsequent snapshot (which
+///      it does on the idle transition), iOS clears the indicator.
+///   3. The fallback struct round-trips through JSONEncoder/Decoder
+///      cleanly — the wire format is stable.
+final class ModelFallbackSnapshotTests: XCTestCase {
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    /// Minimal RemoteTabState JSON with one engine instance carrying a
+    /// modelFallback block. Mirrors what the desktop's snapshot.ts emits
+    /// when the engine_model_fallback event has been observed for the
+    /// run currently associated with this instance.
+    private func sampleTabWithFallback(requestedModel: String, fallbackModel: String) -> String {
+        """
+        {"id":"t1","title":"Tab","customTitle":null,"status":"running","workingDirectory":"/tmp","permissionMode":"auto","permissionQueue":[],"lastMessage":null,"contextTokens":null,"isEngine":true,"engineInstances":[{"id":"inst1","label":"Main","modelFallback":{"requestedModel":"\(requestedModel)","fallbackModel":"\(fallbackModel)"}}],"activeEngineInstanceId":"inst1"}
+        """
+    }
+
+    func testDecodeSnapshotWithModelFallback() throws {
+        let json = """
+        {"type":"snapshot","tabs":[\(sampleTabWithFallback(requestedModel: "standard", fallbackModel: "claude-sonnet-4-6"))]}
+        """.data(using: .utf8)!
+        let event = try decoder.decode(RemoteEvent.self, from: json)
+        guard case .snapshot(let tabs, _, _, _, _, _, _, _, _, _) = event else {
+            XCTFail("Expected snapshot, got \(event)")
+            return
+        }
+        XCTAssertEqual(tabs.count, 1)
+        let instances = tabs[0].engineInstances ?? []
+        XCTAssertEqual(instances.count, 1, "expected one engine instance")
+        let inst = instances[0]
+        XCTAssertNotNil(inst.modelFallback, "modelFallback should decode from the snapshot payload")
+        XCTAssertEqual(inst.modelFallback?.requestedModel, "standard")
+        XCTAssertEqual(inst.modelFallback?.fallbackModel, "claude-sonnet-4-6")
+    }
+
+    func testDecodeSnapshotWithoutModelFallback() throws {
+        // No modelFallback field on the engineInstances entry — the
+        // desktop omits it on snapshots after the run goes idle (the
+        // engine-event-status idle branch clears the source map). iOS
+        // must decode that as nil so the ⚠ glyph disappears.
+        let json = """
+        {"type":"snapshot","tabs":[{"id":"t1","title":"Tab","customTitle":null,"status":"idle","workingDirectory":"/tmp","permissionMode":"auto","permissionQueue":[],"lastMessage":null,"contextTokens":null,"isEngine":true,"engineInstances":[{"id":"inst1","label":"Main"}],"activeEngineInstanceId":"inst1"}]}
+        """.data(using: .utf8)!
+        let event = try decoder.decode(RemoteEvent.self, from: json)
+        guard case .snapshot(let tabs, _, _, _, _, _, _, _, _, _) = event else {
+            XCTFail("Expected snapshot, got \(event)")
+            return
+        }
+        let instances = tabs[0].engineInstances ?? []
+        XCTAssertEqual(instances.count, 1)
+        XCTAssertNil(instances[0].modelFallback, "modelFallback should be nil when the field is absent from the wire payload")
+    }
+
+    func testModelFallbackStructRoundTrips() throws {
+        // Encode → decode round-trip pins the wire format. If a future
+        // change renames a field or adds a required one, this test
+        // catches the drift before it ships.
+        let original = EngineInstanceModelFallback(
+            requestedModel: "standard",
+            fallbackModel: "claude-sonnet-4-6"
+        )
+        let data = try encoder.encode(original)
+        let decoded = try decoder.decode(EngineInstanceModelFallback.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+}


### PR DESCRIPTION
## Summary

Headline change: when a child agent run requests a model that doesn't resolve to a provider (canonical case: ion-meta specialists declaring `model: standard` with no `tiers.standard` configured), the engine now falls back to `DefaultModel` and emits a typed `ModelFallbackEvent`, with desktop + iOS surfacing a ⚠ indicator on the affected engine instance. The branch also bundles four smaller desktop/repo improvements that piled up alongside it (slash-command frontmatter, slash-command discovery fix, markdown frontmatter rendering, and two new AGENTS.md epistemic-hygiene rules).

## Changes

- **engine:** Thread `DefaultModel` into child runs' `RunConfig` so the existing runloop fallback can fire; emit `ModelFallbackEvent` on the swap path; leave stream content byte-identical to the LLM output (typed event is the complete signaling surface). Distinct log + no-event behavior when neither the requested model nor a default resolves. New `runloop_provider_resolve.go` split out of `runloop.go` to stay under the 800-line cap.
- **desktop:** Translate `ModelFallbackEvent` to `engine_model_fallback`, store per `tabId:instanceId`, render ⚠ in `EngineStatusBar` with tooltip, auto-clear on the next idle transition. Project the fallback onto `engineInstances[i].modelFallback` in `snapshot.ts` so iOS sees it.
- **desktop:** Parse `model:` from slash-command YAML frontmatter and forward it to `runOptions.model` / `p.model` with a no-stomp policy that preserves explicit per-prompt overrides. Resolution stays engine-side via `ResolveTierChain` → literal → `defaultModel`.
- **desktop:** Fix `IPC.DISCOVER_COMMANDS` short-circuiting to `[]` when `enableClaudeCompat` is off — ion-native commands (`~/.ion/commands`, `{project}/.ion/commands`) are always available; only the `.claude/` family is gated. Adds a `DiscoveredCommand.origin` discriminator (`'ion' | 'claude'`) used by both the desktop IPC handler and the iOS remote `discover_commands` handler.
- **desktop:** Render YAML frontmatter as a structured block at the top of the markdown preview instead of leaking the raw `---` fences into the body.
- **ios:** Render the ⚠ glyph on the engine instance bar when `modelFallback` is set; tap shows requested + fallback model. New `FrontmatterSplitter.swift` + tests; wire frontmatter editing into the markdown editing flow for parity with desktop.
- **repo:** Add two AGENTS.md rules — "Operator premises — verify before acting" (verify factual claims about the codebase before acting on them) and "The typed-event corollary" (a typed `NormalizedEvent` variant is the engine's complete signaling surface; no parallel surface in stream content). Mirrored in `docs/engine-grounding.md`.
- **repo:** Add `allowed_bash_commands` (gh issue create/list/view) to `/create-issue` so the command can call the GitHub CLI from plan mode; hint `model: smart`.

Closes #174
