### PR TITLE
feat: remote-client document attachments -- PDFs as wire document blocks

### DIFF
--- a/desktop/src/main/__tests__/prompt-pipeline-addenda.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-addenda.test.ts
@@ -124,7 +124,7 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 import { processIncomingPrompt } from '../prompt-pipeline'

--- a/desktop/src/main/__tests__/prompt-pipeline-attachments.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-attachments.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the attachment-encoding path in prompt-pipeline.ts.
+ *
+ * When a desktop-source prompt carries `attachments`, the pipeline calls
+ * encodeAttachments and merges the result onto runOptions.imageAttachments
+ * before forwarding to sessionPlane.submitPrompt. When no attachments are
+ * present the runOptions object is left untouched.
+ *
+ * These cases are split from the main suite so neither file exceeds the
+ * 600-line cap.
+ *
+ * Split from: prompt-pipeline.test.ts (file-size cohesion boundary)
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Mocks — same pattern as prompt-pipeline.test.ts.
+// ───────────────────────────────────────────────────────────────────────────
+
+const mocks = vi.hoisted(() => {
+  const bridgeListeners = new Map<string, Array<(key: string, event: any) => void>>()
+  const sendCommandMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const sendPromptMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.({ ok: true }) ?? function () { return Promise.resolve({ ok: true }) }
+  const submitPromptMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.(undefined) ?? function () { return Promise.resolve() }
+  const setPermissionModeMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const remoteSendMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const executeJsMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.(null) ?? function () { return Promise.resolve(null) }
+  const broadcastMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  const clearConversationFileMock = (globalThis as any).vi?.fn?.()?.mockResolvedValue?.(undefined) ?? function () { return Promise.resolve() }
+  // getTabStatusMock: default fresh tab (no conversationId, no prompts since
+  // checkpoint). Attachment tests exercise the non-slash desktop path so
+  // isFirstPromptForTab is not the focus, but the mock must exist so the
+  // pipeline's freshness guard doesn't throw.
+  const getTabStatusMock = (globalThis as any).vi?.fn?.()?.mockReturnValue?.({ conversationId: null, promptCountSinceCheckpoint: 0 }) ?? function () { return { conversationId: null, promptCountSinceCheckpoint: 0 } }
+  const notifyConversationClearedMock = (globalThis as any).vi?.fn?.() ?? function () {}
+  return {
+    bridgeListeners,
+    sendCommandMock,
+    sendPromptMock,
+    submitPromptMock,
+    setPermissionModeMock,
+    remoteSendMock,
+    executeJsMock,
+    broadcastMock,
+    clearConversationFileMock,
+    getTabStatusMock,
+    notifyConversationClearedMock,
+  }
+})
+
+// Rebuild as real vi.fn() values now that vi is in scope.
+mocks.sendCommandMock = vi.fn()
+mocks.sendPromptMock = vi.fn().mockResolvedValue({ ok: true })
+mocks.submitPromptMock = vi.fn().mockResolvedValue(undefined)
+mocks.setPermissionModeMock = vi.fn()
+mocks.remoteSendMock = vi.fn()
+mocks.executeJsMock = vi.fn().mockResolvedValue(null)
+mocks.broadcastMock = vi.fn()
+mocks.clearConversationFileMock = vi.fn().mockResolvedValue(undefined)
+mocks.getTabStatusMock = vi.fn().mockReturnValue({ conversationId: null, promptCountSinceCheckpoint: 0 })
+mocks.notifyConversationClearedMock = vi.fn()
+
+function emitBridgeEvent(key: string, event: any): void {
+  const arr = mocks.bridgeListeners.get('event') ?? []
+  for (const fn of arr) fn(key, event)
+}
+
+vi.mock('../state', () => {
+  const mockEngineBridge = {
+    sendCommand: (...args: any[]) => mocks.sendCommandMock(...args),
+    sendPrompt: (...args: any[]) => mocks.sendPromptMock(...args),
+    clearConversationFile: (...args: any[]) => mocks.clearConversationFileMock(...args),
+    on: (name: string, fn: (key: string, event: any) => void) => {
+      const arr = mocks.bridgeListeners.get(name) ?? []
+      arr.push(fn)
+      mocks.bridgeListeners.set(name, arr)
+    },
+  }
+  return {
+    state: {
+      mainWindow: { webContents: { executeJavaScript: (...args: any[]) => mocks.executeJsMock(...args) } },
+      remoteTransport: { send: (...args: any[]) => mocks.remoteSendMock(...args) },
+    },
+    sessionPlane: {
+      submitPrompt: (...args: any[]) => mocks.submitPromptMock(...args),
+      setPermissionMode: (...args: any[]) => mocks.setPermissionModeMock(...args),
+      getTabStatus: (...args: any[]) => mocks.getTabStatusMock(...args),
+      notifyConversationCleared: (...args: any[]) => mocks.notifyConversationClearedMock(...args),
+    },
+    engineBridge: mockEngineBridge,
+    extensionCommandRegistry: new Map(),
+  }
+})
+
+vi.mock('../broadcast', () => ({
+  broadcast: (...args: any[]) => mocks.broadcastMock(...args),
+}))
+
+vi.mock('../logger', () => ({
+  log: vi.fn(),
+  debug: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
+vi.mock('../settings-store', () => ({
+  readSettings: () => ({ enableClaudeCompat: true }),
+  SETTINGS_DEFAULTS: { enableClaudeCompat: true },
+}))
+
+// Full encoding mock (not a passthrough): the attachment tests need the
+// encoder to produce real output so submitPrompt receives the encoded bytes.
+vi.mock('../remote/attachment-encoder', () => ({
+  encodeAttachments: (text: string, atts: any[]) => ({
+    encoded: atts
+      .filter((a: any) => a.path.endsWith('.pdf') || a.type === 'image')
+      .map((a: any) => ({ mediaType: a.path.endsWith('.pdf') ? 'application/pdf' : 'image/jpeg', data: 'QkFTRTY0', path: a.path })),
+    rewrittenText: text.replace(/\[Attached (?:file|image): ([^\]]+)\]/g, '[Attachment: rewritten]'),
+  }),
+}))
+
+// Pull in the SUT AFTER mocks are set up.
+import { processIncomingPrompt } from '../prompt-pipeline'
+import { _resetAwaitersForTests } from '../command-await'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ───────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mocks.sendCommandMock.mockReset()
+  mocks.sendPromptMock.mockReset().mockResolvedValue({ ok: true })
+  mocks.submitPromptMock.mockReset().mockResolvedValue(undefined)
+  mocks.setPermissionModeMock.mockReset()
+  mocks.remoteSendMock.mockReset()
+  mocks.executeJsMock.mockReset().mockResolvedValue(null)
+  mocks.broadcastMock.mockReset()
+  mocks.clearConversationFileMock.mockReset().mockResolvedValue(undefined)
+  mocks.getTabStatusMock.mockReset().mockReturnValue({ conversationId: null, promptCountSinceCheckpoint: 0 })
+  mocks.notifyConversationClearedMock.mockReset()
+  mocks.bridgeListeners.clear()
+  _resetAwaitersForTests()
+  mocks.sendCommandMock.mockImplementation((key: string, command: string, _args: string) => {
+    setTimeout(() => emitBridgeEvent(key, { type: 'engine_command_result', command, commandError: '', message: `command executed: ${command}` }), 0)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('processIncomingPrompt — rawAttachments encoding', () => {
+  it('desktop prompt with rawAttachments encodes them into runOptions before submit', async () => {
+    const opts = {
+      prompt: '[Attached file: /Users/someone/report.pdf]\n\nsummarize',
+      projectPath: '/proj',
+    } as any
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: opts.prompt,
+      reqId: 'req-1',
+      source: 'desktop',
+      hasExtensions: true,
+      projectPath: '/proj',
+      runOptions: opts,
+      attachments: [{ type: 'file', name: 'report.pdf', path: '/Users/someone/report.pdf' }],
+    })
+    expect(mocks.submitPromptMock).toHaveBeenCalledTimes(1)
+    const submitted = mocks.submitPromptMock.mock.calls[0][2]
+    // Marker rewritten so no downstream component reads a client-local path.
+    expect(submitted.prompt).not.toContain('[Attached file:')
+    // Bytes merged onto the wire field the bridge forwards to the engine.
+    expect(submitted.imageAttachments).toHaveLength(1)
+    expect(submitted.imageAttachments[0].mediaType).toBe('application/pdf')
+  })
+
+  it('desktop prompt without attachments leaves runOptions untouched', async () => {
+    const opts = { prompt: 'plain', projectPath: '/proj' } as any
+    await processIncomingPrompt({
+      tabId: 'tab-1', text: 'plain', reqId: 'req-1', source: 'desktop',
+      hasExtensions: false, projectPath: '/proj', runOptions: opts,
+    })
+    expect(mocks.submitPromptMock.mock.calls[0][2].imageAttachments).toBeUndefined()
+  })
+})

--- a/desktop/src/main/__tests__/prompt-pipeline-clear-wipe.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-clear-wipe.test.ts
@@ -111,7 +111,7 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 import { processIncomingPrompt } from '../prompt-pipeline'

--- a/desktop/src/main/__tests__/prompt-pipeline-convergence.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-convergence.test.ts
@@ -104,7 +104,7 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 // Pull in the SUT AFTER mocks are set up.

--- a/desktop/src/main/__tests__/prompt-pipeline-plan-mode.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-plan-mode.test.ts
@@ -109,7 +109,7 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 import { processIncomingPrompt } from '../prompt-pipeline'

--- a/desktop/src/main/__tests__/prompt-pipeline-remote-slash-success.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline-remote-slash-success.test.ts
@@ -90,7 +90,7 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 import { processIncomingPrompt } from '../prompt-pipeline'

--- a/desktop/src/main/__tests__/prompt-pipeline.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline.test.ts
@@ -131,7 +131,12 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, atts: any[]) => ({
+    encoded: atts
+      .filter((a: any) => a.path.endsWith('.pdf') || a.type === 'image')
+      .map((a: any) => ({ mediaType: a.path.endsWith('.pdf') ? 'application/pdf' : 'image/jpeg', data: 'QkFTRTY0', path: a.path })),
+    rewrittenText: text.replace(/\[Attached (?:file|image): ([^\]]+)\]/g, '[Attachment: rewritten]'),
+  }),
 }))
 
 // Pull in the SUT AFTER mocks are set up.
@@ -185,6 +190,39 @@ describe('processIncomingPrompt — non-slash text', () => {
     expect(mocks.submitPromptMock).toHaveBeenCalledTimes(1)
     expect(mocks.submitPromptMock).toHaveBeenCalledWith('tab-1', 'req-1', opts)
     expect(mocks.sendCommandMock).not.toHaveBeenCalled()
+  })
+
+  it('desktop prompt with rawAttachments encodes them into runOptions before submit', async () => {
+    const opts = {
+      prompt: '[Attached file: /Users/someone/report.pdf]\n\nsummarize',
+      projectPath: '/proj',
+    } as any
+    await processIncomingPrompt({
+      tabId: 'tab-1',
+      text: opts.prompt,
+      reqId: 'req-1',
+      source: 'desktop',
+      hasExtensions: true,
+      projectPath: '/proj',
+      runOptions: opts,
+      attachments: [{ type: 'file', name: 'report.pdf', path: '/Users/someone/report.pdf' }],
+    })
+    expect(mocks.submitPromptMock).toHaveBeenCalledTimes(1)
+    const submitted = mocks.submitPromptMock.mock.calls[0][2]
+    // Marker rewritten so no downstream component reads a client-local path.
+    expect(submitted.prompt).not.toContain('[Attached file:')
+    // Bytes merged onto the wire field the bridge forwards to the engine.
+    expect(submitted.imageAttachments).toHaveLength(1)
+    expect(submitted.imageAttachments[0].mediaType).toBe('application/pdf')
+  })
+
+  it('desktop prompt without attachments leaves runOptions untouched', async () => {
+    const opts = { prompt: 'plain', projectPath: '/proj' } as any
+    await processIncomingPrompt({
+      tabId: 'tab-1', text: 'plain', reqId: 'req-1', source: 'desktop',
+      hasExtensions: false, projectPath: '/proj', runOptions: opts,
+    })
+    expect(mocks.submitPromptMock.mock.calls[0][2].imageAttachments).toBeUndefined()
   })
 
   it('remote CLI broadcasts REMOTE_USER_MESSAGE instead of calling sessionPlane', async () => {

--- a/desktop/src/main/__tests__/prompt-pipeline.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline.test.ts
@@ -131,7 +131,7 @@ vi.mock('../settings-store', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 // Pull in the SUT AFTER mocks are set up.

--- a/desktop/src/main/__tests__/prompt-pipeline.test.ts
+++ b/desktop/src/main/__tests__/prompt-pipeline.test.ts
@@ -130,13 +130,10 @@ vi.mock('../settings-store', () => ({
   SETTINGS_DEFAULTS: { enableClaudeCompat: true },
 }))
 
+// Attachment-encoding cases live in prompt-pipeline-attachments.test.ts; this
+// file uses a passthrough stub so non-attachment tests are unaffected.
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeAttachments: (text: string, atts: any[]) => ({
-    encoded: atts
-      .filter((a: any) => a.path.endsWith('.pdf') || a.type === 'image')
-      .map((a: any) => ({ mediaType: a.path.endsWith('.pdf') ? 'application/pdf' : 'image/jpeg', data: 'QkFTRTY0', path: a.path })),
-    rewrittenText: text.replace(/\[Attached (?:file|image): ([^\]]+)\]/g, '[Attachment: rewritten]'),
-  }),
+  encodeAttachments: (text: string, _atts: any[]) => ({ encoded: [], rewrittenText: text }),
 }))
 
 // Pull in the SUT AFTER mocks are set up.
@@ -190,39 +187,6 @@ describe('processIncomingPrompt — non-slash text', () => {
     expect(mocks.submitPromptMock).toHaveBeenCalledTimes(1)
     expect(mocks.submitPromptMock).toHaveBeenCalledWith('tab-1', 'req-1', opts)
     expect(mocks.sendCommandMock).not.toHaveBeenCalled()
-  })
-
-  it('desktop prompt with rawAttachments encodes them into runOptions before submit', async () => {
-    const opts = {
-      prompt: '[Attached file: /Users/someone/report.pdf]\n\nsummarize',
-      projectPath: '/proj',
-    } as any
-    await processIncomingPrompt({
-      tabId: 'tab-1',
-      text: opts.prompt,
-      reqId: 'req-1',
-      source: 'desktop',
-      hasExtensions: true,
-      projectPath: '/proj',
-      runOptions: opts,
-      attachments: [{ type: 'file', name: 'report.pdf', path: '/Users/someone/report.pdf' }],
-    })
-    expect(mocks.submitPromptMock).toHaveBeenCalledTimes(1)
-    const submitted = mocks.submitPromptMock.mock.calls[0][2]
-    // Marker rewritten so no downstream component reads a client-local path.
-    expect(submitted.prompt).not.toContain('[Attached file:')
-    // Bytes merged onto the wire field the bridge forwards to the engine.
-    expect(submitted.imageAttachments).toHaveLength(1)
-    expect(submitted.imageAttachments[0].mediaType).toBe('application/pdf')
-  })
-
-  it('desktop prompt without attachments leaves runOptions untouched', async () => {
-    const opts = { prompt: 'plain', projectPath: '/proj' } as any
-    await processIncomingPrompt({
-      tabId: 'tab-1', text: 'plain', reqId: 'req-1', source: 'desktop',
-      hasExtensions: false, projectPath: '/proj', runOptions: opts,
-    })
-    expect(mocks.submitPromptMock.mock.calls[0][2].imageAttachments).toBeUndefined()
   })
 
   it('remote CLI broadcasts REMOTE_USER_MESSAGE instead of calling sessionPlane', async () => {
@@ -633,6 +597,4 @@ describe('processIncomingPrompt — /clear with no engine session (unknown_comma
     expect(calls.every((s: string) => !s.includes('Unknown command'))).toBe(true)
   })
 })
-
-// /clear file-wipe tests (loaded-but-not-started tab) live in the companion
-// file prompt-pipeline-clear-wipe.test.ts to keep both files under 600 lines.
+// /clear file-wipe tests live in prompt-pipeline-clear-wipe.test.ts (file-size cap).

--- a/desktop/src/main/__tests__/remote-wire-merge.test.ts
+++ b/desktop/src/main/__tests__/remote-wire-merge.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   processIncomingPromptMock: vi.fn().mockResolvedValue(undefined),
   readSettingsMock: vi.fn().mockReturnValue({ defaultBaseDirectory: '/home/test' }),
   getRemoteTabStatesMock: vi.fn().mockResolvedValue({ tabs: [] }),
-  encodeImageAttachmentsMock: vi.fn().mockReturnValue({ encoded: [], rewrittenText: '' }),
+  encodeAttachmentsMock: vi.fn().mockReturnValue({ encoded: [], rewrittenText: '' }),
   getVoiceSystemPromptMock: vi.fn().mockReturnValue(undefined),
 }))
 
@@ -95,7 +95,7 @@ vi.mock('../ipc-validation', () => ({
 }))
 
 vi.mock('../remote/attachment-encoder', () => ({
-  encodeImageAttachments: (...args: any[]) => mocks.encodeImageAttachmentsMock(...args),
+  encodeAttachments: (...args: any[]) => mocks.encodeAttachmentsMock(...args),
 }))
 
 // Mock engine.ts so tabs.ts can import getVoiceSystemPrompt without
@@ -263,7 +263,7 @@ describe('handlePrompt', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.executeJsMock.mockResolvedValue(null)
-    mocks.encodeImageAttachmentsMock.mockReturnValue({ encoded: [], rewrittenText: 'hello engine' })
+    mocks.encodeAttachmentsMock.mockReturnValue({ encoded: [], rewrittenText: 'hello engine' })
     mocks.processIncomingPromptMock.mockResolvedValue(undefined)
   })
 
@@ -380,16 +380,16 @@ describe('handlePrompt', () => {
     expect(args.instanceId).toBe('new-inst')
   })
 
-  it('calls encodeImageAttachments on engine path', async () => {
+  it('calls encodeAttachments on engine path', async () => {
     mocks.executeJsMock.mockResolvedValue('inst-enc')
-    mocks.encodeImageAttachmentsMock.mockReturnValue({ encoded: [], rewrittenText: 'rewritten' })
+    mocks.encodeAttachmentsMock.mockReturnValue({ encoded: [], rewrittenText: 'rewritten' })
 
     await handlePrompt(
       { type: 'desktop_prompt', tabId: 'tab-7', text: 'hi', instanceId: 'inst-enc', attachments: [{ type: 'file', name: 'foo.txt', path: '/tmp/foo.txt' }] },
       DEVICE_ID,
     )
 
-    expect(mocks.encodeImageAttachmentsMock).toHaveBeenCalledOnce()
+    expect(mocks.encodeAttachmentsMock).toHaveBeenCalledOnce()
     const args = mocks.processIncomingPromptMock.mock.calls[0][0]
     expect(args.text).toBe('rewritten')
   })

--- a/desktop/src/main/ipc/session.ts
+++ b/desktop/src/main/ipc/session.ts
@@ -161,6 +161,10 @@ export function registerSessionIpc(): void {
         text: options.prompt,
         reqId: requestId,
         source: 'desktop',
+        // Raw composer attachments -- encoded by the pipeline's desktop
+        // branch (fs/nativeImage are main-process-only, so the renderer
+        // could not encode them).
+        attachments: options.rawAttachments,
         // DATA-derived: an extension-backed conversation carries its resolved
         // extension list in RunOptions (the unified renderer `submit` populates
         // it from the tab's profile); a plain CLI tab does not. There is no

--- a/desktop/src/main/prompt-pipeline.ts
+++ b/desktop/src/main/prompt-pipeline.ts
@@ -374,6 +374,20 @@ async function submitAsPrompt(p: IncomingPrompt): Promise<void> {
     log(`pipeline: WARNING desktop-source prompt missing runOptions — cannot submit tab=${p.tabId}`)
     return
   }
+  // Desktop composer attachments: the renderer prepended [Attached ...]
+  // markers into runOptions.prompt and passed the raw paths through
+  // (rawAttachments -> p.attachments). Encode them here -- identical
+  // treatment to the remote branch above -- so PDFs/images reach the
+  // engine as wire bytes instead of client-local path markers.
+  const desktopAttachments = p.attachments || []
+  if (desktopAttachments.length > 0) {
+    const { encoded, rewrittenText } = encodeAttachments(p.runOptions.prompt, desktopAttachments, { isRemote: IS_REMOTE })
+    p.runOptions.prompt = rewrittenText
+    if (encoded.length > 0) {
+      p.runOptions.imageAttachments = [...(p.runOptions.imageAttachments || []), ...encoded]
+    }
+    log(`pipeline: desktop attachments encoded tab=${p.tabId} raw=${desktopAttachments.length} encoded=${encoded.length}`)
+  }
   if (!p.runOptions.enterPlanModeDescription) {
     p.runOptions.enterPlanModeDescription = ENTER_PLAN_MODE_DESCRIPTION
   }

--- a/desktop/src/main/prompt-pipeline.ts
+++ b/desktop/src/main/prompt-pipeline.ts
@@ -97,7 +97,8 @@ import { state, sessionPlane, engineBridge } from './state'
 import { broadcast } from './broadcast'
 import { parseSlash, type ParsedSlash } from './slash-parse'
 import { handleSlash as handleSlashBranch } from './prompt-pipeline-slash'
-import { encodeImageAttachments } from './remote/attachment-encoder'
+import { encodeAttachments } from './remote/attachment-encoder'
+import { IS_REMOTE } from './engine-bridge'
 import type { ImageAttachmentPayload } from '../shared/types'
 import { ENTER_PLAN_MODE_DESCRIPTION, PLAN_MODE_SPARSE_REMINDER } from './prompt-pipeline-prose'
 import { emitRemoteMessageAdded, insertRendererSystemMessage, clearConnectingStatus } from './prompt-pipeline-renderer'
@@ -345,7 +346,7 @@ async function submitAsPrompt(p: IncomingPrompt): Promise<void> {
       const ctx = attachments.map((a) => `[Attached ${a.type}: ${a.path}]`).join('\n')
       fullPrompt = `${ctx}\n\n${fullPrompt}`
     }
-    const { encoded, rewrittenText } = encodeImageAttachments(fullPrompt, attachments)
+    const { encoded, rewrittenText } = encodeAttachments(fullPrompt, attachments, { isRemote: IS_REMOTE })
     log(`pipeline: submit prompt via REMOTE_USER_MESSAGE tab=${p.tabId} textLen=${rewrittenText.length} encodedImages=${encoded.length}`)
     broadcast(IPC.REMOTE_USER_MESSAGE, {
       tabId: p.tabId,

--- a/desktop/src/main/remote/__tests__/attachment-encoder.test.ts
+++ b/desktop/src/main/remote/__tests__/attachment-encoder.test.ts
@@ -22,7 +22,7 @@ vi.mock('electron', () => {
   }
 })
 
-import { encodeImageAttachments, type RawAttachment } from '../attachment-encoder'
+import { encodeAttachments, type RawAttachment } from '../attachment-encoder'
 
 let workDir: string
 
@@ -46,28 +46,49 @@ const att = (path: string, type = 'image', name?: string): RawAttachment => ({
   name: name ?? path.split('/').pop() ?? path,
 })
 
-describe('encodeImageAttachments', () => {
+const local = { isRemote: false }
+const remote = { isRemote: true }
+
+/** Write a sparse file whose stat size is `mb` megabytes. */
+const writeSparse = (name: string, mb: number): string => {
+  const p = join(workDir, name)
+  const fd = require('fs').openSync(p, 'w')
+  require('fs').writeSync(fd, Buffer.from([0]), 0, 1, mb * 1024 * 1024)
+  require('fs').closeSync(fd)
+  return p
+}
+
+describe('encodeAttachments — images', () => {
   it('returns empty result when no attachments are supplied', () => {
-    const r = encodeImageAttachments('hi', undefined)
+    const r = encodeAttachments('hi', undefined, local)
     expect(r.encoded).toEqual([])
     expect(r.rewrittenText).toBe('hi')
   })
 
-  it('encodes a real jpeg and leaves the prompt text untouched', () => {
+  it('encodes a real jpeg and rewrites its marker to the content-attached form', () => {
     const path = writeBytes('photo.jpg', Buffer.from([0xff, 0xd8, 0xff, 0xe0]))
     const text = `[Attached image: ${path}]\n\nwhat is this`
-    const { encoded, rewrittenText } = encodeImageAttachments(text, [att(path)])
-    expect(rewrittenText).toBe(text)
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(path)], local)
+    expect(rewrittenText).toBe('[Attachment: photo.jpg (content attached)]\n\nwhat is this')
     expect(encoded).toHaveLength(1)
     expect(encoded[0].mediaType).toBe('image/jpeg')
     expect(encoded[0].data).toBe(Buffer.from([0xff, 0xd8, 0xff, 0xe0]).toString('base64'))
     expect(encoded[0].path).toBe(path)
   })
 
+  it('the rewritten marker matches neither harness MARKER_RE nor engine attachmentMarkerRe', () => {
+    const path = writeBytes('photo.jpg', Buffer.from([0xff, 0xd8]))
+    const { rewrittenText } = encodeAttachments(`[Attached image: ${path}]`, [att(path)], remote)
+    // Same grammar as harness-ts attachmentResolver MARKER_RE and the engine's
+    // attachmentMarkerRe: a rewritten marker must never re-match either.
+    const markerRe = /\[Attached (file|image|plan): ([^\]]+)\]/g
+    expect(rewrittenText.match(markerRe)).toBeNull()
+  })
+
   it('rewrites the marker for a missing file and omits it from encoded', () => {
     const path = join(workDir, 'gone.png')
     const text = `[Attached image: ${path}]\n\nplease describe`
-    const { encoded, rewrittenText } = encodeImageAttachments(text, [att(path)])
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(path)], local)
     expect(encoded).toEqual([])
     expect(rewrittenText).toBe('[image unavailable: gone.png]\n\nplease describe')
   })
@@ -75,66 +96,24 @@ describe('encodeImageAttachments', () => {
   it('rewrites the marker for an unsupported extension', () => {
     const path = writeBytes('thing.bmp', Buffer.from([1, 2, 3]))
     const text = `[Attached image: ${path}]`
-    const { encoded, rewrittenText } = encodeImageAttachments(text, [att(path)])
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(path)], local)
     expect(encoded).toEqual([])
     expect(rewrittenText).toBe('[image unavailable: thing.bmp]')
   })
 
-  it('preserves non-image attachments untouched in text and out of encoded', () => {
-    const filePath = join(workDir, 'notes.txt')
-    writeFileSync(filePath, 'hello')
-    const text = `[Attached file: ${filePath}]\n\ncan you read this`
-    const { encoded, rewrittenText } = encodeImageAttachments(text, [att(filePath, 'file')])
-    expect(encoded).toEqual([])
-    expect(rewrittenText).toBe(text)
-  })
-
-  it('handles a mix: one good image + one missing image + one file', () => {
-    const good = writeBytes('good.png', Buffer.from([0x89, 0x50, 0x4e, 0x47]))
-    const missing = join(workDir, 'missing.jpg')
-    const file = writeBytes('readme.txt', Buffer.from('x'))
-    const text = [
-      `[Attached image: ${good}]`,
-      `[Attached image: ${missing}]`,
-      `[Attached file: ${file}]`,
-      '',
-      'please describe',
-    ].join('\n')
-    const { encoded, rewrittenText } = encodeImageAttachments(text, [
-      att(good),
-      att(missing),
-      att(file, 'file'),
-    ])
-    expect(encoded).toHaveLength(1)
-    expect(encoded[0].path).toBe(good)
-    expect(encoded[0].mediaType).toBe('image/png')
-    expect(rewrittenText).toContain(`[Attached image: ${good}]`)
-    expect(rewrittenText).toContain('[image unavailable: missing.jpg]')
-    expect(rewrittenText).toContain(`[Attached file: ${file}]`)
-    expect(rewrittenText).not.toContain(missing)
-  })
-
   it('rejects images larger than the raw cap by rewriting the marker', () => {
-    const big = join(workDir, 'huge.jpg')
-    // Create a sparse-ish 26 MB file by writing one byte at offset 26*1024*1024,
-    // which exceeds the 25 MB raw cap before any decode is attempted.
-    const fd = require('fs').openSync(big, 'w')
-    require('fs').writeSync(fd, Buffer.from([0]), 0, 1, 26 * 1024 * 1024)
-    require('fs').closeSync(fd)
+    const big = writeSparse('huge.jpg', 26)
     const text = `[Attached image: ${big}]`
-    const { encoded, rewrittenText } = encodeImageAttachments(text, [att(big)])
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(big)], local)
     expect(encoded).toEqual([])
     expect(rewrittenText).toBe('[image unavailable: huge.jpg]')
   })
 
   it('passes png through unchanged when small, sends webp recompressed as jpeg', () => {
-    // PNG passthrough preserves transparency when bytes <= TARGET_BYTES.
     const png = writeBytes('a.png', Buffer.from([1, 2]))
-    // WEBP gets recompressed via the JPEG path (the encoder normalizes to
-    // a format Anthropic always accepts).
     const webp = writeBytes('b.webp', Buffer.from([3, 4]))
     const text = `[Attached image: ${png}]\n[Attached image: ${webp}]`
-    const { encoded } = encodeImageAttachments(text, [att(png), att(webp)])
+    const { encoded } = encodeAttachments(text, [att(png), att(webp)], local)
     expect(encoded).toHaveLength(2)
     expect(encoded[0].mediaType).toBe('image/png')
     expect(encoded[1].mediaType).toBe('image/jpeg')
@@ -142,8 +121,75 @@ describe('encodeImageAttachments', () => {
 
   it('does not pollute the directory when given empty input', () => {
     mkdirSync(join(workDir, 'subdir'))
-    const r = encodeImageAttachments('', [])
+    const r = encodeAttachments('', [], local)
     expect(r.encoded).toEqual([])
     expect(r.rewrittenText).toBe('')
+  })
+})
+
+describe('encodeAttachments — PDFs', () => {
+  it('encodes a pdf verbatim (no recompression) and rewrites its marker', () => {
+    const bytes = Buffer.from('%PDF-1.4 test content')
+    const path = writeBytes('report.pdf', bytes)
+    const text = `[Attached file: ${path}]\n\nsummarize`
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(path, 'file')], remote)
+    expect(encoded).toHaveLength(1)
+    expect(encoded[0].mediaType).toBe('application/pdf')
+    expect(encoded[0].data).toBe(bytes.toString('base64'))
+    expect(encoded[0].path).toBe(path)
+    expect(rewrittenText).toBe('[Attachment: report.pdf (content attached)]\n\nsummarize')
+  })
+
+  it('over-cap pdf: keeps the original marker locally (Read/disk fallback)', () => {
+    const big = writeSparse('big.pdf', 25)
+    const text = `[Attached file: ${big}]`
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(big, 'file')], local)
+    expect(encoded).toEqual([])
+    expect(rewrittenText).toBe(text)
+  })
+
+  it('over-cap pdf: rewrites to an honest note remotely', () => {
+    const big = writeSparse('big.pdf', 25)
+    const text = `[Attached file: ${big}]`
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(big, 'file')], remote)
+    expect(encoded).toEqual([])
+    expect(rewrittenText).toContain('[file unavailable: big.pdf -- too large to send (25MB)]')
+  })
+
+  it('enforces the cumulative prompt budget across multiple pdfs', () => {
+    const a = writeSparse('a.pdf', 20)
+    const b = writeSparse('b.pdf', 20)
+    const text = `[Attached file: ${a}]\n[Attached file: ${b}]`
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(a, 'file'), att(b, 'file')], remote)
+    expect(encoded).toHaveLength(1)
+    expect(encoded[0].path).toBe(a)
+    expect(rewrittenText).toContain('[Attachment: a.pdf (content attached)]')
+    expect(rewrittenText).toContain('[file unavailable: b.pdf -- attachment budget for this message exceeded]')
+  })
+
+  it('missing pdf: keeps marker locally, rewrites remotely', () => {
+    const gone = join(workDir, 'gone.pdf')
+    const text = `[Attached file: ${gone}]`
+    expect(encodeAttachments(text, [att(gone, 'file')], local).rewrittenText).toBe(text)
+    expect(encodeAttachments(text, [att(gone, 'file')], remote).rewrittenText).toBe('[file unavailable: gone.pdf]')
+  })
+
+  it('leaves non-pdf file attachments and plan markers untouched', () => {
+    const txt = writeBytes('notes.txt', Buffer.from('hello'))
+    const text = `[Attached file: ${txt}]\n[Attached plan: /tmp/plan.md]\ngo`
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(txt, 'file')], remote)
+    expect(encoded).toEqual([])
+    expect(rewrittenText).toBe(text)
+  })
+
+  it('handles pdf + image together', () => {
+    const pdf = writeBytes('doc.pdf', Buffer.from('%PDF-1.4 x'))
+    const img = writeBytes('pic.jpg', Buffer.from([0xff, 0xd8]))
+    const text = `[Attached file: ${pdf}]\n[Attached image: ${img}]\ncompare`
+    const { encoded, rewrittenText } = encodeAttachments(text, [att(pdf, 'file'), att(img)], remote)
+    expect(encoded).toHaveLength(2)
+    expect(encoded.map((e) => e.mediaType)).toEqual(['application/pdf', 'image/jpeg'])
+    expect(rewrittenText).toContain('[Attachment: doc.pdf (content attached)]')
+    expect(rewrittenText).toContain('[Attachment: pic.jpg (content attached)]')
   })
 })

--- a/desktop/src/main/remote/attachment-encoder.ts
+++ b/desktop/src/main/remote/attachment-encoder.ts
@@ -23,6 +23,16 @@ const MAX_DIM = 1568
 // the engine's NDJSON line cap with room to spare.
 const TARGET_BYTES = 1_000_000
 
+// Engine-side cap for a single inlined document (mirrors the engine's
+// maxInlineAttachmentBytes). PDFs are sent verbatim -- never recompressed --
+// so anything over this is refused client-side with an honest fallback.
+const PDF_MAX_BYTES = 24 * 1024 * 1024
+
+// Cumulative raw-bytes budget across all attachments in one prompt. Base64
+// inflates by ~4/3, so 36MB raw ~= 48MB encoded -- comfortably under the
+// engine's 64MB NDJSON line cap including envelope.
+const PROMPT_TOTAL_MAX_BYTES = 36 * 1024 * 1024
+
 const MIME_BY_EXT: Record<string, string> = {
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -36,6 +46,17 @@ export interface RawAttachment {
   type: string // "image" | "file" | ...
   name: string
   path: string
+}
+
+export interface EncodeOptions {
+  /**
+   * Whether the engine runs on a different host. Controls the fallback for
+   * attachments we cannot inline: locally the original marker survives (the
+   * engine can still read the path from disk -- #789); remotely the marker is
+   * rewritten to an honest "unavailable" note, because a client-local path is
+   * meaningless on the engine host.
+   */
+  isRemote: boolean
 }
 
 export interface EncodeResult {
@@ -86,20 +107,36 @@ function compressImage(buf: Buffer, mediaType: string): { bytes: Buffer; mediaTy
   return { bytes: img.toJPEG(35), mediaType: 'image/jpeg' }
 }
 
+/** Replace the first occurrence of `marker` in `text` with `replacement`. */
+function replaceMarker(text: string, marker: string, replacement: string): string {
+  const idx = text.indexOf(marker)
+  if (idx < 0) return text
+  return text.slice(0, idx) + replacement + text.slice(idx + marker.length)
+}
+
 /**
- * Read each image attachment from disk, base64-encode it, and produce both:
+ * Read each attachment from disk, base64-encode it, and produce both:
  *   - an array of {mediaType,data,path} payloads to ride alongside the user
- *     prompt as native multimodal content, and
- *   - a rewritten prompt text in which any [Attached image: <path>] marker
- *     for an unreadable image is replaced with [image unavailable: <name>].
+ *     prompt as native multimodal content (image blocks for images, document
+ *     blocks for PDFs -- the engine keys on mediaType), and
+ *   - a rewritten prompt text.
  *
- * Non-image attachments and successfully encoded image markers are left in
- * the text untouched — the marker doubles as a client-side display hint
- * that an image was sent at this turn.
+ * Marker rewriting is the contract that keeps remote engines fast and honest:
+ *   - successfully encoded attachments get `[Attachment: <name> (content
+ *     attached)]` -- a form that matches NEITHER the harness resolver's
+ *     MARKER_RE nor the engine's attachmentMarkerRe, so no component ever
+ *     polls or Reads a client-local path for content that already rode the
+ *     wire (previously every remote image/PDF burned a ~15s resolver timeout);
+ *   - failures fall back per EncodeOptions.isRemote (see above).
+ *
+ * Non-image, non-PDF `file` attachments keep their original marker: locally
+ * the engine's Read fallback handles them; remotely they are a known gap
+ * (the model will say it cannot access the file).
  */
-export function encodeImageAttachments(
+export function encodeAttachments(
   text: string,
   attachments: RawAttachment[] | undefined,
+  opts: EncodeOptions,
 ): EncodeResult {
   if (!attachments || attachments.length === 0) {
     return { encoded: [], rewrittenText: text }
@@ -107,54 +144,90 @@ export function encodeImageAttachments(
 
   const encoded: ImageAttachmentPayload[] = []
   let rewritten = text
+  let totalBytes = 0
 
   for (const a of attachments) {
-    if (a.type !== 'image') continue
+    const name = basename(a.path)
     const ext = extname(a.path).toLowerCase()
-    const mediaType = MIME_BY_EXT[ext]
+    const isPdf = a.type === 'file' && ext === '.pdf'
+    if (a.type !== 'image' && !isPdf) continue
 
-    const fail = (reason: string): void => {
-      warn(`encoded skipped: ${reason} path=${a.path}`)
-      const marker = `[Attached image: ${a.path}]`
-      const replacement = `[image unavailable: ${basename(a.path)}]`
-      // Replace only the first occurrence of this exact marker so identical
-      // paths in the same prompt are handled in order.
-      const idx = rewritten.indexOf(marker)
-      if (idx >= 0) {
-        rewritten = rewritten.slice(0, idx) + replacement + rewritten.slice(idx + marker.length)
+    const marker = `[Attached ${a.type}: ${a.path}]`
+    const kindNoun = a.type === 'image' ? 'image' : 'file'
+    const fail = (reason: string, note: string): void => {
+      warn(`encode skipped: ${reason} path=${a.path}`)
+      if (opts.isRemote || a.type === 'image') {
+        // Remote: the path cannot be read on the engine host, so an honest
+        // note beats a dead marker. Images also always get the note (their
+        // markers were never Read-fallback material).
+        rewritten = replaceMarker(rewritten, marker, `[${kindNoun} unavailable: ${name}${note}]`)
       }
+      // Local non-image: keep the original marker -- the engine reads the
+      // path from disk (#789) or the model falls back to the Read tool.
     }
 
-    if (!mediaType) {
-      fail(`unsupported image extension: ${ext || '(none)'}`)
+    const srcPath = a.path
+    let size: number
+    try {
+      size = statSync(srcPath).size
+    } catch (err) {
+      fail(`stat failed: ${(err as Error).message}`, '')
       continue
     }
 
-    let buf: Buffer
-    try {
-      const st = statSync(a.path)
-      if (st.size > RAW_MAX_BYTES) {
-        fail(`image too large to load: ${(st.size / (1024 * 1024)).toFixed(1)}MB > ${RAW_MAX_BYTES / (1024 * 1024)}MB`)
+    if (isPdf) {
+      if (size > PDF_MAX_BYTES) {
+        fail(`pdf too large: ${(size / (1024 * 1024)).toFixed(1)}MB`, ` -- too large to send (${(size / (1024 * 1024)).toFixed(0)}MB)`)
         continue
       }
-      buf = readFileSync(a.path)
-    } catch (err) {
-      fail(`read failed: ${(err as Error).message}`)
+      if (totalBytes + size > PROMPT_TOTAL_MAX_BYTES) {
+        fail(`prompt attachment budget exceeded`, ' -- attachment budget for this message exceeded')
+        continue
+      }
+      let buf: Buffer
+      try {
+        buf = readFileSync(srcPath)
+      } catch (err) {
+        fail(`read failed: ${(err as Error).message}`, '')
+        continue
+      }
+      totalBytes += buf.length
+      encoded.push({ mediaType: 'application/pdf', data: buf.toString('base64'), path: a.path })
+      rewritten = replaceMarker(rewritten, marker, `[Attachment: ${name} (content attached)]`)
+      log(`encoded pdf: ${name} raw=${buf.length}`)
       continue
     }
 
+    // Images: existing compress pipeline, unchanged.
+    const mediaType = MIME_BY_EXT[ext]
+    if (!mediaType) {
+      fail(`unsupported image extension: ${ext || '(none)'}`, '')
+      continue
+    }
+    if (size > RAW_MAX_BYTES) {
+      fail(`image too large to load: ${(size / (1024 * 1024)).toFixed(1)}MB > ${RAW_MAX_BYTES / (1024 * 1024)}MB`, '')
+      continue
+    }
+    let buf: Buffer
+    try {
+      buf = readFileSync(srcPath)
+    } catch (err) {
+      fail(`read failed: ${(err as Error).message}`, '')
+      continue
+    }
     const compressed = compressImage(buf, mediaType)
     if (!compressed) {
-      fail(`decode failed: not a valid image`)
+      fail(`decode failed: not a valid image`, '')
       continue
     }
-
+    totalBytes += compressed.bytes.length
     encoded.push({
       mediaType: compressed.mediaType,
       data: compressed.bytes.toString('base64'),
       path: a.path,
     })
-    log(`encoded image: ${basename(a.path)} raw=${buf.length} sent=${compressed.bytes.length} mime=${compressed.mediaType}`)
+    rewritten = replaceMarker(rewritten, marker, `[Attachment: ${name} (content attached)]`)
+    log(`encoded image: ${name} raw=${buf.length} sent=${compressed.bytes.length} mime=${compressed.mediaType}`)
   }
 
   return { encoded, rewrittenText: rewritten }

--- a/desktop/src/main/remote/handlers/__tests__/engine-reset.test.ts
+++ b/desktop/src/main/remote/handlers/__tests__/engine-reset.test.ts
@@ -59,7 +59,7 @@ vi.mock('../../../logger', () => ({
 }))
 
 vi.mock('../../attachment-encoder', () => ({
-  encodeImageAttachments: (text: string) => ({ encoded: [], rewrittenText: text }),
+  encodeAttachments: (text: string) => ({ encoded: [], rewrittenText: text }),
 }))
 
 vi.mock('../../../prompt-pipeline', () => ({

--- a/desktop/src/main/remote/handlers/__tests__/handle-cancel.test.ts
+++ b/desktop/src/main/remote/handlers/__tests__/handle-cancel.test.ts
@@ -54,7 +54,7 @@ vi.mock('../../../state', () => ({
 
 vi.mock('../../../logger', () => ({ log: vi.fn() }))
 vi.mock('../../../prompt-pipeline', () => ({ processIncomingPrompt: vi.fn() }))
-vi.mock('../attachment-encoder', () => ({ encodeImageAttachments: vi.fn() }))
+vi.mock('../attachment-encoder', () => ({ encodeAttachments: vi.fn() }))
 vi.mock('./engine', () => ({ getVoiceSystemPrompt: vi.fn() }))
 
 import { handleCancel } from '../tabs-prompt'

--- a/desktop/src/main/remote/handlers/tabs-prompt.ts
+++ b/desktop/src/main/remote/handlers/tabs-prompt.ts
@@ -2,7 +2,8 @@ import { existsSync, readFileSync } from 'fs'
 import { log as _log } from '../../logger'
 import { state, sessionPlane, engineBridge } from '../../state'
 import { processIncomingPrompt } from '../../prompt-pipeline'
-import { encodeImageAttachments } from '../attachment-encoder'
+import { encodeAttachments } from '../attachment-encoder'
+import { IS_REMOTE } from '../../engine-bridge'
 import { getVoiceSystemPrompt } from './engine'
 import { performUnifiedInterrupt } from '../../engine-control-plane-interrupt'
 import type { RemoteCommand } from '../protocol'
@@ -122,7 +123,7 @@ export async function handlePrompt(cmd: Extract<RemoteCommand, { type: 'desktop_
       const ctx = attachments.map((a) => `[Attached ${a.type}: ${a.path}]`).join('\n')
       fullText = `${ctx}\n\n${fullText}`
     }
-    const { encoded, rewrittenText } = encodeImageAttachments(fullText, attachments)
+    const { encoded, rewrittenText } = encodeAttachments(fullText, attachments, { isRemote: IS_REMOTE })
     const voicePrompt = getVoiceSystemPrompt(deviceId)
     // Reuse the iOS-supplied clientMsgId as the engine request id so the
     // user-message echo (below) carries this exact id back to iOS. iOS reconciles

--- a/desktop/src/renderer/stores/slices/send-slice.ts
+++ b/desktop/src/renderer/stores/slices/send-slice.ts
@@ -347,6 +347,18 @@ export function createSendSlice(set: StoreSet, get: StoreGet): Partial<State> {
         extensions,
         implementationPhase,
         imageAttachments,
+        // Raw paths for main-process encoding (PDFs/images -> wire bytes).
+        // Only user-typed submits carry these; remote bounces arrive with
+        // imageAttachments already encoded and an empty tab.attachments.
+        rawAttachments: (() => {
+          // Plan attachments are marker-only by design -- never encoded.
+          const encodable = msgAttachments.filter(
+            (a): a is typeof a & { type: 'image' | 'file' } => a.type === 'image' || a.type === 'file',
+          )
+          return encodable.length > 0
+            ? encodable.map((a) => ({ type: a.type, name: a.name, path: a.path }))
+            : undefined
+        })(),
         thinkingEffort,
         planFilePath: sendInst?.planFilePath || undefined,
         // Forward remote-source marker so the IPC.PROMPT handler skips the

--- a/desktop/src/shared/types-session.ts
+++ b/desktop/src/shared/types-session.ts
@@ -416,6 +416,13 @@ export interface RunOptions {
    */
   imageAttachments?: ImageAttachmentPayload[]
   /**
+   * Raw (not yet encoded) file/image attachments from the desktop composer.
+   * The renderer cannot encode (fs + nativeImage live in main), so it passes
+   * the paths through; the prompt pipeline's desktop branch runs
+   * encodeAttachments on them -- same treatment the remote branches get.
+   */
+  rawAttachments?: Array<{ type: 'image' | 'file'; name: string; path: string }>
+  /**
    * Persisted plan file path from tab state. When set, the engine uses this
    * path instead of allocating a fresh slug — restoring continuity after
    * desktop restart. The engine validates that the file exists on disk; if

--- a/engine/internal/backend/cli_attachments.go
+++ b/engine/internal/backend/cli_attachments.go
@@ -29,9 +29,10 @@ var attachmentMarkerRe = regexp.MustCompile(`\[Attached (file|image|plan): ([^\]
 // PDFs referenced by `[Attached file: <abs>]` markers are read from disk and
 // inlined as native `document` blocks so the model ingests them directly,
 // instead of the Read tool expanding each page into a separate image block and
-// stalling the request for minutes (#789). Images supplied via opts.Attachments
-// (already base64) become `image` blocks, mirroring ApiBackend's
-// buildUserContentBlocks.
+// stalling the request for minutes (#789). opts.Attachments (already base64)
+// becomes `image` blocks for image/* media types and `document` blocks for
+// application/pdf -- the latter is how remote clients deliver documents whose
+// paths only exist on the client machine (#853).
 //
 // Anything we cannot or should not inline (non-PDF files, `plan` markers,
 // oversized or unreadable files) keeps its marker untouched so the existing
@@ -72,26 +73,55 @@ func buildCliUserContent(prompt string, attachments []types.ImageAttachment) []m
 		text = strings.ReplaceAll(text, full, "") // consumed -> strip marker
 	}
 
-	// Image blocks: opts.Attachments carries pre-encoded base64 images. The
-	// desktop adds a redundant `[Attached image: ...]` marker 1:1 alongside each
-	// one, so when we emit image blocks we strip those markers to avoid the
-	// model also trying to Read the path.
+	// Wire-attachment blocks: opts.Attachments carries pre-encoded base64
+	// content from the client. Images become `image` blocks. PDFs become
+	// `document` blocks -- this is the remote-desktop path (#853): the
+	// client's filesystem is not reachable from the engine host, so the
+	// bytes ride the wire instead of a path marker. Unknown media types are
+	// skipped (their marker, if any, stays for the Read fallback).
+	consumedPaths := make(map[string]bool)
 	for _, a := range attachments {
 		if a.Data == "" || a.MediaType == "" {
 			continue
 		}
-		media = append(media, map[string]interface{}{
-			"type": "image",
-			"source": map[string]interface{}{
-				"type":       "base64",
-				"media_type": a.MediaType,
-				"data":       a.Data,
-			},
-		})
+		switch {
+		case a.MediaType == "application/pdf":
+			media = append(media, map[string]interface{}{
+				"type": "document",
+				"source": map[string]interface{}{
+					"type":       "base64",
+					"media_type": "application/pdf",
+					"data":       a.Data,
+				},
+			})
+		case strings.HasPrefix(a.MediaType, "image/"):
+			media = append(media, map[string]interface{}{
+				"type": "image",
+				"source": map[string]interface{}{
+					"type":       "base64",
+					"media_type": a.MediaType,
+					"data":       a.Data,
+				},
+			})
+		default:
+			continue
+		}
+		if a.Path != "" {
+			consumedPaths[a.Path] = true
+		}
 	}
 	if len(attachments) > 0 {
+		// Strip markers the wire attachments made redundant: every `image`
+		// marker (the desktop adds one 1:1 alongside each encoded image) and
+		// any `file` marker whose path matches a consumed wire attachment --
+		// otherwise the model would try to Read a path that may not exist on
+		// this host.
 		text = attachmentMarkerRe.ReplaceAllStringFunc(text, func(s string) string {
-			if sub := attachmentMarkerRe.FindStringSubmatch(s); sub != nil && sub[1] == "image" {
+			sub := attachmentMarkerRe.FindStringSubmatch(s)
+			if sub == nil {
+				return s
+			}
+			if sub[1] == "image" || (sub[1] == "file" && consumedPaths[sub[2]]) {
 				return ""
 			}
 			return s

--- a/engine/internal/backend/cli_attachments.go
+++ b/engine/internal/backend/cli_attachments.go
@@ -1,0 +1,112 @@
+package backend
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// maxInlineAttachmentBytes caps a file we will base64-inline as a content
+// block. Anthropic's PDF limit is ~32MB; staying well under it leaves headroom
+// for the ~33% base64 inflation. Files larger than this keep their marker so
+// the model falls back to the Read tool.
+const maxInlineAttachmentBytes = 24 * 1024 * 1024
+
+// attachmentMarkerRe matches the `[Attached file|image|plan: <path>]` markers
+// the harness before_prompt resolver leaves in the prompt after materializing
+// the referenced file to an absolute path. Mirrors attachmentResolver.ts
+// MARKER_RE.
+var attachmentMarkerRe = regexp.MustCompile(`\[Attached (file|image|plan): ([^\]]+)\]`)
+
+// buildCliUserContent turns the resolved prompt plus pre-encoded image
+// attachments into the content-block slice for the CLI stream-json user
+// message.
+//
+// PDFs referenced by `[Attached file: <abs>]` markers are read from disk and
+// inlined as native `document` blocks so the model ingests them directly,
+// instead of the Read tool expanding each page into a separate image block and
+// stalling the request for minutes (#789). Images supplied via opts.Attachments
+// (already base64) become `image` blocks, mirroring ApiBackend's
+// buildUserContentBlocks.
+//
+// Anything we cannot or should not inline (non-PDF files, `plan` markers,
+// oversized or unreadable files) keeps its marker untouched so the existing
+// Read-tool path still works. The non-attachment case returns a single text
+// block identical to the previous hardcoded behavior.
+func buildCliUserContent(prompt string, attachments []types.ImageAttachment) []map[string]interface{} {
+	text := prompt
+	media := make([]map[string]interface{}, 0, len(attachments)+1)
+
+	// Document blocks: read PDFs referenced by `file` markers from disk.
+	seen := make(map[string]bool)
+	for _, m := range attachmentMarkerRe.FindAllStringSubmatch(prompt, -1) {
+		full, kind, path := m[0], m[1], m[2]
+		if kind != "file" || strings.ToLower(filepath.Ext(path)) != ".pdf" {
+			continue // only PDFs get the document-block treatment in v1
+		}
+		if seen[path] {
+			text = strings.ReplaceAll(text, full, "")
+			continue // already inlined this file; just drop the duplicate marker
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.Size() == 0 || info.Size() > maxInlineAttachmentBytes {
+			continue // leave marker; model falls back to the Read tool
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		seen[path] = true
+		media = append(media, map[string]interface{}{
+			"type": "document",
+			"source": map[string]interface{}{
+				"type":       "base64",
+				"media_type": "application/pdf",
+				"data":       base64.StdEncoding.EncodeToString(data),
+			},
+		})
+		text = strings.ReplaceAll(text, full, "") // consumed -> strip marker
+	}
+
+	// Image blocks: opts.Attachments carries pre-encoded base64 images. The
+	// desktop adds a redundant `[Attached image: ...]` marker 1:1 alongside each
+	// one, so when we emit image blocks we strip those markers to avoid the
+	// model also trying to Read the path.
+	for _, a := range attachments {
+		if a.Data == "" || a.MediaType == "" {
+			continue
+		}
+		media = append(media, map[string]interface{}{
+			"type": "image",
+			"source": map[string]interface{}{
+				"type":       "base64",
+				"media_type": a.MediaType,
+				"data":       a.Data,
+			},
+		})
+	}
+	if len(attachments) > 0 {
+		text = attachmentMarkerRe.ReplaceAllStringFunc(text, func(s string) string {
+			if sub := attachmentMarkerRe.FindStringSubmatch(s); sub != nil && sub[1] == "image" {
+				return ""
+			}
+			return s
+		})
+	}
+
+	// Text block first (matches ApiBackend's buildUserContentBlocks). Collapse
+	// whitespace left by stripped markers; keep a non-empty placeholder so the
+	// message stays well-formed when the prompt was only an attachment.
+	text = strings.TrimSpace(text)
+	if text == "" && len(media) > 0 {
+		text = "(see attached)"
+	}
+	blocks := make([]map[string]interface{}, 0, len(media)+1)
+	blocks = append(blocks, map[string]interface{}{"type": "text", "text": text})
+	blocks = append(blocks, media...)
+	return blocks
+}

--- a/engine/internal/backend/cli_attachments.go
+++ b/engine/internal/backend/cli_attachments.go
@@ -20,6 +20,10 @@ const maxInlineAttachmentBytes = 24 * 1024 * 1024
 // the harness before_prompt resolver leaves in the prompt after materializing
 // the referenced file to an absolute path. Mirrors attachmentResolver.ts
 // MARKER_RE.
+// Note: `plan` markers are captured by this regex but are intentionally NOT
+// consumed by the document-block builder — the `kind != "file"` guard in the
+// loop body passes them through untouched so the model still sees the marker
+// text and can act on the plan context via the Read tool.
 var attachmentMarkerRe = regexp.MustCompile(`\[Attached (file|image|plan): ([^\]]+)\]`)
 
 // buildCliUserContent turns the resolved prompt plus pre-encoded image

--- a/engine/internal/backend/cli_attachments_test.go
+++ b/engine/internal/backend/cli_attachments_test.go
@@ -1,0 +1,125 @@
+package backend
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dsswift/ion/engine/internal/types"
+)
+
+// writeTempPDF writes n bytes to a .pdf file in the test's temp dir and returns
+// its absolute path.
+func writeTempPDF(t *testing.T, name string, n int) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(strings.Repeat("x", n)), 0o600); err != nil {
+		t.Fatalf("write temp pdf: %v", err)
+	}
+	return p
+}
+
+func blockType(b map[string]interface{}) string {
+	s, _ := b["type"].(string)
+	return s
+}
+
+// Regression guard: no markers and no attachments returns exactly one text
+// block holding the original prompt -- identical to the pre-#789 behavior.
+func TestBuildCliUserContent_PlainPrompt(t *testing.T) {
+	blocks := buildCliUserContent("hello world", nil)
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 block, got %d", len(blocks))
+	}
+	if blockType(blocks[0]) != "text" || blocks[0]["text"] != "hello world" {
+		t.Fatalf("unexpected text block: %#v", blocks[0])
+	}
+}
+
+func TestBuildCliUserContent_PDFMarkerBecomesDocumentBlock(t *testing.T) {
+	pdf := writeTempPDF(t, "manual.pdf", 1024)
+	prompt := "summarize this [Attached file: " + pdf + "] please"
+
+	blocks := buildCliUserContent(prompt, nil)
+	if len(blocks) != 2 {
+		t.Fatalf("want text + document, got %d blocks: %#v", len(blocks), blocks)
+	}
+	// Marker stripped from the text block.
+	if txt, _ := blocks[0]["text"].(string); strings.Contains(txt, "[Attached") {
+		t.Fatalf("marker not stripped from text: %q", txt)
+	}
+	doc := blocks[1]
+	if blockType(doc) != "document" {
+		t.Fatalf("want document block, got %q", blockType(doc))
+	}
+	src, _ := doc["source"].(map[string]interface{})
+	if src["media_type"] != "application/pdf" || src["type"] != "base64" {
+		t.Fatalf("bad document source: %#v", src)
+	}
+	if _, err := base64.StdEncoding.DecodeString(src["data"].(string)); err != nil {
+		t.Fatalf("document data is not valid base64: %v", err)
+	}
+}
+
+func TestBuildCliUserContent_ImageAttachmentBecomesImageBlock(t *testing.T) {
+	// An image delivered via opts.Attachments plus its redundant marker.
+	prompt := "look [Attached image: /tmp/shot.png]"
+	atts := []types.ImageAttachment{{MediaType: "image/png", Data: "Zm9v", Path: "/tmp/shot.png"}}
+
+	blocks := buildCliUserContent(prompt, atts)
+	if len(blocks) != 2 {
+		t.Fatalf("want text + image, got %d blocks: %#v", len(blocks), blocks)
+	}
+	if txt, _ := blocks[0]["text"].(string); strings.Contains(txt, "[Attached") {
+		t.Fatalf("image marker not stripped from text: %q", txt)
+	}
+	if blockType(blocks[1]) != "image" {
+		t.Fatalf("want image block, got %q", blockType(blocks[1]))
+	}
+}
+
+func TestBuildCliUserContent_OversizedPDFKeepsMarker(t *testing.T) {
+	pdf := writeTempPDF(t, "huge.pdf", maxInlineAttachmentBytes+1)
+	prompt := "read [Attached file: " + pdf + "]"
+
+	blocks := buildCliUserContent(prompt, nil)
+	if len(blocks) != 1 {
+		t.Fatalf("oversized file should not be inlined; got %d blocks", len(blocks))
+	}
+	if txt, _ := blocks[0]["text"].(string); !strings.Contains(txt, "[Attached file:") {
+		t.Fatalf("oversized-file marker should be preserved for Read fallback: %q", txt)
+	}
+}
+
+func TestBuildCliUserContent_NonPDFAndPlanMarkersUntouched(t *testing.T) {
+	prompt := "x [Attached file: /tmp/notes.txt] y [Attached plan: /tmp/plan.md]"
+	blocks := buildCliUserContent(prompt, nil)
+	if len(blocks) != 1 {
+		t.Fatalf("non-pdf/plan markers should not produce media blocks; got %d", len(blocks))
+	}
+	txt, _ := blocks[0]["text"].(string)
+	if !strings.Contains(txt, "notes.txt") || !strings.Contains(txt, "plan.md") {
+		t.Fatalf("non-pdf/plan markers should be preserved: %q", txt)
+	}
+}
+
+func TestBuildCliUserContent_DuplicatePDFMarkerInlinedOnce(t *testing.T) {
+	pdf := writeTempPDF(t, "dup.pdf", 512)
+	prompt := "[Attached file: " + pdf + "] and again [Attached file: " + pdf + "]"
+
+	blocks := buildCliUserContent(prompt, nil)
+	docs := 0
+	for _, b := range blocks {
+		if blockType(b) == "document" {
+			docs++
+		}
+	}
+	if docs != 1 {
+		t.Fatalf("duplicate marker should inline once, got %d document blocks", docs)
+	}
+	if txt, _ := blocks[0]["text"].(string); strings.Contains(txt, "[Attached") {
+		t.Fatalf("both duplicate markers should be stripped: %q", txt)
+	}
+}

--- a/engine/internal/backend/cli_attachments_test.go
+++ b/engine/internal/backend/cli_attachments_test.go
@@ -123,3 +123,61 @@ func TestBuildCliUserContent_DuplicatePDFMarkerInlinedOnce(t *testing.T) {
 		t.Fatalf("both duplicate markers should be stripped: %q", txt)
 	}
 }
+
+// Wire-delivered PDF (remote client): a document block is built straight from
+// Data with zero disk access, and a matching `file` marker is stripped so the
+// model cannot try to Read a client-local path (#853).
+func TestBuildCliUserContent_WirePDFDocumentBlock(t *testing.T) {
+	pdfB64 := base64.StdEncoding.EncodeToString([]byte("%PDF-1.4 fake"))
+	clientPath := "/Users/someone-else/Downloads/report.pdf" // does not exist here
+	prompt := "[Attached file: " + clientPath + "]\nsummarize this"
+	blocks := buildCliUserContent(prompt, []types.ImageAttachment{
+		{MediaType: "application/pdf", Data: pdfB64, Path: clientPath},
+	})
+	if len(blocks) != 2 {
+		t.Fatalf("want text+document, got %d blocks: %#v", len(blocks), blocks)
+	}
+	if blockType(blocks[1]) != "document" {
+		t.Fatalf("want document block, got %q", blockType(blocks[1]))
+	}
+	src := blocks[1]["source"].(map[string]interface{})
+	if src["media_type"] != "application/pdf" || src["data"] != pdfB64 {
+		t.Fatalf("document source mismatch: %#v", src)
+	}
+	text := blocks[0]["text"].(string)
+	if strings.Contains(text, clientPath) || strings.Contains(text, "[Attached file:") {
+		t.Fatalf("file marker not stripped: %q", text)
+	}
+}
+
+// Mixed wire attachments keep their relative order and unknown media types are
+// dropped without breaking the rest.
+func TestBuildCliUserContent_WireMixedAndUnknown(t *testing.T) {
+	blocks := buildCliUserContent("look", []types.ImageAttachment{
+		{MediaType: "image/png", Data: "aW1n"},
+		{MediaType: "application/zip", Data: "emlw"}, // dropped
+		{MediaType: "application/pdf", Data: "cGRm"},
+	})
+	if len(blocks) != 3 {
+		t.Fatalf("want text+image+document, got %d: %#v", len(blocks), blocks)
+	}
+	if blockType(blocks[1]) != "image" || blockType(blocks[2]) != "document" {
+		t.Fatalf("unexpected order: %q, %q", blockType(blocks[1]), blockType(blocks[2]))
+	}
+}
+
+// A `file` marker whose path matches no wire attachment stays untouched (the
+// local-disk #789 path or Read fallback still owns it).
+func TestBuildCliUserContent_UnmatchedFileMarkerKept(t *testing.T) {
+	prompt := "[Attached file: /nonexistent/other.pdf] and [Attached image: /tmp/x.png]"
+	blocks := buildCliUserContent(prompt, []types.ImageAttachment{
+		{MediaType: "application/pdf", Data: "cGRm", Path: "/somewhere/else.pdf"},
+	})
+	text := blocks[0]["text"].(string)
+	if !strings.Contains(text, "[Attached file: /nonexistent/other.pdf]") {
+		t.Fatalf("unmatched file marker should survive: %q", text)
+	}
+	if strings.Contains(text, "[Attached image:") {
+		t.Fatalf("image marker should be stripped when wire attachments exist: %q", text)
+	}
+}

--- a/engine/internal/backend/cli_backend.go
+++ b/engine/internal/backend/cli_backend.go
@@ -421,14 +421,14 @@ func (b *CliBackend) runProcess(ctx context.Context, run *cliRun, opts types.Run
 
 	utils.Log("CliBackend", fmt.Sprintf("process started: pid=%d requestID=%s", cmd.Process.Pid, run.requestID))
 
-	// Write initial prompt as NDJSON user message over stdin
+	// Write initial prompt as NDJSON user message over stdin. PDFs/images
+	// referenced by the prompt are inlined as native document/image content
+	// blocks rather than left for the Read tool to expand (#789).
 	initMsg := map[string]interface{}{
 		"type": "user",
 		"message": map[string]interface{}{
-			"role": "user",
-			"content": []map[string]interface{}{
-				{"type": "text", "text": opts.Prompt},
-			},
+			"role":    "user",
+			"content": buildCliUserContent(opts.Prompt, opts.Attachments),
 		},
 	}
 	if data, err := json.Marshal(initMsg); err == nil {

--- a/engine/internal/protocol/protocol.go
+++ b/engine/internal/protocol/protocol.go
@@ -69,11 +69,11 @@ type ClientCommand struct {
 	Path       string `json:"path,omitempty"`
 	ShowHidden bool   `json:"showHidden,omitempty"`
 
-	// send_prompt: pre-encoded image attachments to attach to the user
-	// message as native image content blocks. The engine has no opinion on
-	// any client-side marker syntax inside Text — clients pass image bytes
-	// here and the backend forwards them to the provider via its multimodal
-	// content format.
+	// send_prompt: pre-encoded attachments (images, PDF documents) to
+	// attach to the user message as native image/document content blocks.
+	// The engine has no opinion on any client-side marker syntax inside
+	// Text — clients pass attachment bytes here and the backend forwards
+	// them to the provider via its multimodal content format.
 	Attachments []types.ImageAttachment `json:"attachments,omitempty"`
 
 	// send_prompt: when true, the engine maps this onto

--- a/engine/internal/protocol/protocol.go
+++ b/engine/internal/protocol/protocol.go
@@ -74,6 +74,9 @@ type ClientCommand struct {
 	// The engine has no opinion on any client-side marker syntax inside
 	// Text — clients pass attachment bytes here and the backend forwards
 	// them to the provider via its multimodal content format.
+	// Supported media_type values: "image/*" (any image subtype) and
+	// "application/pdf" (routed to native document blocks). Other values
+	// are silently skipped. See types.ImageAttachment for the full contract.
 	Attachments []types.ImageAttachment `json:"attachments,omitempty"`
 
 	// send_prompt: when true, the engine maps this onto

--- a/engine/internal/server/server.go
+++ b/engine/internal/server/server.go
@@ -292,13 +292,14 @@ func (s *Server) handleClient(conn net.Conn) {
 	}()
 
 	scanner := bufio.NewScanner(conn)
-	// 8 MB per NDJSON line. Generous enough for an image-bearing prompt
-	// (Anthropic caps inputs at ~5 MB raw per image; base64 inflates by
-	// 4/3, so ~7 MB worst case + envelope) without inviting clients to
-	// spray multi-megabyte payloads. Old cap of 1 MB caused mid-stream
-	// EPIPE on the client write whenever an image attachment landed on
-	// the wire.
-	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	// 64 MB per NDJSON line. Sized for inline document attachments: a
+	// 24 MB PDF (maxInlineAttachmentBytes) base64-inflates to ~32 MB, and
+	// a prompt may carry more than one. bufio.Scanner grows its buffer
+	// lazily, so the higher cap costs nothing until a large line arrives.
+	// Old cap of 1 MB caused mid-stream EPIPE on the client write whenever
+	// an image attachment landed on the wire; 8 MB dropped the connection
+	// for wire-inlined PDFs.
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/engine/internal/types/llm.go
+++ b/engine/internal/types/llm.go
@@ -127,11 +127,13 @@ type ImageSource struct {
 	Data      string `json:"data"`
 }
 
-// ImageAttachment carries pre-encoded image bytes supplied alongside a user
-// prompt. The engine does not parse any client-side marker syntax; clients
-// that want the LLM to see images send them through this structured field.
-// Path is optional and used only for logging / correlation; the engine never
-// reads from disk based on it.
+// ImageAttachment carries pre-encoded attachment bytes (images or PDF
+// documents, keyed by MediaType) supplied alongside a user prompt. The engine
+// does not parse any client-side marker syntax; clients that want the LLM to
+// see attachment content send the bytes through this structured field --
+// essential for remote clients whose filesystem the engine cannot reach.
+// Path is optional and used for logging / correlation and redundant-marker
+// stripping; the engine never reads from disk based on it.
 type ImageAttachment struct {
 	MediaType string `json:"media_type"`
 	Data      string `json:"data"`

--- a/engine/internal/types/llm.go
+++ b/engine/internal/types/llm.go
@@ -134,6 +134,19 @@ type ImageSource struct {
 // essential for remote clients whose filesystem the engine cannot reach.
 // Path is optional and used for logging / correlation and redundant-marker
 // stripping; the engine never reads from disk based on it.
+//
+// Supported MediaType values:
+//   - "image/*"         — any image/* MIME type (e.g. "image/jpeg", "image/png",
+//                         "image/gif", "image/webp"). The engine emits a native
+//                         image block for the provider.
+//   - "application/pdf" — the engine emits a native document block (the provider's
+//                         first-class PDF support). This is the standard path for
+//                         remote clients that cannot expose a filesystem path to
+//                         the engine host (#853).
+//
+// Any other MediaType value is silently skipped by the backend; the
+// corresponding marker (if any) remains in the prompt for the Read-tool
+// fallback to handle.
 type ImageAttachment struct {
 	MediaType string `json:"media_type"`
 	Data      string `json:"data"`


### PR DESCRIPTION
Fixes #269.

## What

Three commits, engine-first deploy order matters (an old engine drops >8MB NDJSON lines from a new desktop):

1. **feat(cli-backend): inline PDF/image attachments as content blocks** -- CliBackend user messages become a content-block array: PDFs referenced by `[Attached file: <abs>]` markers are read from local disk and inlined as native `document` blocks (fixes the Read-tool page-explosion stall on large PDFs); images from `opts.Attachments` become `image` blocks (previously the CLI backend ignored wire attachments entirely). 24MB inline cap; anything not inlineable keeps its marker for the Read fallback.
2. **feat(engine): document blocks from wire attachments + 64MB line cap** -- `application/pdf` entries in `opts.Attachments` become `document` blocks with zero disk access (the remote-client path); file markers matching a consumed attachment's `path` are stripped; socket NDJSON line cap 8MB -> 64MB (bufio grows lazily, so no cost when unused).
3. **feat(desktop): inline PDFs on the wire + rewrite consumed markers** -- `encodeAttachments` (renamed from `encodeImageAttachments`) base64s `.pdf` files verbatim (24MB/file, 36MB raw/prompt) and rewrites consumed markers -- PDFs and images -- to `[Attachment: <name> (content attached)]`; failure fallback is `isRemote`-aware.

No wire-protocol struct changes: `ImageAttachment {media_type, data, path}` already flows through every hop generically; the only kind-aware code is the content-block builder.

## Testing

- `go test ./internal/backend/ ./internal/server/` -- new cases: wire-PDF -> document block with zero disk access, mixed image+PDF ordering, unknown media types dropped, unmatched markers preserved.
- Desktop vitest: 1990 passing, incl. new encoder cases (verbatim PDF bytes, marker rewrite grammar pinned against the engine marker regex, over-cap local vs remote fallback, cumulative budget, plan markers untouched).
- E2E on a two-machine setup (desktop MacBook -> engine Mac mini over TCP): PDF containing a unique codeword attached remotely -> CLI transcript shows exactly one native `document` block, zero tool_use calls, model answers the codeword verbatim.

## Notes

- ApiBackend parity (document branch in `buildUserContentBlocks`) is a natural follow-up; this PR is CLI-backend-first since that's where user content already assembles as blocks.
- Non-PDF file types keep their original marker (local Read fallback unchanged; remote remains a known gap -- called out in #269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)