### PR TITLE
fix(engine): catch up interval jobs across restarts

### DIFF
--- a/engine/internal/scheduling/catchup_test.go
+++ b/engine/internal/scheduling/catchup_test.go
@@ -95,10 +95,11 @@ func TestCatchUp_CatchUpDisabledByConfig(t *testing.T) {
 	}
 }
 
-// TestCatchUp_IntervalDoesNotRunCatchUp — interval jobs never
-// catch up; the bootstrap path skips persistence/catch-up for them
-// regardless of any marker on disk.
-func TestCatchUp_IntervalDoesNotRunCatchUp(t *testing.T) {
+// TestCatchUp_IntervalNoMarkerSchedulesNextRun — an interval job with no
+// last-run marker (first run ever) schedules the normal now+interval
+// next-run. Catch-up needs a marker to compare against, so a fresh job
+// waits its first full interval — no thundering herd on a fresh install.
+func TestCatchUp_IntervalNoMarkerSchedulesNextRun(t *testing.T) {
 	dir := t.TempDir()
 	s := New(Config{PersistDir: dir})
 
@@ -109,10 +110,59 @@ func TestCatchUp_IntervalDoesNotRunCatchUp(t *testing.T) {
 	loc := s.loadTz(jobTz(job))
 	next := s.computeBootstrapNextRun("ext-a", job, now, loc)
 
-	// Should be exactly now + intervalMs.
+	// No marker → exactly now + intervalMs.
 	want := now.Add(60 * time.Second)
 	if !next.Equal(want) {
-		t.Errorf("interval next-run = %v, want %v", next, want)
+		t.Errorf("interval next-run with no marker = %v, want %v", next, want)
+	}
+}
+
+// TestCatchUp_IntervalCatchesUpWhenOverdue — after a restart, an interval
+// job whose last run is more than one interval ago is overdue and must be
+// scheduled to fire ~now (staggered), not a full interval out. This is the
+// fix for interval jobs starving on frequently-restarting engines: without
+// it, every restart reset next-run to now+interval so a job whose interval
+// exceeds mean uptime never fired.
+func TestCatchUp_IntervalCatchesUpWhenOverdue(t *testing.T) {
+	dir := t.TempDir()
+	s := New(Config{PersistDir: dir})
+
+	now := time.Date(2026, 5, 25, 11, 0, 0, 0, time.UTC)
+	job := stubIntervalJob("int", (2 * time.Hour).Milliseconds()) // 2h
+
+	// Last run 5h ago — more than one interval → overdue.
+	s.recordLastRunByName("ext-a", job, now.Add(-5*time.Hour))
+
+	loc := s.loadTz(jobTz(job))
+	next := s.computeBootstrapNextRun("ext-a", job, now, loc)
+
+	want := now.Add(CatchUpStagger)
+	if !next.Equal(want) {
+		t.Errorf("overdue interval next-run = %v, want %v (now+stagger)", next, want)
+	}
+}
+
+// TestCatchUp_IntervalResumesCadenceWhenNotOverdue — an interval job whose
+// last run is less than one interval ago resumes its original cadence
+// (lastRun+interval) across the restart, rather than resetting to
+// now+interval (which would drift the schedule later on every restart).
+func TestCatchUp_IntervalResumesCadenceWhenNotOverdue(t *testing.T) {
+	dir := t.TempDir()
+	s := New(Config{PersistDir: dir})
+
+	now := time.Date(2026, 5, 25, 11, 0, 0, 0, time.UTC)
+	job := stubIntervalJob("int", (2 * time.Hour).Milliseconds()) // 2h
+
+	// Last run 30m ago — not yet due; next slot is lastRun+2h.
+	lastRun := now.Add(-30 * time.Minute)
+	s.recordLastRunByName("ext-a", job, lastRun)
+
+	loc := s.loadTz(jobTz(job))
+	next := s.computeBootstrapNextRun("ext-a", job, now, loc)
+
+	want := lastRun.Add(2 * time.Hour)
+	if !next.Equal(want) {
+		t.Errorf("not-yet-due interval next-run = %v, want %v (lastRun+interval)", next, want)
 	}
 }
 

--- a/engine/internal/scheduling/persistence.go
+++ b/engine/internal/scheduling/persistence.go
@@ -35,7 +35,9 @@ type lastRunMarker struct {
 
 // recordLastRun writes the marker for a successful fire. No-op if
 // persistDir is empty (tests, or persistence disabled by config).
-// Interval jobs do not write markers — they don't catch up.
+// All job kinds write markers — interval jobs need them so they can
+// resume their cadence and catch up across engine restarts (see
+// computeBootstrapNextRun).
 func (s *Scheduler) recordLastRun(h *extension.Host, job extension.ScheduleJob, firedAt time.Time) {
 	s.recordLastRunByName(hostName(h), job, firedAt)
 }
@@ -45,9 +47,6 @@ func (s *Scheduler) recordLastRun(h *extension.Host, job extension.ScheduleJob, 
 // without spinning up a real subprocess.
 func (s *Scheduler) recordLastRunByName(name string, job extension.ScheduleJob, firedAt time.Time) {
 	if s.persistDir == "" {
-		return
-	}
-	if job.Kind == extension.ScheduleInterval {
 		return
 	}
 	path := s.markerPathByName(name, job)

--- a/engine/internal/scheduling/persistence_test.go
+++ b/engine/internal/scheduling/persistence_test.go
@@ -97,21 +97,30 @@ func TestPersistence_WriteAndRead(t *testing.T) {
 	}
 }
 
-// TestPersistence_IntervalSkipsWrite verifies the documented behavior
-// that interval jobs do NOT write last-run markers — only daily and
-// weekly do. Interval catch-up is meaningless (next-run = now +
-// intervalMs), so writing a marker every tick is pure waste.
-func TestPersistence_IntervalSkipsWrite(t *testing.T) {
+// TestPersistence_IntervalWritesMarker verifies interval jobs persist a
+// last-run marker (like daily/weekly). The marker lets an interval job
+// resume its cadence and catch up across engine restarts instead of
+// resetting to now+interval on every start. See computeBootstrapNextRun.
+func TestPersistence_IntervalWritesMarker(t *testing.T) {
 	dir := t.TempDir()
 	s := New(Config{PersistDir: dir})
 
 	job := stubIntervalJob("int-1", 30_000)
+	want := time.Now().UTC().Truncate(time.Second)
 
-	s.recordLastRunByName("ext-a", job, time.Now().UTC())
+	s.recordLastRunByName("ext-a", job, want)
+
+	got, ok := s.readLastRunByName("ext-a", job)
+	if !ok {
+		t.Fatal("interval job did not write a readable last-run marker")
+	}
+	if !got.Equal(want) {
+		t.Fatalf("interval marker = %v, want %v", got, want)
+	}
 
 	files, _ := os.ReadDir(dir)
-	if len(files) != 0 {
-		t.Fatalf("interval job wrote %d marker files; want 0: %v", len(files), files)
+	if len(files) != 1 {
+		t.Fatalf("interval job wrote %d marker files; want 1: %v", len(files), files)
 	}
 }
 

--- a/engine/internal/scheduling/timezone.go
+++ b/engine/internal/scheduling/timezone.go
@@ -187,19 +187,44 @@ func (s *Scheduler) bootstrapNextRun(h *extension.Host, job extension.ScheduleJo
 func (s *Scheduler) computeBootstrapNextRun(name string, job extension.ScheduleJob, now time.Time, loc *time.Location) time.Time {
 	next := nextRunFor(job, now, loc)
 
-	// Catch-up only applies to daily/weekly (interval jobs catch up
-	// implicitly by firing at now+interval). Disabled when persistence
-	// is off or CatchUpEnabled is explicitly false.
-	if job.Kind != extension.ScheduleInterval && s.shouldCatchUp() {
-		if lastRun, ok := s.readLastRunByName(name, job); ok {
-			// What was the most recent scheduled slot BEFORE now?
-			lastSlot := lastScheduledSlotBefore(job, now, loc)
-			// If lastSlot is after lastRun, the slot was missed.
-			if lastSlot.After(lastRun) {
-				// Schedule the catch-up fire ~now + stagger.
-				next = now.Add(CatchUpStagger)
-				utils.Log("scheduler", fmt.Sprintf("bootstrapNextRun: ext=%s id=%q catch-up scheduled (missed slot %s)", name, job.JobID, lastSlot))
-			}
+	// Catch-up is disabled when persistence is off or CatchUpEnabled is
+	// explicitly false. In that case every kind uses the naive next-run.
+	if !s.shouldCatchUp() {
+		return next
+	}
+
+	// Interval catch-up: resume the persisted cadence across restarts.
+	// Without a marker the in-memory next-run reset to now+interval on
+	// every start, so a job whose interval exceeds mean uptime never
+	// fired. With a marker we compute the next fire from the last run;
+	// if that moment already passed (job missed one or more intervals
+	// across the restart) fire ~now, staggered. No marker (first run
+	// ever) keeps the original now+interval semantics — no thundering
+	// herd on a fresh install.
+	if job.Kind == extension.ScheduleInterval {
+		lastRun, ok := s.readLastRunByName(name, job)
+		if !ok || job.IntervalMs <= 0 {
+			return next
+		}
+		nextFromLast := lastRun.Add(time.Duration(job.IntervalMs) * time.Millisecond)
+		if nextFromLast.After(now) {
+			// Not yet due — resume the original cadence.
+			return nextFromLast
+		}
+		// Overdue across the restart — catch up soon.
+		utils.Log("scheduler", fmt.Sprintf("bootstrapNextRun: ext=%s id=%q interval catch-up scheduled (lastRun %s)", name, job.JobID, lastRun.Format(time.RFC3339)))
+		return now.Add(CatchUpStagger)
+	}
+
+	// Daily/weekly catch-up: fire the most recent missed slot ~now.
+	if lastRun, ok := s.readLastRunByName(name, job); ok {
+		// What was the most recent scheduled slot BEFORE now?
+		lastSlot := lastScheduledSlotBefore(job, now, loc)
+		// If lastSlot is after lastRun, the slot was missed.
+		if lastSlot.After(lastRun) {
+			// Schedule the catch-up fire ~now + stagger.
+			next = now.Add(CatchUpStagger)
+			utils.Log("scheduler", fmt.Sprintf("bootstrapNextRun: ext=%s id=%q catch-up scheduled (missed slot %s)", name, job.JobID, lastSlot))
 		}
 	}
 	return next


### PR DESCRIPTION
## Problem

Interval schedule jobs re-seed their next-run to `now + IntervalMs` on every engine start and never persist a last-run marker (`recordLastRun` returns early for `ScheduleInterval`; `computeBootstrapNextRun` gates catch-up on `Kind != ScheduleInterval`). So on an engine that restarts more often than a job's interval, that job **never fires** — a silent failure with no skip/fail event. Only daily/weekly jobs catch up. There is also no sub-daily cron kind, so interval is the only sub-daily option and it's the one that starves.

Observed on a frequently-restarting deployment: reliability degraded monotonically with interval length (5–10min jobs ~100%, 4–8h jobs ~30% or never).

## Fix (symmetric with existing daily/weekly catch-up)

- `persistence.go`: interval jobs now write last-run markers.
- `timezone.go`: on bootstrap, an interval job with a marker resumes its cadence (`lastRun+interval`); if that moment already passed it catches up at `now + CatchUpStagger`. No marker (first run ever) keeps `now+interval` — no thundering herd on a fresh install.

## Tests

Added: interval job writes+reads a marker; overdue → `now+stagger`; not-yet-due → `lastRun+interval`. All three fail on the pre-fix code (verified red→green). Existing daily/weekly catch-up tests unchanged and green.

Fixes #286